### PR TITLE
Fix #32 - add %%ceolkit:scale directive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,11 +71,12 @@ The parser **always returns a `Score`**, even on error. Every stage has a recove
 `Note` carries both `writtenAccidental` (what was in the ABC source) and `displayedAccidental` (what a renderer should draw after key signature and intra-bar accidental memory). These differ, e.g., for the second `c` after `^c` in C major.
 
 ### CeolKit extensions
-Four `%%ceolkit:*` directives are first-class model members:
+Five `%%ceolkit:*` directives are first-class model members:
 - `%%ceolkit:pipeformat true|false`
 - `%%ceolkit:pagenumber N`
 - `%%ceolkit:stemalignment N`
 - `%%ceolkit:justifylast true|false`
+- `%%ceolkit:scale F` (F > 0; tune-wide, never per-voice)
 
 All are represented in `CeolKitDirective` (an enum, not a string map) with an `.unknown(name:payload:)` case for forward compatibility. They attach to a `Scope` (`.fileGlobal`, `.tuneGlobal`, `.voiceLocal(VoiceId)`).
 

--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -146,6 +146,94 @@ file preamble or at the very start of a tune header).
 
 ---
 
+## `%%ceolkit:scale`
+
+**Syntax:** `%%ceolkit:scale <positive number>`
+
+**Type:** floating-point number, greater than zero
+
+**Default:** `1.0` (the renderer's own staff size, unmodified)
+
+**Scope:** global (file preamble or tune header); tune-wide, never per-voice
+
+### Description
+
+Scales the rendered music relative to the renderer's default size, so
+`%%ceolkit:scale 0.8` engraves everything at 80%. This is the in-source
+counterpart to the SVG renderer's `staffSize` configuration value, and it is
+the way to fit a long tune onto one page or to match the size of an adjacent
+engraving without changing the caller's render configuration.
+
+The factor multiplies the staff size, and with it every dimension derived from
+it: note heads, stems, beams, accidentals, clefs, and the vertical gaps between
+systems and between tunes.
+
+Page size and margins are **not** scaled — they stay in absolute points, so
+scaling the music never resizes the page. Because the usable width is
+unchanged, a smaller factor fits more measures onto each staff line. Title,
+subtitle, and composer rows are also unscaled; they are typeset in absolute
+point sizes.
+
+The value must be greater than zero. A missing, zero, negative, or non-numeric
+argument produces a warning and the directive is ignored, leaving the tune at
+the renderer's default size.
+
+Per-voice scaling is not supported: a scale set in a tune body applies to the
+whole tune regardless of which voice is current.
+
+### Scoping
+
+Like the other CeolKit directives, the value is set where it is encountered and
+persists until changed. A factor in the file preamble therefore governs every
+tune in the file, and a tune header can override it for that tune and the ones
+that follow.
+
+### Examples
+
+#### Fit a long tune onto one page
+
+```abc
+X:1
+T:A Long Reel
+M:4/4
+L:1/8
+%%ceolkit:scale 0.75
+K:D
+|:DEFD ADFD|DEFD AFEC|DEFD ADFD|1 EFED CDEC:|2 EFED CEAc||
+```
+
+#### File-wide default with a per-tune override
+
+```abc
+%%ceolkit:scale 0.8
+X:1
+T:Rendered at 80%
+M:4/4
+L:1/8
+K:G
+GABG|DEFD|
+
+X:2
+T:Rendered at 60%
+M:4/4
+L:1/8
+%%ceolkit:scale 0.6
+K:G
+GABG|DEFD|
+```
+
+The first tune (and any tune that follows without its own directive) renders at
+80%; the second, and every tune after it, renders at 60%.
+
+### Relationship to `%%scale`
+
+`abcm2ps` spells this `%%scale`. CeolKit uses the `%%ceolkit:` namespace instead,
+both for consistency with the rest of these extensions and to avoid implying
+full `%%scale` compatibility. A bare `%%scale` is still reported as an
+unsupported stylesheet directive.
+
+---
+
 ## `%%ceolkit:stemalignment`
 
 **Syntax:** `%%ceolkit:stemalignment <integer>`

--- a/Sources/CeolKitModel/CeolKitDirective.swift
+++ b/Sources/CeolKitModel/CeolKitDirective.swift
@@ -11,6 +11,7 @@ public enum CeolKitDirective: Hashable, Sendable {
     case pipeFormat(Bool)              // %%ceolkit:pipeformat true|false
     case pageNumber(Int)               // %%ceolkit:pagenumber N  (N >= 1)
     case stemAlignment(Int)            // %%ceolkit:stemalignment N  (signed integer)
+    case scale(Double)                 // %%ceolkit:scale F  (F > 0)
     case landscape(Bool)               // %%landscape 0|1  (ABC v2.2 §9.1)
     case flatBeams(Bool)               // %%flatbeams true|false  (abcm2ps; implicit in pipeFormat)
     case justifyLast(Bool)             // %%ceolkit:justifylast true|false

--- a/Sources/CeolKitModel/Diagnostic.swift
+++ b/Sources/CeolKitModel/Diagnostic.swift
@@ -45,6 +45,7 @@ public enum DiagnosticCode: String, Codable, Sendable {
     // CeolKit extensions
     case invalidPageNumber
     case misplacedStemAlignment
+    case invalidScale
     // Directives
     case unknownDirective
     case redundantDirective

--- a/Sources/CeolKitModel/StaffProperties.swift
+++ b/Sources/CeolKitModel/StaffProperties.swift
@@ -9,10 +9,8 @@ import Foundation
 
 public struct StaffProperties: Hashable, Sendable {
     public let staffLines: Int     // default 5
-    public let scale: Double?      // optional rendering scale factor; nil = default
 
-    public init(staffLines: Int, scale: Double?) {
+    public init(staffLines: Int) {
         self.staffLines = staffLines
-        self.scale = scale
     }
 }

--- a/Sources/CeolKitParser/Fields/KeyFieldParser.swift
+++ b/Sources/CeolKitParser/Fields/KeyFieldParser.swift
@@ -79,7 +79,7 @@ enum KeyFieldParser {
             explicit: explicit,
             clef: ClefSpec(clef: clef, octaveShift: octaveShift),
             transposition: .none,
-            staffProperties: StaffProperties(staffLines: staffLines, scale: nil),
+            staffProperties: StaffProperties(staffLines: staffLines),
             source: source
         )
         return (key, [])
@@ -218,7 +218,7 @@ enum KeyFieldParser {
             explicit: false,
             clef: ClefSpec(clef: .treble, octaveShift: 0),
             transposition: .none,
-            staffProperties: StaffProperties(staffLines: 5, scale: nil),
+            staffProperties: StaffProperties(staffLines: 5),
             source: source
         )
     }

--- a/Sources/CeolKitParser/Fields/VoiceFieldParser.swift
+++ b/Sources/CeolKitParser/Fields/VoiceFieldParser.swift
@@ -67,7 +67,7 @@ enum VoiceFieldParser {
         let props = VoiceProperties(
             clef: ClefSpec(clef: clef, octaveShift: octaveShift),
             transposition: Transposition(semitones: transposeSemitones, octave: transposeOctave),
-            staffProperties: StaffProperties(staffLines: staffLines, scale: nil),
+            staffProperties: StaffProperties(staffLines: staffLines),
             name: name,
             subname: subname,
             stemDirection: stem,

--- a/Sources/CeolKitParser/Semantic/SemanticPass.swift
+++ b/Sources/CeolKitParser/Semantic/SemanticPass.swift
@@ -595,8 +595,8 @@ struct SemanticPass {
                     source: source
                 ))
             }
-        case "landscape", "flatbeams", "ceolkit:justifylast", "writefields", "dateformat", "footer",
-             "straightflags", "graceslurs":
+        case "landscape", "flatbeams", "ceolkit:justifylast", "ceolkit:scale", "writefields",
+             "dateformat", "footer", "straightflags", "graceslurs":
             var tempDiags: [Diagnostic] = []
             if let d = parseCeolKitDirective(name: name, payload: payload, source: source, diagnostics: &tempDiags) {
                 ctx.bodyTuneDirectives.append(CeolKitDirectiveScope(directive: d, scope: .tuneGlobal, source: source))
@@ -763,7 +763,7 @@ struct SemanticPass {
             explicit: false,
             clef: ClefSpec(clef: .treble, octaveShift: 0),
             transposition: .none,
-            staffProperties: StaffProperties(staffLines: 5, scale: nil),
+            staffProperties: StaffProperties(staffLines: 5),
             source: source
         )
     }
@@ -871,6 +871,18 @@ struct SemanticPass {
             if let n = Int(trimmed) { return .stemAlignment(n) }
             diagnostics.append(Diagnostic(severity: .warning, code: .misplacedStemAlignment,
                 message: "%%ceolkit:stemalignment expects an integer", source: source))
+            return nil
+        case "ceolkit:scale":
+            if let f = Double(trimmed) {
+                if f <= 0 || !f.isFinite {
+                    diagnostics.append(Diagnostic(severity: .warning, code: .invalidScale,
+                        message: "%%ceolkit:scale must be a positive number (got \(trimmed))", source: source))
+                    return nil
+                }
+                return .scale(f)
+            }
+            diagnostics.append(Diagnostic(severity: .warning, code: .invalidScale,
+                message: "%%ceolkit:scale expects a number (got '\(trimmed)')", source: source))
             return nil
         case "landscape":
             if let value = parseLogical(trimmed) { return .landscape(value) }
@@ -1082,7 +1094,7 @@ struct SemanticPass {
         VoiceProperties(
             clef: ClefSpec(clef: .treble, octaveShift: 0),
             transposition: .none,
-            staffProperties: StaffProperties(staffLines: 5, scale: nil),
+            staffProperties: StaffProperties(staffLines: 5),
             name: nil,
             subname: nil,
             stemDirection: .auto,
@@ -1344,7 +1356,7 @@ private struct BodyContext {
             voiceProperties[id] = VoiceProperties(
                 clef: properties.clef != defaultClef ? properties.clef : existing.clef,
                 transposition: properties.transposition != .none ? properties.transposition : existing.transposition,
-                staffProperties: (properties.staffProperties.staffLines != 5 || properties.staffProperties.scale != nil)
+                staffProperties: properties.staffProperties.staffLines != 5
                     ? properties.staffProperties : existing.staffProperties,
                 name: properties.name ?? existing.name,
                 subname: properties.subname ?? existing.subname,

--- a/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
+++ b/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
@@ -22,7 +22,6 @@ public struct SVGRenderer: CeolKitRenderer {
         // File-preamble directives are promoted to the first tune by the parser.
         let effectiveConfig = applyingScoreDirectives(score)
 
-        let sizer     = MeasureSizer(config: effectiveConfig, metadata: metadata)
         let breaker   = LineBreaker()
         let justifier = Justifier()
         let engine    = VerticalLayoutEngine(config: effectiveConfig, metadata: metadata)
@@ -43,15 +42,23 @@ public struct SVGRenderer: CeolKitRenderer {
         var tuneBlocks: [TuneBlock] = []
         var stemDirection: StemDirection = .auto
         var justifyLastSystem = effectiveConfig.justifyLastSystem
+        // %%ceolkit:scale is tune-scoped but sticky: a preamble value governs every following
+        // tune until a later tune header overrides it.
+        var scale = 1.0
 
         for tune in score.tunes {
             for scope in tune.directives {
                 switch scope.directive {
                 case .pipeFormat(true):     stemDirection = .down
                 case .justifyLast(let on):  justifyLastSystem = on
+                case .scale(let factor):    scale = factor
                 default: break
                 }
             }
+            // The music scales; the page does not. Sizing and header widths are therefore
+            // derived from a per-tune staff size, while `usableWidth` stays absolute.
+            let tuneConfig = effectiveConfig.scaled(by: scale)
+            let sizer = MeasureSizer(config: tuneConfig, metadata: metadata)
             var tuneSystems: [JustifiedSystem] = []
             var meterForFirstSystem: Meter? = tune.meter
             for voice in tune.voices {
@@ -74,10 +81,10 @@ public struct SVGRenderer: CeolKitRenderer {
                 // Header widths differ between the first system (has time sig) and later ones.
                 let firstHeaderW = systemHeaderWidth(
                     clef: voice.properties.clef, keySignature: tune.key, meter: meterForFirstSystem,
-                    metadata: metadata, staffSize: effectiveConfig.staffSize)
+                    metadata: metadata, staffSize: tuneConfig.staffSize)
                 let laterHeaderW = systemHeaderWidth(
                     clef: voice.properties.clef, keySignature: tune.key, meter: nil,
-                    metadata: metadata, staffSize: effectiveConfig.staffSize)
+                    metadata: metadata, staffSize: tuneConfig.staffSize)
                 let systems = breaker.breakIntoSystems(pairs, usableWidth: usableWidth,
                                                        firstSystemHeaderWidth: firstHeaderW,
                                                        laterSystemHeaderWidth: laterHeaderW,
@@ -104,7 +111,7 @@ public struct SVGRenderer: CeolKitRenderer {
                 tune: tune, writeFields: tuneWriteFields, layoutConfig: effectiveConfig
             ).build()
             tuneBlocks.append(TuneBlock(systems: tuneSystems, titleRows: titleRows,
-                                        titleBlockHeight: titleBlockHeight))
+                                        titleBlockHeight: titleBlockHeight, scale: scale))
         }
 
         let emitter = SVGEmitter(config: effectiveConfig, metadata: metadata, stemDirection: stemDirection)

--- a/Sources/CeolKitSVGRenderer/Config/SVGRenderConfig.swift
+++ b/Sources/CeolKitSVGRenderer/Config/SVGRenderConfig.swift
@@ -31,6 +31,18 @@ public struct SVGRenderConfig: Sendable {
         self.straightFlags = straightFlags
         self.graceSlurs = graceSlurs
     }
+
+    /// Returns a copy with `staffSize` and the vertical gaps derived from it multiplied
+    /// by `factor` (`%%ceolkit:scale`).  Page size and margins are absolute and unchanged:
+    /// scaling the music must not resize the page.
+    public func scaled(by factor: Double) -> SVGRenderConfig {
+        guard factor != 1.0 else { return self }
+        var copy = self
+        copy.staffSize = staffSize * factor
+        copy.systemGap = systemGap * factor
+        copy.tuneGap = tuneGap * factor
+        return copy
+    }
 }
 
 public struct PageSize: Sendable {

--- a/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
@@ -85,7 +85,11 @@ struct SVGEmitter: Sendable {
         emitScrollSyncMetadata(for: page, pageNumber: pageNumber, builder: &builder)
         emitTitleBlock(page.titleRows, builder: &builder)
         for system in page.systems {
-            emitSystem(system, pendingTies: &pendingTies, pendingSlurs: &pendingSlurs, builder: &builder)
+            // Systems on one page can come from tunes with different %%ceolkit:scale factors,
+            // so each is emitted through a copy of self whose staffSize matches that system.
+            sized(to: system.staffSize)
+                .emitSystem(system, pendingTies: &pendingTies, pendingSlurs: &pendingSlurs,
+                            builder: &builder)
         }
         emitFooterBlock(page.footerRows, builder: &builder)
         return builder.buildDocument(
@@ -95,6 +99,18 @@ struct SVGEmitter: Sendable {
             libertinusSerifBase64: libertinusSerifBase64,
             libertinusSerifItalicBase64: libertinusSerifItalicBase64
         )
+    }
+
+    /// Returns a copy of this emitter whose `config.staffSize` is `staffSize`.
+    ///
+    /// Every staff, glyph, stem, and beam dimension below `emitSystem` is expressed as a
+    /// multiple of `config.staffSize`, so swapping it here scales an entire system without
+    /// threading a size argument through the whole emission tree.
+    private func sized(to staffSize: Double) -> SVGEmitter {
+        guard staffSize != config.staffSize else { return self }
+        var scaledConfig = config
+        scaledConfig.staffSize = staffSize
+        return SVGEmitter(config: scaledConfig, metadata: metadata, stemDirection: stemDirection)
     }
 
     // MARK: - Scroll-sync metadata

--- a/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
@@ -71,11 +71,17 @@ public struct TuneBlock: Sendable {
     public let systems: [JustifiedSystem]
     public let titleRows: [ResolvedTitleRow]
     public let titleBlockHeight: Double
+    /// Multiplier applied to `SVGRenderConfig.staffSize` (and the inter-system/inter-tune gaps
+    /// derived from it) for this tune's music, from `%%ceolkit:scale`.  `1.0` = renderer default.
+    /// The title block is laid out in absolute points and is unaffected.
+    public let scale: Double
 
-    public init(systems: [JustifiedSystem], titleRows: [ResolvedTitleRow] = [], titleBlockHeight: Double = 0) {
+    public init(systems: [JustifiedSystem], titleRows: [ResolvedTitleRow] = [],
+                titleBlockHeight: Double = 0, scale: Double = 1.0) {
         self.systems = systems
         self.titleRows = titleRows
         self.titleBlockHeight = titleBlockHeight
+        self.scale = scale
     }
 }
 
@@ -188,6 +194,9 @@ public struct ResolvedSystem: Sendable {
     public let measures: [ResolvedMeasure]
     /// Y offset of the top staff line relative to `origin.y`.
     public let staffOrigin: Double
+    /// Distance between adjacent staff lines, after `%%ceolkit:scale` has been applied.
+    /// The emitter derives every glyph and stem dimension in this system from it.
+    public let staffSize: Double
     /// Height of the staff body: 4 × staffSize (five lines, four spaces).
     public let staffHeight: Double
     /// Space above the top staff line (ledger lines, chord symbols, annotations).
@@ -208,6 +217,7 @@ public struct ResolvedSystem: Sendable {
         origin: Point,
         measures: [ResolvedMeasure],
         staffOrigin: Double,
+        staffSize: Double,
         staffHeight: Double,
         extraAbove: Double,
         extraBelow: Double,
@@ -220,6 +230,7 @@ public struct ResolvedSystem: Sendable {
         self.origin = origin
         self.measures = measures
         self.staffOrigin = staffOrigin
+        self.staffSize = staffSize
         self.staffHeight = staffHeight
         self.extraAbove = extraAbove
         self.extraBelow = extraBelow

--- a/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
@@ -36,7 +36,7 @@ public struct VerticalLayoutEngine: Sendable {
         var previousAbcLine: Int?
 
         for jsystem in systems {
-            let (extraAbove, extraBelow) = verticalExtent(of: jsystem)
+            let (extraAbove, extraBelow) = verticalExtent(of: jsystem, staffSize: config.staffSize)
             let totalHeight = extraAbove + staffHeight + extraBelow
 
             if !pageSystems.isEmpty && y + totalHeight > config.pageSize.height - config.margins.bottom {
@@ -48,20 +48,7 @@ public struct VerticalLayoutEngine: Sendable {
             }
 
             let systemOrigin = Point(x: config.margins.left, y: y)
-            let timeSigW = jsystem.meter.map {
-                timeSignatureWidth(for: $0, metadata: metadata, staffSize: config.staffSize)
-            } ?? 0
-            // When no time signature follows, use noteheadWidth as the trailing gap after the key
-            // signature so the space to the first bar line equals one note head.
-            let keySigTrailing: Double? = timeSigW > 0 ? nil : {
-                metadata.glyphBBoxes["noteheadBlack"].map { $0.width * config.staffSize }
-                    ?? config.staffSize * 1.2
-            }()
-            let keySigW = jsystem.keySignature.map {
-                keySignatureWidth(for: $0, metadata: metadata, staffSize: config.staffSize,
-                                  trailingGap: keySigTrailing)
-            } ?? 0
-            let startWidth = clefStartWidth(for: jsystem.clef) + keySigW + timeSigW
+            let startWidth = systemStartWidth(for: jsystem, staffSize: config.staffSize)
             let measures = resolveMeasures(
                 jsystem.measures,
                 systemOrigin: systemOrigin,
@@ -75,6 +62,7 @@ public struct VerticalLayoutEngine: Sendable {
                 origin: systemOrigin,
                 measures: measures,
                 staffOrigin: extraAbove,
+                staffSize: config.staffSize,
                 staffHeight: staffHeight,
                 extraAbove: extraAbove,
                 extraBelow: extraBelow,
@@ -107,8 +95,6 @@ public struct VerticalLayoutEngine: Sendable {
     /// Each tune's title rows are offset from their tune-relative `baselineY` values
     /// by the actual page y-origin at the moment they are placed.
     public func layout(_ tuneBlocks: [TuneBlock]) -> ResolvedLayout {
-        let staffHeight = 4.0 * config.staffSize
-
         var pages: [ResolvedPage] = []
         var pageSystems: [ResolvedSystem] = []
         var pageTitleRows: [ResolvedTitleRow] = []
@@ -116,6 +102,14 @@ public struct VerticalLayoutEngine: Sendable {
         var previousAbcLine: Int?
 
         for block in tuneBlocks {
+            // %%ceolkit:scale sizes this tune's music (and the gaps derived from staffSize)
+            // relative to the renderer default. Page size and margins stay absolute.
+            let tuneConfig  = config.scaled(by: block.scale)
+            let staffSize   = tuneConfig.staffSize
+            let staffHeight = 4.0 * staffSize
+            let systemGap   = tuneConfig.systemGap
+            let tuneGap     = tuneConfig.tuneGap
+
             // If the current page already has content, check whether the entire tune
             // fits in the remaining space. If not, close the current page. Tunes that
             // are taller than a full page are still forced to a fresh page here; the
@@ -141,7 +135,7 @@ public struct VerticalLayoutEngine: Sendable {
             y += block.titleBlockHeight
 
             for (si, jsystem) in block.systems.enumerated() {
-                let (extraAbove, extraBelow) = verticalExtent(of: jsystem)
+                let (extraAbove, extraBelow) = verticalExtent(of: jsystem, staffSize: staffSize)
                 let totalHeight = extraAbove + staffHeight + extraBelow
 
                 if !pageSystems.isEmpty && y + totalHeight > config.pageSize.height - config.margins.bottom {
@@ -152,18 +146,7 @@ public struct VerticalLayoutEngine: Sendable {
                 }
 
                 let systemOrigin = Point(x: config.margins.left, y: y)
-                let timeSigW = jsystem.meter.map {
-                    timeSignatureWidth(for: $0, metadata: metadata, staffSize: config.staffSize)
-                } ?? 0
-                let keySigTrailing: Double? = timeSigW > 0 ? nil : {
-                    metadata.glyphBBoxes["noteheadBlack"].map { $0.width * config.staffSize }
-                        ?? config.staffSize * 1.2
-                }()
-                let keySigW = jsystem.keySignature.map {
-                    keySignatureWidth(for: $0, metadata: metadata, staffSize: config.staffSize,
-                                      trailingGap: keySigTrailing)
-                } ?? 0
-                let startWidth = clefStartWidth(for: jsystem.clef) + keySigW + timeSigW
+                let startWidth = systemStartWidth(for: jsystem, staffSize: staffSize)
                 let measures = resolveMeasures(
                     jsystem.measures,
                     systemOrigin: systemOrigin,
@@ -176,6 +159,7 @@ public struct VerticalLayoutEngine: Sendable {
                     origin: systemOrigin,
                     measures: measures,
                     staffOrigin: extraAbove,
+                    staffSize: staffSize,
                     staffHeight: staffHeight,
                     extraAbove: extraAbove,
                     extraBelow: extraBelow,
@@ -186,7 +170,7 @@ public struct VerticalLayoutEngine: Sendable {
                     abcLine: abcLine
                 ))
                 let isLastInBlock = si == block.systems.count - 1
-                y += totalHeight + (isLastInBlock ? config.tuneGap : config.systemGap)
+                y += totalHeight + (isLastInBlock ? tuneGap : systemGap)
             }
         }
 
@@ -207,18 +191,35 @@ public struct VerticalLayoutEngine: Sendable {
     /// including its title block, all systems, and inter-system gaps (but not the
     /// trailing gap that follows the last system).
     private func totalHeight(of block: TuneBlock) -> Double {
-        let staffHeight = 4.0 * config.staffSize
+        let tuneConfig  = config.scaled(by: block.scale)
+        let staffHeight = 4.0 * tuneConfig.staffSize
         var h = block.titleBlockHeight
         for (i, jsystem) in block.systems.enumerated() {
-            let (ea, eb) = verticalExtent(of: jsystem)
+            let (ea, eb) = verticalExtent(of: jsystem, staffSize: tuneConfig.staffSize)
             h += ea + staffHeight + eb
-            if i < block.systems.count - 1 { h += config.systemGap }
+            if i < block.systems.count - 1 { h += tuneConfig.systemGap }
         }
         return h
     }
 
-    private func clefStartWidth(for spec: ClefSpec) -> Double {
-        clefHeaderWidth(for: spec, metadata: metadata, staffSize: config.staffSize)
+    /// Width of the clef + key signature + time signature run that precedes the first
+    /// measure of `jsystem`, at the given staff size.
+    private func systemStartWidth(for jsystem: JustifiedSystem, staffSize: Double) -> Double {
+        let timeSigW = jsystem.meter.map {
+            timeSignatureWidth(for: $0, metadata: metadata, staffSize: staffSize)
+        } ?? 0
+        // When no time signature follows, use noteheadWidth as the trailing gap after the key
+        // signature so the space to the first bar line equals one note head.
+        let keySigTrailing: Double? = timeSigW > 0 ? nil : {
+            metadata.glyphBBoxes["noteheadBlack"].map { $0.width * staffSize }
+                ?? staffSize * 1.2
+        }()
+        let keySigW = jsystem.keySignature.map {
+            keySignatureWidth(for: $0, metadata: metadata, staffSize: staffSize,
+                              trailingGap: keySigTrailing)
+        } ?? 0
+        let clefW = clefHeaderWidth(for: jsystem.clef, metadata: metadata, staffSize: staffSize)
+        return clefW + keySigW + timeSigW
     }
 
     /// The 1-based ABC source line of the first measure that contributes content
@@ -239,7 +240,8 @@ public struct VerticalLayoutEngine: Sendable {
 
     // MARK: - Vertical extent
 
-    private func verticalExtent(of system: JustifiedSystem) -> (extraAbove: Double, extraBelow: Double) {
+    private func verticalExtent(of system: JustifiedSystem,
+                                staffSize: Double) -> (extraAbove: Double, extraBelow: Double) {
         var maxLedgerAbove = 0
         var maxLedgerBelow = 0
         var hasChordSymbolsOrAnnotations = false
@@ -259,7 +261,7 @@ public struct VerticalLayoutEngine: Sendable {
             }
         }
 
-        let s = config.staffSize
+        let s = staffSize
         // Grace note stems always point upward (graceScale=0.6) × 3.5 staff spaces above the
         // notehead. Reserve that height so stems never intrude into the title block zone.
         let graceOvershoot = hasGraceGroups ? 3.5 * s * 0.6 : 0

--- a/Tests/CeolKitParserTests/Extensions/CeolKitExtensionTests.swift
+++ b/Tests/CeolKitParserTests/Extensions/CeolKitExtensionTests.swift
@@ -1,6 +1,6 @@
 // CeolKit extension directive conformance tests.
 // Tests %%ceolkit:pipeformat, %%ceolkit:pagenumber, %%ceolkit:stemalignment,
-// %%ceolkit:justifylast.
+// %%ceolkit:justifylast, %%ceolkit:scale.
 // See EXTENSIONS.md and CeolKit spec §7.
 import Testing
 import CeolKitModel
@@ -355,5 +355,113 @@ struct CeolKitExtensionTests {
             return false
         }
         #expect(!hasDirective)
+    }
+
+    // MARK: %%ceolkit:scale
+
+    /// Returns the scale factor from the first `.scale` directive on any tune, if present.
+    private func scaleFactor(in result: ParseResult) -> Double? {
+        result.score.tunes.flatMap(\.directives).compactMap {
+            if case .scale(let f) = $0.directive { return f }
+            return nil
+        }.first
+    }
+
+    @Test("%%ceolkit:scale 0.8 attaches scale(0.8) directive at tune scope")
+    func scaleValidFactor() {
+        let abc = """
+        X:1
+        T:Test
+        M:4/4
+        L:1/4
+        %%ceolkit:scale 0.8
+        K:G
+        GABC|
+        """
+        let result = parse(abc)
+        let directive = result.score.firstTune?.directives.first(where: {
+            if case .scale = $0.directive { return true }
+            return false
+        })
+        #expect(directive != nil)
+        #expect(scaleFactor(in: result) == 0.8)
+        if let d = directive, case .tuneGlobal = d.scope {} else {
+            Issue.record("Expected .tuneGlobal scope, got \(String(describing: directive?.scope))")
+        }
+    }
+
+    @Test("%%ceolkit:scale accepts a factor greater than 1")
+    func scaleGreaterThanOne() {
+        let abc = "X:1\nT:T\nM:4/4\nL:1/4\n%%ceolkit:scale 1.5\nK:C\nC|"
+        #expect(scaleFactor(in: parse(abc)) == 1.5)
+    }
+
+    @Test("%%ceolkit:scale accepts an integer payload")
+    func scaleIntegerPayload() {
+        let abc = "X:1\nT:T\nM:4/4\nL:1/4\n%%ceolkit:scale 2\nK:C\nC|"
+        #expect(scaleFactor(in: parse(abc)) == 2.0)
+    }
+
+    @Test("%%ceolkit:scale in the file preamble is promoted to the first tune")
+    func scaleInPreamble() {
+        let abc = "%%ceolkit:scale 0.5\nX:1\nT:T\nM:4/4\nL:1/4\nK:C\nC|"
+        #expect(scaleFactor(in: parse(abc)) == 0.5)
+    }
+
+    @Test("%%ceolkit:scale in the tune body is accepted, not reported as unknown")
+    func scaleInBody() {
+        let abc = """
+        X:1
+        T:Test
+        M:4/4
+        L:1/4
+        K:C
+        CDEC|
+        %%ceolkit:scale 0.75
+        CDEC|
+        """
+        let result = parse(abc)
+        #expect(scaleFactor(in: result) == 0.75)
+        let unknowns = result.score.diagnostics.filter { $0.code == .unknownDirective }
+        #expect(unknowns.isEmpty)
+    }
+
+    @Test("%%ceolkit:scale 0 is invalid — emits warning and drops directive")
+    func scaleZeroEmitsWarning() {
+        let abc = "%%ceolkit:scale 0\nX:1\nT:T\nM:4/4\nL:1/4\nK:C\nC|"
+        let result = parse(abc)
+        let warnings = result.score.diagnostics.filter {
+            $0.severity == .warning && $0.code == .invalidScale
+        }
+        #expect(!warnings.isEmpty)
+        #expect(scaleFactor(in: result) == nil)
+    }
+
+    @Test("%%ceolkit:scale -0.5 is invalid — emits warning and drops directive")
+    func scaleNegativeEmitsWarning() {
+        let abc = "%%ceolkit:scale -0.5\nX:1\nT:T\nM:4/4\nL:1/4\nK:C\nC|"
+        let result = parse(abc)
+        let warnings = result.score.diagnostics.filter { $0.code == .invalidScale }
+        #expect(!warnings.isEmpty)
+        #expect(scaleFactor(in: result) == nil)
+    }
+
+    @Test("%%ceolkit:scale big (non-numeric) emits warning and drops directive")
+    func scaleNonNumericEmitsWarning() {
+        let abc = "%%ceolkit:scale big\nX:1\nT:T\nM:4/4\nL:1/4\nK:C\nC|"
+        let result = parse(abc)
+        let warnings = result.score.diagnostics.filter { $0.code == .invalidScale }
+        #expect(!warnings.isEmpty)
+        #expect(scaleFactor(in: result) == nil)
+    }
+
+    @Test("%%ceolkit:scale with a non-finite payload emits warning and drops directive")
+    func scaleNonFiniteEmitsWarning() {
+        for payload in ["inf", "nan"] {
+            let result = parse("%%ceolkit:scale \(payload)\nX:1\nT:T\nM:4/4\nL:1/4\nK:C\nC|")
+            #expect(result.score.diagnostics.contains { $0.code == .invalidScale },
+                    "expected invalidScale for payload '\(payload)'")
+            #expect(scaleFactor(in: result) == nil)
+        }
     }
 }

--- a/Tests/CeolKitSVGRendererTests/IntegrationTests.swift
+++ b/Tests/CeolKitSVGRendererTests/IntegrationTests.swift
@@ -38,7 +38,7 @@ private func makeVoice(id: String, measures: [Measure]) -> Voice {
         properties: VoiceProperties(
             clef:            ClefSpec(clef: .treble, octaveShift: 0),
             transposition:   .none,
-            staffProperties: StaffProperties(staffLines: 5, scale: nil),
+            staffProperties: StaffProperties(staffLines: 5),
             name:            nil,
             subname:         nil,
             stemDirection:   .auto,
@@ -64,7 +64,7 @@ private func makeTune(
         explicit:        false,
         clef:            ClefSpec(clef: .treble, octaveShift: 0),
         transposition:   .none,
-        staffProperties: StaffProperties(staffLines: 5, scale: nil),
+        staffProperties: StaffProperties(staffLines: 5),
         source:          dummyRange
     )
     let meta = TuneMetadata(

--- a/Tests/CeolKitSVGRendererTests/SVGEmitterTests.swift
+++ b/Tests/CeolKitSVGRendererTests/SVGEmitterTests.swift
@@ -28,6 +28,7 @@ private func system(measures: [ResolvedMeasure], abcLine: Int = 1, originY: Doub
         origin: Point(x: config.margins.left, y: originY),
         measures: measures,
         staffOrigin: 50,
+        staffSize: config.staffSize,
         staffHeight: staffHeight,
         extraAbove: 50,
         extraBelow: 0,

--- a/Tests/CeolKitSVGRendererTests/ScaleDirectiveTests.swift
+++ b/Tests/CeolKitSVGRendererTests/ScaleDirectiveTests.swift
@@ -1,0 +1,166 @@
+//
+//  ScaleDirectiveTests.swift
+//  CeolKitSVGRendererTests
+//
+//  Rendering behaviour of %%ceolkit:scale (issue #32).
+//
+
+import CeolKitModel
+import CeolKitParser
+import Testing
+@testable import CeolKitSVGRenderer
+
+@Suite("%%ceolkit:scale rendering")
+struct ScaleDirectiveTests {
+
+    private static let tuneBody = """
+        X:1
+        T:First
+        M:4/4
+        L:1/4
+        K:C
+        CDEF|GABc|
+        """
+
+    private func render(_ abc: String) throws -> [String] {
+        let score = CeolKitParser().parse(abc, options: .default).score
+        return try SVGRenderer().render(score)
+    }
+
+    private struct HorizontalLine {
+        let x1: Double
+        let x2: Double
+        let y: Double
+    }
+
+    /// Every horizontal `<line>` element in `svg`, in document order.
+    private func horizontalLines(in svg: String) -> [HorizontalLine] {
+        svg.matches(of: /<line x1="([\d.-]+)" y1="([\d.-]+)" x2="([\d.-]+)" y2="([\d.-]+)"/)
+            .compactMap { match -> HorizontalLine? in
+                guard let x1 = Double(match.1), let y1 = Double(match.2),
+                      let x2 = Double(match.3), let y2 = Double(match.4),
+                      y1 == y2 else { return nil }
+                return HorizontalLine(x1: x1, x2: x2, y: y1)
+            }
+    }
+
+    /// Distance between adjacent staff lines for each system in `svg`, in document order.
+    ///
+    /// `emitStaffLines` opens each system with exactly five consecutive lines sharing one
+    /// x range, which tells a staff apart from the ledger lines drawn later inside its
+    /// measures — those are notehead-width and do not come five to a run.
+    private func staffSpacings(in svg: String) -> [Double] {
+        let lines = horizontalLines(in: svg)
+        var spacings: [Double] = []
+        var i = 0
+        while i + 4 < lines.count {
+            let staff = lines[i ..< i + 5]
+            if staff.allSatisfy({ $0.x1 == lines[i].x1 && $0.x2 == lines[i].x2 }) {
+                spacings.append(lines[i + 1].y - lines[i].y)
+                i += 5
+            } else {
+                i += 1
+            }
+        }
+        return spacings
+    }
+
+    /// `pages` with the scroll-sync metadata comment removed.
+    ///
+    /// Adding a directive line to a source shifts every following ABC line number, so the
+    /// `abcLine` anchors legitimately differ between two sources that must nevertheless
+    /// engrave identically. Everything outside the comment is drawing geometry.
+    private func drawingOnly(_ pages: [String]) -> [String] {
+        pages.map { $0.replacing(/<!-- ceolkit-meta: [^>]*-->/, with: "") }
+    }
+
+    /// The `width`/`height` attributes of the root `<svg>` element, as written.
+    private func pageAttributes(of svg: String) -> String? {
+        svg.firstMatch(of: /<svg [^>]*(width="[\d.]+" height="[\d.]+")/).map { String($0.1) }
+    }
+
+    @Test("%%ceolkit:scale 0.5 halves staff line spacing")
+    func halfScaleHalvesStaffSpacing() throws {
+        let plainPage  = try #require(try render(Self.tuneBody).first)
+        let scaledPage = try #require(
+            try render(Self.tuneBody.replacing("K:C", with: "%%ceolkit:scale 0.5\nK:C")).first)
+
+        let plainSpacing  = try #require(staffSpacings(in: plainPage).first)
+        let scaledSpacing = try #require(staffSpacings(in: scaledPage).first)
+
+        #expect(plainSpacing == SVGRenderConfig().staffSize)
+        #expect(abs(scaledSpacing - plainSpacing * 0.5) < 1e-9)
+    }
+
+    @Test("%%ceolkit:scale applies per tune — only the tune carrying it is resized")
+    func scaleIsScopedToItsTune() throws {
+        let abc = """
+        X:1
+        T:First
+        M:4/4
+        L:1/4
+        K:C
+        CDEF|GABc|
+
+        X:2
+        T:Second
+        M:4/4
+        L:1/4
+        %%ceolkit:scale 0.5
+        K:C
+        CDEF|GABc|
+        """
+        let page = try #require(try render(abc).first)
+        let spacings = staffSpacings(in: page)
+        try #require(spacings.count == 2)
+        #expect(spacings[0] == SVGRenderConfig().staffSize)
+        #expect(abs(spacings[1] - spacings[0] * 0.5) < 1e-9)
+    }
+
+    @Test("A preamble %%ceolkit:scale governs every following tune")
+    func preambleScalePersistsAcrossTunes() throws {
+        let abc = """
+        %%ceolkit:scale 0.5
+        X:1
+        T:First
+        M:4/4
+        L:1/4
+        K:C
+        CDEF|GABc|
+
+        X:2
+        T:Second
+        M:4/4
+        L:1/4
+        K:C
+        CDEF|GABc|
+        """
+        let page = try #require(try render(abc).first)
+        let spacings = staffSpacings(in: page)
+        try #require(spacings.count == 2)
+        #expect(spacings.allSatisfy { abs($0 - SVGRenderConfig().staffSize * 0.5) < 1e-9 })
+    }
+
+    @Test("%%ceolkit:scale 1.0 engraves identically to no directive at all")
+    func unitScaleMatchesAbsentDirective() throws {
+        let plain = try render(Self.tuneBody)
+        let unit  = try render(Self.tuneBody.replacing("K:C", with: "%%ceolkit:scale 1.0\nK:C"))
+        #expect(drawingOnly(plain) == drawingOnly(unit))
+    }
+
+    @Test("Scaling the music leaves the page size untouched")
+    func scaleDoesNotResizePage() throws {
+        let plainPage  = try #require(try render(Self.tuneBody).first)
+        let scaledPage = try #require(
+            try render(Self.tuneBody.replacing("K:C", with: "%%ceolkit:scale 0.5\nK:C")).first)
+        let plainAttrs = try #require(pageAttributes(of: plainPage))
+        #expect(pageAttributes(of: scaledPage) == plainAttrs)
+    }
+
+    @Test("An invalid %%ceolkit:scale leaves the tune at the renderer default")
+    func invalidScaleFallsBackToDefault() throws {
+        let plain   = try render(Self.tuneBody)
+        let invalid = try render(Self.tuneBody.replacing("K:C", with: "%%ceolkit:scale 0\nK:C"))
+        #expect(drawingOnly(plain) == drawingOnly(invalid))
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/SpecTitleBlockBuilderTests.swift
+++ b/Tests/CeolKitSVGRendererTests/SpecTitleBlockBuilderTests.swift
@@ -38,7 +38,7 @@ private func makeTune(
         explicit: false,
         clef: ClefSpec(clef: .treble, octaveShift: 0),
         transposition: .none,
-        staffProperties: StaffProperties(staffLines: 5, scale: nil),
+        staffProperties: StaffProperties(staffLines: 5),
         source: dummySrc
     )
     return Tune(
@@ -55,7 +55,7 @@ private func makeTune(
             properties: VoiceProperties(
                 clef: ClefSpec(clef: .treble, octaveShift: 0),
                 transposition: .none,
-                staffProperties: StaffProperties(staffLines: 5, scale: nil),
+                staffProperties: StaffProperties(staffLines: 5),
                 name: nil, subname: nil, stemDirection: .auto, middleNote: nil
             ),
             staves: [Staff(measures: [], overlays: [])],


### PR DESCRIPTION
Closes #32.

Adds `%%ceolkit:scale <positive number>`, which scales a tune's rendered music relative to the renderer's default size — `%%ceolkit:scale 0.8` engraves everything at 80%.

Page size and margins stay in absolute points, so the usable width is unchanged and a smaller factor fits more measures onto each staff line. Title blocks are unscaled.

The factor is tune-scoped but sticky: a preamble value governs every following tune until a later tune header overrides it. Per-voice scaling is deliberately not supported, per the issue.

## Changes

**Model** — `CeolKitDirective.scale(Double)` and `DiagnosticCode.invalidScale`. Also removes the dead `StaffProperties.scale` field per the issue's closing note: it was constructed as `nil` at all five call sites and read by no renderer.

**Parser** — `parseCeolKitDirective` handles `ceolkit:scale`, rejecting zero, negative, non-finite, and non-numeric payloads with a warning and dropping the directive (following the `%%ceolkit:pagenumber` precedent). Added to the `applyBodyDirective` pass-through list so it is accepted in a tune body rather than reported as unknown.

**Renderer** — the substantive part. `applyingScoreDirectives` yielded one config for the whole document, and `MeasureSizer` / `VerticalLayoutEngine` / `SVGEmitter` were all built once outside the tune loop. The factor is now threaded per tune:

- `SVGRenderConfig.scaled(by:)` derives `staffSize`, `systemGap`, and `tuneGap`; page size and margins are deliberately untouched.
- `SVGRenderer.render` tracks a sticky `scale` alongside `stemDirection` and `justifyLastSystem`, and builds `MeasureSizer` and the system header widths per tune. `usableWidth` stays absolute.
- `TuneBlock.scale` carries it into `VerticalLayoutEngine`, which stamps the effective `staffSize` onto each `ResolvedSystem`.
- `SVGEmitter.emitPage` emits each system through `sized(to:)`, a copy of itself with that system's `staffSize`. Every dimension below `emitSystem` is already a multiple of `config.staffSize`, so this scales a whole system without threading a size argument through ~50 call sites.

**Docs** — a `%%ceolkit:scale` section in EXTENSIONS.md following the existing Syntax / Type / Default / Scope / Description / Examples format, including the relationship to `abcm2ps`'s `%%scale`.

Two incidental cleanups fell out: the clef/key/time header-width block was duplicated verbatim in both `layout` overloads and is now `systemStartWidth(for:staffSize:)`; and `ResolvedSystem.staffSize` is a required init parameter rather than defaulting to a magic `6.0`.

## Tests

560 pass, up from 545.

- **Parser** (9): valid factors, preamble and tune-body placement, and `0` / negative / non-numeric / `inf` / `nan` each producing a warning and no directive.
- **Renderer** (6): `scale 0.5` halves staff-line spacing; two tunes in one file with only the second scaled render at different sizes (this pins the per-tune scoping); a preamble factor governs both tunes; page size is unchanged; and `scale 1.0` and an invalid factor both render identically to no directive.

The two identical-output tests compare with the `ceolkit-meta` comment stripped — adding a directive line shifts every following ABC line number, so the `abcLine` scroll-sync anchors legitimately differ between two sources that engrave identically. The existing snapshot tests are the real proof that absent-directive output is unchanged, and they pass untouched.

## Note

Title blocks do not scale, per issue item 5. `SpecTitleBlockBuilder` derives its `lineHeight` from `staffSize`, so it is still passed the *unscaled* config — otherwise title row spacing would shrink while the 18pt/12pt fonts stayed put. Easy to change if you'd rather the title block track the music.

## Base branch

Targeting `develop` rather than `main`: this branch was cut from `develop`, and `main` is one commit behind it, so a `main`-based PR would sweep in the already-merged Fix #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Pta6z6NrN1yAATUKJCpFS