### PR TITLE
Fix #39 - tighten grace-note group spacing

### DIFF
--- a/Sources/CeolKitSVGRenderer/Config/SVGRenderConfig.swift
+++ b/Sources/CeolKitSVGRenderer/Config/SVGRenderConfig.swift
@@ -11,6 +11,13 @@ public struct SVGRenderConfig: Sendable {
     public var justifyLastSystem: Bool
     public var straightFlags: Bool
     public var graceSlurs: Bool
+    /// Step between adjacent grace noteheads within one grace group, as a multiple of the
+    /// grace notehead width.
+    ///
+    /// The notes of a beamed embellishment (a grip, taorluath or birl) share a beam and are
+    /// engraved nearly adjacent, so this stays close to `1.0`.  It does not affect the padding
+    /// at the outer edges of the group, nor the gap before the principal note.
+    public var graceNoteSpacing: Double
 
     public init(
         pageSize: PageSize = .letter,
@@ -20,7 +27,8 @@ public struct SVGRenderConfig: Sendable {
         tuneGap: Double? = nil,
         justifyLastSystem: Bool = false,
         straightFlags: Bool = false,
-        graceSlurs: Bool = true
+        graceSlurs: Bool = true,
+        graceNoteSpacing: Double = 1.05
     ) {
         self.pageSize = pageSize
         self.margins = margins
@@ -30,6 +38,7 @@ public struct SVGRenderConfig: Sendable {
         self.justifyLastSystem = justifyLastSystem
         self.straightFlags = straightFlags
         self.graceSlurs = graceSlurs
+        self.graceNoteSpacing = graceNoteSpacing
     }
 
     /// Returns a copy with `staffSize` and the vertical gaps derived from it multiplied

--- a/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
@@ -830,7 +830,7 @@ struct SVGEmitter: Sendable {
     // MARK: - Grace groups
 
     /// Scale factor for grace note glyphs and geometry relative to normal notes.
-    private let graceScale = 0.6
+    private var graceScale: Double { GraceMetrics.scale }
 
     @discardableResult
     private func emitGraceGroup(_ grace: GraceGroup, originX: Double,
@@ -841,21 +841,20 @@ struct SVGEmitter: Sendable {
         let s          = config.staffSize
         let fontSize   = 4.0 * s * graceScale
         let stemThick  = metadata.engravingDefaults.stemThickness * s
-        let noteW      = noteheadWidth() * graceScale
-        let colWidth   = noteW * 1.5   // total column per grace note: 0.25W lead + W head + 0.25W trail
+        let metrics    = GraceMetrics(config: config, metadata: metadata)
         let stemLength = 3.5 * s * graceScale
         let multiple   = grace.notes.count > 1
 
         // Pre-pass: compute notehead Y and stem X for each grace note.
-        // Each note's notehead is offset 0.25 × noteW into its column so adjacent noteheads
-        // have 0.5 × noteW of breathing room between them.
-        // Grace note stems always point up, so the stem X is at the right edge of the notehead.
+        // Notehead x positions come from `GraceMetrics`, the same source the sizer used to
+        // reserve this group's width.
         struct GracePos { let x, noteheadY, stemX: Double; let staffPos: Int }
+        let noteheadXs = metrics.noteheadOffsets(grace.notes)
         let positions: [GracePos] = grace.notes.enumerated().map { i, note in
-            let x   = originX + Double(i) * colWidth + noteW * 0.25
+            let x   = originX + noteheadXs[i]
             let sp  = self.staffPos(for: note.pitch)
             let y   = noteY(staffPos: sp, bottomStaffY: bottomStaffY)
-            return GracePos(x: x, noteheadY: y, stemX: x + noteW, staffPos: sp)
+            return GracePos(x: x, noteheadY: y, stemX: x + metrics.noteheadWidth, staffPos: sp)
         }
 
         // The beam (or flag) sits at the top of the highest note's stem.

--- a/Sources/CeolKitSVGRenderer/Layout/GraceMetrics.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/GraceMetrics.swift
@@ -1,0 +1,74 @@
+import Foundation
+import CeolKitModel
+
+/// Horizontal geometry of a grace-note group.
+///
+/// The sizer reserves the space and the emitter draws into it, so both derive their
+/// numbers from here rather than from duplicated literals.
+///
+/// A group's box is laid out as
+///
+/// ```
+/// |<-pad->|<-head->|<-advance->|<-head->|<-pad->|
+/// ```
+///
+/// where `pad` is `edgePad × graceNoteheadWidth` at each outer edge and `advance` is the
+/// step between adjacent noteheads.  Adjacent noteheads within a group sit on a shared beam
+/// and are engraved nearly touching, so `advance` is close to one notehead width — much
+/// tighter than the outer padding implies (see `SVGRenderConfig.graceNoteSpacing`).
+///
+/// A note carrying a displayed accidental is the exception: its accidental glyph is drawn to
+/// the left of its notehead, so it needs the wider `accidentalAdvance` to keep clear of the
+/// preceding note.
+struct GraceMetrics {
+    /// Scale factor for grace note glyphs and geometry relative to normal notes.
+    static let scale = 0.6
+
+    /// Padding at each outer edge of a group, in grace notehead widths.
+    static let edgePad = 0.25
+
+    /// Step for a note whose notehead is preceded by an accidental glyph, in grace
+    /// notehead widths.  Accidental placement within the group is unchanged from before
+    /// grace groups were tightened, so this keeps the space that placement assumes.
+    static let accidentalAdvance = 1.5
+
+    /// Width of a grace notehead.
+    let noteheadWidth: Double
+
+    /// Step between the x of one notehead and the next within the same group.
+    let advance: Double
+
+    init(config: SVGRenderConfig, metadata: BravuraMetadata) {
+        let fullNoteheadWidth = metadata.glyphBBoxes["noteheadBlack"].map { $0.width * config.staffSize }
+                                ?? config.staffSize * 1.2
+        self.noteheadWidth = fullNoteheadWidth * Self.scale
+        self.advance = self.noteheadWidth * config.graceNoteSpacing
+    }
+
+    /// x of each notehead's left edge, relative to the group's left edge.
+    func noteheadOffsets(_ notes: [Note]) -> [Double] {
+        var x = noteheadWidth * Self.edgePad
+        var offsets: [Double] = []
+        offsets.reserveCapacity(notes.count)
+        for (i, note) in notes.enumerated() {
+            if i > 0 {
+                x += note.displayedAccidental != nil ? noteheadWidth * Self.accidentalAdvance : advance
+            }
+            offsets.append(x)
+        }
+        return offsets
+    }
+
+    /// x of each note's stem, relative to the group's left edge.
+    ///
+    /// Grace stems always point up, so the stem sits at the right edge of the notehead.
+    func stemOffsets(_ notes: [Note]) -> [Double] {
+        noteheadOffsets(notes).map { $0 + noteheadWidth }
+    }
+
+    /// Total width of a grace group.
+    func width(_ notes: [Note]) -> Double {
+        let last = stemOffsets(notes).last ?? (noteheadWidth * (Self.edgePad + 1))
+        return last + noteheadWidth * Self.edgePad
+    }
+}

--- a/Sources/CeolKitSVGRenderer/Layout/MeasureSizer.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/MeasureSizer.swift
@@ -8,10 +8,12 @@ import CeolKitModel
 public struct MeasureSizer: Sendable {
     private let config: SVGRenderConfig
     private let metadata: BravuraMetadata
+    private let graceMetrics: GraceMetrics
 
     public init(config: SVGRenderConfig, metadata: BravuraMetadata) {
         self.config = config
         self.metadata = metadata
+        self.graceMetrics = GraceMetrics(config: config, metadata: metadata)
     }
 
     /// Sizes a single measure.
@@ -125,30 +127,31 @@ public struct MeasureSizer: Sendable {
         }
     }
 
-    /// Width consumed by a grace group: 1.5 × grace notehead width per note,
-    /// giving 0.25× leading and 0.25× trailing padding (0.5× between adjacent noteheads).
+    /// Width consumed by a grace group: outer padding at each edge plus one `advance`
+    /// per additional notehead.  See `GraceMetrics`.
     private func graceGroupWidth(_ grace: GraceGroup) -> Double {
-        noteheadWidth() * 0.6 * 1.5 * Double(max(grace.notes.count, 1))
+        graceMetrics.width(grace.notes)
     }
 
-    /// Gap between the grace group's last column boundary and the principal notehead.
+    /// Gap between the grace group's right edge and the principal notehead.
     ///
     /// For a single grace note the 32nd-note flag extends right of the stem and overhangs the
     /// column boundary.  We measure the overhang from the bounding-box data and add a small
     /// comfortable clearance so the flag tip is visibly separated from the principal note.
     /// Multi-note groups use beams that don't overhang, so a simpler fixed gap is used there.
     private func graceNoteGap(for grace: GraceGroup) -> Double {
-        let graceNHW = noteheadWidth() * 0.6   // grace notehead width (graceScale = 0.6)
-        guard grace.notes.count == 1 else {
-            // Beamed group: no flag overhang; keep original gap.
-            return noteheadWidth() * (0.25 * 0.6 + 0.25)
+        guard let single = grace.notes.first, grace.notes.count == 1 else {
+            // Beamed group: no flag overhang; the group's own trailing pad plus a
+            // notehead-quarter of clearance before the principal note.
+            return noteheadWidth() * (GraceMetrics.edgePad * GraceMetrics.scale + 0.25)
         }
-        // Single grace note: compute how far the flag extends past the column boundary.
-        // stemX within the column = 1.25 × graceNHW; columnWidth = 1.5 × graceNHW.
-        // flagWidth (rendered) = bboxWidth × staffSize × 0.6.
-        let flagW = metadata.glyphBBoxes["flag32ndUp"].map { $0.width * config.staffSize * 0.6 }
+        // Single grace note: compute how far the flag extends past the group's right edge.
+        // flagWidth (rendered) = bboxWidth × staffSize × graceScale.
+        let flagW = metadata.glyphBBoxes["flag32ndUp"]
+                        .map { $0.width * config.staffSize * GraceMetrics.scale }
                     ?? config.staffSize * 0.625
-        let flagOverhang = max(0, 1.25 * graceNHW + flagW - 1.5 * graceNHW)
+        let stemX        = graceMetrics.stemOffsets([single])[0]
+        let flagOverhang = max(0, stemX + flagW - graceMetrics.width([single]))
         return flagOverhang + config.staffSize * 0.25
     }
 

--- a/Tests/CeolKitSVGRendererTests/MeasureSizerTests.swift
+++ b/Tests/CeolKitSVGRendererTests/MeasureSizerTests.swift
@@ -163,4 +163,74 @@ private func measure(events: [Event]) -> Measure {
         // (grace group is smaller than a full note column).
         #expect(pairedSized.naturalWidth < twoNoteSized.naturalWidth)
     }
+
+    // MARK: - Grace group width (issue #39)
+
+    /// The notes of a beamed embellishment share a beam and sit nearly adjacent, so each
+    /// note after the first costs only `graceNoteSpacing` notehead widths — not the
+    /// full 1.5 that the group's outer padding would suggest.
+    @Test func beamedGraceNotesAdvanceByGraceNoteSpacing() throws {
+        let metadata = try BravuraMetadata.load()
+        let config   = SVGRenderConfig()
+        let metrics  = GraceMetrics(config: config, metadata: metadata)
+        let g        = note(duration: Fraction(numerator: 1, denominator: 2))
+
+        let widths = (1...4).map { count in
+            metrics.width(Array(repeating: g, count: count))
+        }
+
+        // Each additional notehead adds exactly one advance.
+        for i in 1..<widths.count {
+            #expect(abs((widths[i] - widths[i - 1]) - metrics.advance) < 0.001)
+        }
+        #expect(abs(metrics.advance - metrics.noteheadWidth * config.graceNoteSpacing) < 0.001)
+        // The advance is well under the 1.5 × notehead width charged before issue #39.
+        #expect(metrics.advance < metrics.noteheadWidth * 1.5)
+    }
+
+    /// Single grace notes were already spaced correctly; issue #39 must not move them.
+    @Test func singleGraceGroupWidthIsUnchanged() throws {
+        let metadata = try BravuraMetadata.load()
+        let config   = SVGRenderConfig()
+        let metrics  = GraceMetrics(config: config, metadata: metadata)
+        let g        = note(duration: Fraction(numerator: 1, denominator: 2))
+
+        #expect(abs(metrics.width([g]) - metrics.noteheadWidth * 1.5) < 0.001)
+    }
+
+    @Test func graceNoteSpacingConfigNarrowsBeamedGroups() throws {
+        let metadata = try BravuraMetadata.load()
+        let g        = note(duration: Fraction(numerator: 1, denominator: 2))
+        let grace    = GraceGroup(kind: .appoggiatura, notes: [g, g, g], source: dummyRange)
+        let quarter  = Fraction(numerator: 2, denominator: 1)
+        let events: [Event] = [.grace(grace), .note(note(duration: quarter))]
+
+        let wide  = MeasureSizer(config: SVGRenderConfig(graceNoteSpacing: 1.5), metadata: metadata)
+        let tight = MeasureSizer(config: SVGRenderConfig(graceNoteSpacing: 1.05), metadata: metadata)
+
+        let wideSized  = wide.size(measure(events: events),  unitNoteLength: unitNoteLength)
+        let tightSized = tight.size(measure(events: events), unitNoteLength: unitNoteLength)
+
+        #expect(tightSized.naturalWidth < wideSized.naturalWidth)
+        // The principal note follows the grace group, so it moves left by the same amount.
+        #expect(tightSized.eventOffsets[1] < wideSized.eventOffsets[1])
+    }
+
+    /// A grace note with an accidental keeps the wider advance: its accidental glyph is
+    /// drawn to the left of the notehead and needs the room.
+    @Test func graceNoteWithAccidentalKeepsWiderAdvance() throws {
+        let metadata = try BravuraMetadata.load()
+        let metrics  = GraceMetrics(config: SVGRenderConfig(), metadata: metadata)
+        let plain    = note(duration: Fraction(numerator: 1, denominator: 2))
+        let sharp    = note(duration: Fraction(numerator: 1, denominator: 2), accidental: .sharp)
+
+        let plainOffsets = metrics.noteheadOffsets([plain, plain])
+        let sharpOffsets = metrics.noteheadOffsets([plain, sharp])
+
+        #expect(abs((plainOffsets[1] - plainOffsets[0]) - metrics.advance) < 0.001)
+        #expect(abs((sharpOffsets[1] - sharpOffsets[0])
+                    - metrics.noteheadWidth * GraceMetrics.accidentalAdvance) < 0.001)
+        // A leading accidental does not widen the group's left edge.
+        #expect(plainOffsets[0] == sharpOffsets[0])
+    }
 }

--- a/Tests/CeolKitSVGRendererTests/SVGEmitterTests.swift
+++ b/Tests/CeolKitSVGRendererTests/SVGEmitterTests.swift
@@ -358,6 +358,35 @@ private let quarterUNL = Fraction(numerator: 1, denominator: 4)
         #expect(lineCount == 11)
     }
 
+    /// The emitter must draw grace noteheads at the positions `GraceMetrics` describes —
+    /// the same source the sizer used to reserve the group's width (issue #39).
+    @Test func beamedGraceNoteheadsAreDrawnAtMetricsOffsets() throws {
+        let notes = [graceNote(step: .f, octave: 4),
+                     graceNote(step: .g, octave: 4),
+                     graceNote(step: .a, octave: 4)]
+        let grace   = GraceGroup(kind: .appoggiatura, notes: notes, source: dummyRange)
+        let originX = 60.0
+        let svgs = try emitter.emit(layout(systems: [system(measures: [measureWithGrace(grace, x: originX)])]))
+        let svg  = try #require(svgs.first)
+
+        let metrics  = GraceMetrics(config: config, metadata: metadata)
+        let expected = metrics.noteheadOffsets(notes).map { originX + $0 }
+
+        // Notehead glyphs are emitted in order, one <text> per grace note.
+        let noteheadXs = svg.components(separatedBy: "<text ").dropFirst()
+            .filter { $0.contains(String(SMuFLGlyph.noteheadBlack.character)) }
+            .compactMap { chunk -> Double? in
+                guard let range = chunk.range(of: #"x="([0-9.\-]+)""#, options: .regularExpression)
+                else { return nil }
+                return Double(chunk[range].dropFirst(3).dropLast())
+            }
+
+        #expect(noteheadXs.count == expected.count)
+        for (drawn, want) in zip(noteheadXs, expected) {
+            #expect(abs(drawn - want) < 0.001)
+        }
+    }
+
     @Test func acciaccaturaHasSlashLine() throws {
         let grace = GraceGroup(kind: .acciaccatura, notes: [graceNote(step: .g, octave: 4)],
                                source: dummyRange)


### PR DESCRIPTION
Fixes #39.

## The problem

`MeasureSizer.graceGroupWidth` charged 1.5 × grace notehead width **per note**, applying the
group's outer padding uniformly between every pair of noteheads. But the notes of a beamed
embellishment — a grip, taorluath or birl — sit on a shared beam and want to be nearly
touching. Half a notehead of air between each pair is the bulk of the cost, and in pipe music,
where nearly every principal note carries an embellishment, it consumed ~44% of the usable
line width.

## The change

Separate the step between adjacent noteheads from the padding at the group's outer edges:

```
|<-pad->|<-head->|<-advance->|<-head->|<-pad->|
```

The new `GraceMetrics` owns that geometry for both the sizer (which reserves the space) and
the emitter (which draws into it). Previously each held its own copy of the `0.6` / `1.5` /
`0.25` literals and had to be kept in step by hand.

`advance` is `SVGRenderConfig.graceNoteSpacing`, defaulting to **1.05** notehead widths
(was effectively 1.5). #42 tracks exposing it as a `%%ceolkit:gracenotespacing` directive.

Two things deliberately left alone:

- **Single grace notes** are unchanged. A one-note group is still 1.5 notehead widths wide,
  and the space before the principal note is still governed by the `flag32ndUp` overhang in
  `graceNoteGap`, which was already doing the right thing.
- **Grace notes carrying an accidental** keep the old 1.5 advance
  (`GraceMetrics.accidentalAdvance`). Their accidental glyph is drawn to the left of the
  notehead and already sits tight against the preceding note — see the note below.

## Measurements

Strathspey from #39, staffSize 6.0, landscape US Letter, 720 pt usable, `justifylast false`:

| Case | Before | After |
| --- | --- | --- |
| Repro line, natural width | 711.6 pt | **665.7 pt** |
| Same line with `[\|: … :\|]` | split 3 bars + 1 orphan | **one system, 680.1 pt** |
| 6-line proxy tune | 7 systems | **6 systems, 1 page** |
| `tunebook.abc` (regression check) | 85 systems / 16 pages | 83 systems / 16 pages |

Note the issue's estimate of 80–90 pt was optimistic: the saving is 45.9 pt, because the
1.5 → 1.05 reduction applies once per *gap between* noteheads (24 of them across 17 groups),
not once per grace note (41). It still clears the bar the issue set — the opening line fits
with its repeat barline, and the tune collapses to one page at scale 1.0.

## Tests

585 passing, 5 new:

- the advance rule (each added notehead costs exactly one `advance`)
- single-grace width is unchanged
- `graceNoteSpacing` config actually narrows a beamed group
- an accidental-bearing grace note keeps the wider advance
- the emitter draws noteheads at the offsets the sizer reserved — the invariant `GraceMetrics`
  exists to protect

## Pre-existing bug found, not fixed here

Accidentals inside beamed grace groups collide with the preceding notehead. The emitter places
a grace accidental at a fixed `0.75 × staffSize × 0.6` left of its notehead, which is narrower
than the sharp glyph itself. I verified against the pre-change renderer that this is **not** a
regression, and kept accidental-bearing grace notes at the old advance so this change doesn't
deepen it. Fixing it properly means making the accidental offset glyph-width-driven, which is
its own change set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124Jcjb8FQC6iYTJ3A41UGh
