### PR TITLE
Fix #44 - derive accidental placement from the glyph's own width

### DIFF
--- a/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
@@ -44,11 +44,13 @@ struct SVGEmitter: Sendable {
     let config: SVGRenderConfig
     let metadata: BravuraMetadata
     let stemDirection: StemDirection
+    let accidentalMetrics: AccidentalMetrics
 
     init(config: SVGRenderConfig, metadata: BravuraMetadata, stemDirection: StemDirection = .auto) {
         self.config = config
         self.metadata = metadata
         self.stemDirection = stemDirection
+        self.accidentalMetrics = AccidentalMetrics(config: config, metadata: metadata)
     }
 
     // MARK: - Public entry point
@@ -792,11 +794,16 @@ struct SVGEmitter: Sendable {
                         noteheadY: noteheadY)
     }
 
+    /// Draws an accidental left of the notehead at `x`.
+    ///
+    /// The offset is the glyph's own width plus a clearance gap — a fixed offset would let
+    /// the wider glyphs (a double flat is 1.644 staff spaces) run over the notehead.
     private func emitAccidental(_ alt: Alteration, x: Double, y: Double,
-                                fontSize: Double, builder: inout SVGBuilder) {
-        guard let glyph = accidentalGlyph(for: alt) else { return }
-        let accWidth = config.staffSize * 0.75
-        builder.text(String(glyph.character), x: x - accWidth, y: y,
+                                fontSize: Double, scale: Double = 1.0,
+                                builder: inout SVGBuilder) {
+        guard let glyph = SMuFLGlyph.accidental(for: alt) else { return }
+        let offset = accidentalMetrics.offset(for: alt, scale: scale)
+        builder.text(String(glyph.character), x: x - offset, y: y,
                      fontFamily: "Bravura", fontSize: fontSize)
     }
 
@@ -878,9 +885,9 @@ struct SVGEmitter: Sendable {
             builder.text(String(SMuFLGlyph.noteheadBlack.character), x: pos.x, y: pos.noteheadY,
                          fontFamily: "Bravura", fontSize: fontSize)
 
-            if let acc = note.displayedAccidental, let glyph = accidentalGlyph(for: acc) {
-                builder.text(String(glyph.character), x: pos.x - s * 0.75 * graceScale, y: pos.noteheadY,
-                             fontFamily: "Bravura", fontSize: fontSize)
+            if let acc = note.displayedAccidental {
+                emitAccidental(acc, x: pos.x, y: pos.noteheadY, fontSize: fontSize,
+                               scale: graceScale, builder: &builder)
             }
 
             // Stem runs from the notehead up to beamY; the highest note has exactly stemLength,
@@ -1113,17 +1120,6 @@ struct SVGEmitter: Sendable {
             default:
                 break
             }
-        }
-    }
-
-    private func accidentalGlyph(for alt: Alteration) -> SMuFLGlyph? {
-        switch (alt.numerator, alt.denominator) {
-        case (1, 1):  return .accidentalSharp
-        case (-1, 1): return .accidentalFlat
-        case (0, _):  return .accidentalNatural
-        case (2, 1):  return .accidentalDoubleSharp
-        case (-2, 1): return .accidentalDoubleFlat
-        default:      return nil  // microtonal — no glyph in v0.1 set
         }
     }
 

--- a/Sources/CeolKitSVGRenderer/Layout/AccidentalMetrics.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/AccidentalMetrics.swift
@@ -1,0 +1,64 @@
+import Foundation
+import CeolKitModel
+
+/// Horizontal geometry of an accidental drawn to the left of its notehead.
+///
+/// The sizer reserves the space and the emitter draws into it, so both derive their numbers
+/// from here.  Every measurement comes from the glyph's own bounding box: accidentals differ
+/// in width by more than a factor of two (`accidentalNatural` 0.672 staff spaces against
+/// `accidentalDoubleFlat` 1.644), so a single fixed offset cannot serve them all.
+struct AccidentalMetrics {
+    /// Clearance between the accidental glyph's right edge and the notehead's left edge,
+    /// in staff spaces.
+    static let gap = 0.12
+
+    /// Offset used when a glyph is missing from the font metadata.
+    static let fallbackWidth = 0.75
+
+    private let staffSize: Double
+    private let metadata: BravuraMetadata
+
+    init(config: SVGRenderConfig, metadata: BravuraMetadata) {
+        self.staffSize = config.staffSize
+        self.metadata = metadata
+    }
+
+    /// Rendered width of the accidental glyph for `alteration`, or `nil` when it has no
+    /// glyph in the v0.1 set (microtonal accidentals) and so draws nothing.
+    ///
+    /// - Parameter scale: glyph scale relative to a normal note — `GraceMetrics.scale`
+    ///   for a grace note, `1.0` otherwise.
+    func width(for alteration: Alteration, scale: Double = 1.0) -> Double? {
+        guard let glyph = SMuFLGlyph.accidental(for: alteration) else { return nil }
+        let bboxWidth = metadata.glyphBBoxes[glyph.rawValue]?.width ?? Self.fallbackWidth
+        return bboxWidth * staffSize * scale
+    }
+
+    /// Distance from the notehead's left edge to the accidental glyph's left edge: the glyph's
+    /// own width plus a clearance gap.  This is the space the accidental needs reserved to the
+    /// left of the note, and the offset the emitter draws it at.
+    func offset(for alteration: Alteration, scale: Double = 1.0) -> Double {
+        guard let w = width(for: alteration, scale: scale) else { return 0 }
+        return w + Self.gap * staffSize * scale
+    }
+
+    /// Space to reserve left of a notehead for its accidental, if it has one.
+    func reservation(for accidental: Alteration?, scale: Double = 1.0) -> Double {
+        accidental.map { offset(for: $0, scale: scale) } ?? 0
+    }
+}
+
+extension SMuFLGlyph {
+    /// The accidental glyph for a semantic alteration, or `nil` for microtonal alterations,
+    /// which have no glyph in the v0.1 set.
+    static func accidental(for alteration: Alteration) -> SMuFLGlyph? {
+        switch (alteration.numerator, alteration.denominator) {
+        case (1, 1):  return .accidentalSharp
+        case (-1, 1): return .accidentalFlat
+        case (0, _):  return .accidentalNatural
+        case (2, 1):  return .accidentalDoubleSharp
+        case (-2, 1): return .accidentalDoubleFlat
+        default:      return nil
+        }
+    }
+}

--- a/Sources/CeolKitSVGRenderer/Layout/GraceMetrics.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/GraceMetrics.swift
@@ -18,8 +18,7 @@ import CeolKitModel
 /// tighter than the outer padding implies (see `SVGRenderConfig.graceNoteSpacing`).
 ///
 /// A note carrying a displayed accidental is the exception: its accidental glyph is drawn to
-/// the left of its notehead, so it needs the wider `accidentalAdvance` to keep clear of the
-/// preceding note.
+/// the left of its notehead, so the step into it grows by whatever that glyph needs.
 struct GraceMetrics {
     /// Scale factor for grace note glyphs and geometry relative to normal notes.
     static let scale = 0.6
@@ -27,32 +26,43 @@ struct GraceMetrics {
     /// Padding at each outer edge of a group, in grace notehead widths.
     static let edgePad = 0.25
 
-    /// Step for a note whose notehead is preceded by an accidental glyph, in grace
-    /// notehead widths.  Accidental placement within the group is unchanged from before
-    /// grace groups were tightened, so this keeps the space that placement assumes.
-    static let accidentalAdvance = 1.5
-
     /// Width of a grace notehead.
     let noteheadWidth: Double
 
-    /// Step between the x of one notehead and the next within the same group.
+    /// Step between the x of one notehead and the next within the same group, for notes
+    /// with no accidental.
     let advance: Double
+
+    private let accidentalMetrics: AccidentalMetrics
 
     init(config: SVGRenderConfig, metadata: BravuraMetadata) {
         let fullNoteheadWidth = metadata.glyphBBoxes["noteheadBlack"].map { $0.width * config.staffSize }
                                 ?? config.staffSize * 1.2
         self.noteheadWidth = fullNoteheadWidth * Self.scale
         self.advance = self.noteheadWidth * config.graceNoteSpacing
+        self.accidentalMetrics = AccidentalMetrics(config: config, metadata: metadata)
+    }
+
+    /// Space an accidental on `note` needs to the left of its notehead, at grace scale.
+    private func accidentalSpace(_ note: Note) -> Double {
+        accidentalMetrics.reservation(for: note.displayedAccidental, scale: Self.scale)
     }
 
     /// x of each notehead's left edge, relative to the group's left edge.
     func noteheadOffsets(_ notes: [Note]) -> [Double] {
-        var x = noteheadWidth * Self.edgePad
+        var x = 0.0
         var offsets: [Double] = []
         offsets.reserveCapacity(notes.count)
         for (i, note) in notes.enumerated() {
-            if i > 0 {
-                x += note.displayedAccidental != nil ? noteheadWidth * Self.accidentalAdvance : advance
+            let accSpace = accidentalSpace(note)
+            if i == 0 {
+                // Leading edge: an accidental on the first note needs at least its own
+                // width before the notehead, otherwise the standard outer padding.
+                x = max(noteheadWidth * Self.edgePad, accSpace)
+            } else {
+                // The previous note's stem sits at the right edge of its notehead, so an
+                // accidental on this note has to clear that as well as the usual advance.
+                x += max(advance, noteheadWidth + accSpace)
             }
             offsets.append(x)
         }

--- a/Sources/CeolKitSVGRenderer/Layout/MeasureSizer.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/MeasureSizer.swift
@@ -9,11 +9,13 @@ public struct MeasureSizer: Sendable {
     private let config: SVGRenderConfig
     private let metadata: BravuraMetadata
     private let graceMetrics: GraceMetrics
+    private let accidentalMetrics: AccidentalMetrics
 
     public init(config: SVGRenderConfig, metadata: BravuraMetadata) {
         self.config = config
         self.metadata = metadata
         self.graceMetrics = GraceMetrics(config: config, metadata: metadata)
+        self.accidentalMetrics = AccidentalMetrics(config: config, metadata: metadata)
     }
 
     /// Sizes a single measure.
@@ -75,7 +77,7 @@ public struct MeasureSizer: Sendable {
         case .note(let n):
             let rawCol = base * durationFactor(n.duration, quarterInUnits: quarterInUnits)
             var col = max(minCol, rawCol)
-            let accWidth = n.displayedAccidental != nil ? s * 0.75 : 0
+            let accWidth = accidentalMetrics.reservation(for: n.displayedAccidental)
             // Very short notes (at the minimum floor) get a dot-gap equivalent of extra space
             // so consecutive beamed notes aren't visually pressed against each other.
             let breathingRoom = rawCol < minCol ? noteheadWidth() * 0.2 : 0
@@ -91,8 +93,11 @@ public struct MeasureSizer: Sendable {
 
         case .chord(let c):
             let col = max(minCol, base * durationFactor(c.duration, quarterInUnits: quarterInUnits))
-            let hasAcc = c.notes.contains { $0.displayedAccidental != nil }
-            return col + (hasAcc ? s * 0.75 : 0)
+            // Chord accidentals are not yet stacked, so reserve for the widest of them.
+            let accWidth = c.notes
+                .map { accidentalMetrics.reservation(for: $0.displayedAccidental) }
+                .max() ?? 0
+            return col + accWidth
 
         case .tuplet(let t):
             var totalUnits = 0.0

--- a/Tests/CeolKitSVGRendererTests/MeasureSizerTests.swift
+++ b/Tests/CeolKitSVGRendererTests/MeasureSizerTests.swift
@@ -216,11 +216,13 @@ private func measure(events: [Event]) -> Measure {
         #expect(tightSized.eventOffsets[1] < wideSized.eventOffsets[1])
     }
 
-    /// A grace note with an accidental keeps the wider advance: its accidental glyph is
-    /// drawn to the left of the notehead and needs the room.
-    @Test func graceNoteWithAccidentalKeepsWiderAdvance() throws {
+    /// A grace note with an accidental gets a wider step into it: the accidental glyph is
+    /// drawn to the left of the notehead and must clear the preceding note's stem.
+    @Test func graceNoteWithAccidentalWidensTheStepIntoIt() throws {
         let metadata = try BravuraMetadata.load()
-        let metrics  = GraceMetrics(config: SVGRenderConfig(), metadata: metadata)
+        let config   = SVGRenderConfig()
+        let metrics  = GraceMetrics(config: config, metadata: metadata)
+        let accMetrics = AccidentalMetrics(config: config, metadata: metadata)
         let plain    = note(duration: Fraction(numerator: 1, denominator: 2))
         let sharp    = note(duration: Fraction(numerator: 1, denominator: 2), accidental: .sharp)
 
@@ -228,9 +230,81 @@ private func measure(events: [Event]) -> Measure {
         let sharpOffsets = metrics.noteheadOffsets([plain, sharp])
 
         #expect(abs((plainOffsets[1] - plainOffsets[0]) - metrics.advance) < 0.001)
+
+        // The accidental must clear the previous note's stem, at the right edge of its notehead.
+        let accSpace = accMetrics.offset(for: .sharp, scale: GraceMetrics.scale)
         #expect(abs((sharpOffsets[1] - sharpOffsets[0])
-                    - metrics.noteheadWidth * GraceMetrics.accidentalAdvance) < 0.001)
-        // A leading accidental does not widen the group's left edge.
-        #expect(plainOffsets[0] == sharpOffsets[0])
+                    - (metrics.noteheadWidth + accSpace)) < 0.001)
+        #expect(sharpOffsets[1] - sharpOffsets[0] > metrics.advance)
+    }
+
+    /// An accidental on the *first* note of a group hangs left of the notehead, so the
+    /// group's leading edge has to grow to hold it.
+    @Test func leadingGraceAccidentalWidensTheGroupsLeftEdge() throws {
+        let metadata   = try BravuraMetadata.load()
+        let config     = SVGRenderConfig()
+        let metrics    = GraceMetrics(config: config, metadata: metadata)
+        let accMetrics = AccidentalMetrics(config: config, metadata: metadata)
+        let plain      = note(duration: Fraction(numerator: 1, denominator: 2))
+        let flat       = note(duration: Fraction(numerator: 1, denominator: 2), accidental: .flat)
+
+        let plainOffset = metrics.noteheadOffsets([plain])[0]
+        let flatOffset  = metrics.noteheadOffsets([flat])[0]
+
+        #expect(abs(plainOffset - metrics.noteheadWidth * GraceMetrics.edgePad) < 0.001)
+        #expect(abs(flatOffset - accMetrics.offset(for: .flat, scale: GraceMetrics.scale)) < 0.001)
+        // The accidental starts at the group's left edge, not left of it.
+        #expect(flatOffset > plainOffset)
+    }
+
+    // MARK: - Accidental placement (issue #44)
+
+    /// Accidentals differ in width by more than 2×, so the space reserved for one must come
+    /// from its own glyph rather than a single fixed offset.
+    @Test func accidentalReservationTracksGlyphWidth() throws {
+        let metadata = try BravuraMetadata.load()
+        let metrics  = AccidentalMetrics(config: SVGRenderConfig(), metadata: metadata)
+
+        let natural    = try #require(metrics.width(for: .natural))
+        let sharp      = try #require(metrics.width(for: .sharp))
+        let flat       = try #require(metrics.width(for: .flat))
+        let doubleFlat = try #require(metrics.width(for: .doubleFlat))
+
+        // Ordering follows the Bravura bounding boxes.
+        #expect(natural < flat)
+        #expect(flat < sharp)
+        #expect(sharp < doubleFlat)
+
+        // Every reservation clears its own glyph — that is the bug in #44.
+        for alt in [Alteration.natural, .sharp, .flat, .doubleFlat, .doubleSharp] {
+            let width = try #require(metrics.width(for: alt))
+            #expect(metrics.offset(for: alt) > width)
+        }
+    }
+
+    /// Microtonal alterations have no glyph in the v0.1 set and draw nothing, so they
+    /// must not reserve space either.
+    @Test func microtonalAccidentalReservesNoSpace() throws {
+        let metadata = try BravuraMetadata.load()
+        let metrics  = AccidentalMetrics(config: SVGRenderConfig(), metadata: metadata)
+        let quarterSharp = Alteration(numerator: 1, denominator: 2)
+
+        #expect(metrics.width(for: quarterSharp) == nil)
+        #expect(metrics.offset(for: quarterSharp) == 0)
+        #expect(metrics.reservation(for: quarterSharp) == 0)
+    }
+
+    @Test func doubleFlatReservesMoreColumnThanNatural() throws {
+        let metadata = try BravuraMetadata.load()
+        let sizer    = MeasureSizer(config: SVGRenderConfig(), metadata: metadata)
+        let quarter  = Fraction(numerator: 2, denominator: 1)
+
+        let natural = measure(events: [.note(note(duration: quarter, accidental: .natural))])
+        let dblFlat = measure(events: [.note(note(duration: quarter, accidental: .doubleFlat))])
+
+        let naturalSized = sizer.size(natural, unitNoteLength: unitNoteLength)
+        let dblFlatSized = sizer.size(dblFlat, unitNoteLength: unitNoteLength)
+
+        #expect(dblFlatSized.naturalWidth > naturalSized.naturalWidth)
     }
 }

--- a/Tests/CeolKitSVGRendererTests/SVGEmitterTests.swift
+++ b/Tests/CeolKitSVGRendererTests/SVGEmitterTests.swift
@@ -358,6 +358,39 @@ private let quarterUNL = Fraction(numerator: 1, denominator: 4)
         #expect(lineCount == 11)
     }
 
+    // MARK: Accidental placement (issue #44)
+
+    /// Every accidental must be drawn far enough left that its own glyph clears the notehead.
+    /// A fixed offset does not work: `accidentalDoubleFlat` is 1.644 staff spaces wide against
+    /// `accidentalNatural`'s 0.672.
+    @Test func accidentalGlyphsClearTheirNoteheads() throws {
+        let metrics = AccidentalMetrics(config: config, metadata: metadata)
+
+        for alt in [Alteration.sharp, .flat, .natural, .doubleSharp, .doubleFlat] {
+            let glyph = try #require(SMuFLGlyph.accidental(for: alt))
+            let n     = quarterNote(step: .c, octave: 5, accidental: alt)
+            let noteX = 60.0
+            let event = ResolvedEvent(origin: Point(x: noteX, y: 100), kind: .note(n))
+            let m = ResolvedMeasure(
+                origin: Point(x: noteX, y: 50), width: 150, events: [event],
+                openingBar: nil, closingBar: ResolvedBarLine(x: noteX + 150, kind: .single),
+                unitNoteLength: quarterUNL
+            )
+            let svgs = try emitter.emit(layout(systems: [system(measures: [m])]))
+            let svg  = try #require(svgs.first)
+
+            let chunk = try #require(svg.components(separatedBy: "<text ")
+                .first { $0.contains(String(glyph.character)) })
+            let range = try #require(chunk.range(of: #"x="([0-9.\-]+)""#, options: .regularExpression))
+            let drawnX = try #require(Double(chunk[range].dropFirst(3).dropLast()))
+
+            let glyphWidth = try #require(metrics.width(for: alt))
+            // The glyph's right edge must land left of the notehead's left edge.
+            #expect(drawnX + glyphWidth <= noteX,
+                    "\(glyph.rawValue) overruns its notehead by \(drawnX + glyphWidth - noteX)")
+        }
+    }
+
     /// The emitter must draw grace noteheads at the positions `GraceMetrics` describes —
     /// the same source the sizer used to reserve the group's width (issue #39).
     @Test func beamedGraceNoteheadsAreDrawnAtMetricsOffsets() throws {


### PR DESCRIPTION
Fixes #44.

> **Stacked on #43.** Base is `feature/grace_note_spacing`, not `develop`, because this
> touches the same functions and retires a constant that PR introduced. Merge #43 first and
> this becomes a clean diff against `develop`. Happy to squash the two together instead — say
> the word.

## The problem

Accidentals were drawn at a fixed `0.75 × staffSize` left of their notehead, and
`MeasureSizer` reserved the same fixed amount. Only `accidentalNatural` (0.672 staff spaces)
is narrow enough for that to work:

| Accidental | Width (spaces) | Overlap into the notehead |
| --- | --- | --- |
| natural | 0.672 | none — clears by 0.078 |
| flat | 0.904 | 0.154 × staffSize |
| double sharp | 0.988 | 0.238 × staffSize |
| sharp | 0.996 | 0.246 × staffSize |
| double flat | 1.644 | **0.894 × staffSize** — 76% of the notehead |

Both the principal-note path (`emitAccidental`) and the grace path carried the constant
independently, so both were wrong in the same way.

## The change

`AccidentalMetrics` measures each accidental from its own bounding box. The emitter's two draw
sites and the sizer's two reservations all route through it.

The reservation half matters as much as the draw half: moving the glyph further left without
widening the reserved column would only have relocated the collision onto the *preceding*
note. This is the same sizer/emitter agreement `GraceMetrics` enforces for grace widths in #43.

Other things that fall out:

- The glyph mapping moves off `SVGEmitter` to `SMuFLGlyph.accidental(for:)`, so the metrics
  can share it.
- Microtonal alterations map to no glyph and draw nothing; they now reserve nothing too,
  rather than a phantom `0.75`.
- **`GraceMetrics.accidentalAdvance` is retired.** That 1.5 placeholder existed only so #43
  wouldn't deepen this bug. The step into an accidental-bearing grace note is now the real
  requirement — clear the previous note's stem by the accidental's actual width — and a
  leading accidental widens the group's left edge instead of hanging over whatever precedes it.
- Chords reserve for their *widest* accidental rather than a flat `0.75`.

## Verification

```abc
X:1
T:accidentals
M:C
L:1/4
K:C
^A __B =c _d | {^A}c {__B}c {=c}c {_d}c |
```

Rendered at `--scale 3`, every accidental now clears its notehead, on principal notes and
grace notes alike.

No layout change to tunes without accidentals — the #39 strathspey is unmoved at 665.7 pt, and
`tunebook.abc` holds at 83 systems across 16 pages, so the wider accidental columns don't push
anything over a line.

## Tests

590 passing, 5 new: glyph-width ordering, every reservation clearing its own glyph, microtonal
alterations reserving nothing, a double flat reserving more column than a natural, and an
emitter test asserting the *drawn* glyph's right edge lands left of the notehead — checked for
all five accidentals, which is the assertion that would have caught this originally.

## Still open

Chord accidentals are not stacked to avoid colliding with each other; only the reserved width
is corrected here. Noted in #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124Jcjb8FQC6iYTJ3A41UGh
