### PR TITLE
Fix #36 - emit text as outlines, and make it the default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,15 +62,16 @@ swift run ckprobe tune.abc --scale 0.85             # override %%ceolkit:scale
 swift run ckprobe tune.abc --sweep 1.5,1.0,0.85     # systems/pages per scale factor
 swift run ckprobe tune.abc --natural                # unstretched system widths
 swift run ckprobe tune.abc --out /tmp/out --json
-swift run ckprobe tune.abc --out /tmp/out --outlines        # text as geometry
+swift run ckprobe tune.abc --out /tmp/out --font-face       # <text> + @font-face
 rsvg-convert -w 1500 /tmp/out/page0.svg -o /tmp/page0.png   # to look at a page
 ```
 
-Use `--outlines` whenever you intend to rasterise. `rsvg-convert` — like every other
-non-browser rasteriser — ignores `@font-face` and resolves `font-family` through
-fontconfig, so the default output only looks right on a machine that happens to have
-Bravura and Libertinus Serif installed, and silently substitutes or drops glyphs where it
-does not. See ``TextRendering``.
+`ckprobe` renders in whatever mode the library defaults to, which is
+`TextRendering.outlines` — glyph geometry in the document, no font environment needed. That
+is what makes `rsvg-convert` usable here: like every other non-browser rasteriser it ignores
+`@font-face` and resolves `font-family` through fontconfig, so `--font-face` output only
+looks right on a machine that happens to have Bravura and Libertinus Serif installed, and
+silently substitutes or drops glyphs where it does not.
 
 `CeolKitSVGGeometry` deliberately imports no other CeolKit module: it reads what the
 renderer *drew*, so it can be used to check that against what the layout engine believed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,8 +62,15 @@ swift run ckprobe tune.abc --scale 0.85             # override %%ceolkit:scale
 swift run ckprobe tune.abc --sweep 1.5,1.0,0.85     # systems/pages per scale factor
 swift run ckprobe tune.abc --natural                # unstretched system widths
 swift run ckprobe tune.abc --out /tmp/out --json
+swift run ckprobe tune.abc --out /tmp/out --outlines        # text as geometry
 rsvg-convert -w 1500 /tmp/out/page0.svg -o /tmp/page0.png   # to look at a page
 ```
+
+Use `--outlines` whenever you intend to rasterise. `rsvg-convert` — like every other
+non-browser rasteriser — ignores `@font-face` and resolves `font-family` through
+fontconfig, so the default output only looks right on a machine that happens to have
+Bravura and Libertinus Serif installed, and silently substitutes or drops glyphs where it
+does not. See ``TextRendering``.
 
 `CeolKitSVGGeometry` deliberately imports no other CeolKit module: it reads what the
 renderer *drew*, so it can be used to check that against what the layout engine believed.

--- a/Sources/CeolKitSVGRenderer/Config/SVGRenderConfig.swift
+++ b/Sources/CeolKitSVGRenderer/Config/SVGRenderConfig.swift
@@ -18,6 +18,8 @@ public struct SVGRenderConfig: Sendable {
     /// engraved nearly adjacent, so this stays close to `1.0`.  It does not affect the padding
     /// at the outer edges of the group, nor the gap before the principal note.
     public var graceNoteSpacing: Double
+    /// How glyphs reach the page: as `<text>` resolved through a font, or as geometry.
+    public var textRendering: TextRendering
 
     public init(
         pageSize: PageSize = .letter,
@@ -28,7 +30,8 @@ public struct SVGRenderConfig: Sendable {
         justifyLastSystem: Bool = false,
         straightFlags: Bool = false,
         graceSlurs: Bool = true,
-        graceNoteSpacing: Double = 1.05
+        graceNoteSpacing: Double = 1.05,
+        textRendering: TextRendering = .fontFace
     ) {
         self.pageSize = pageSize
         self.margins = margins
@@ -39,6 +42,7 @@ public struct SVGRenderConfig: Sendable {
         self.straightFlags = straightFlags
         self.graceSlurs = graceSlurs
         self.graceNoteSpacing = graceNoteSpacing
+        self.textRendering = textRendering
     }
 
     /// Returns a copy with `staffSize` and the vertical gaps derived from it multiplied
@@ -52,6 +56,36 @@ public struct SVGRenderConfig: Sendable {
         copy.tuneGap = tuneGap * factor
         return copy
     }
+}
+
+/// How the emitter puts glyphs on the page.
+///
+/// The embedded-font default is self-contained *for browsers only*: no non-browser SVG
+/// rasteriser honours `@font-face`. resvg, librsvg, CairoSVG, Skia, QtSvg, Inkscape and
+/// CoreGraphics all resolve `font-family` through a host font database that the document
+/// cannot populate, so a score rendered by any of them shows staff lines and stems but no
+/// noteheads, clefs, or rests unless the host installed the faces out-of-band — a silent,
+/// plausible-looking failure rather than an error.
+///
+/// Emitting outlines moves that geometry into the document, which is the only way the same
+/// score rasterises identically on macOS and in a Linux container.
+public enum TextRendering: String, Sendable, CaseIterable {
+    /// `<text>` elements plus the bundled faces as base64 `@font-face` sources.
+    /// Text stays selectable and searchable; correct rendering needs a browser, or a host
+    /// that has installed the faces itself (see ``CeolKitFonts``).
+    case fontFace
+    /// `<path>` outlines only, and no `@font-face` block. Renders identically everywhere
+    /// and drops the embedded faces, but the text is no longer selectable or searchable.
+    case outlines
+    /// Outlines for the geometry, plus non-painting `<text>` elements carrying the same
+    /// strings so the document stays selectable, searchable, and accessible.
+    case both
+
+    /// Whether the document embeds the bundled faces as `@font-face` sources.
+    public var embedsFontFaces: Bool { self != .outlines }
+
+    /// Whether glyph geometry is written into the document as outlines.
+    public var emitsOutlines: Bool { self != .fontFace }
 }
 
 public struct PageSize: Sendable {

--- a/Sources/CeolKitSVGRenderer/Config/SVGRenderConfig.swift
+++ b/Sources/CeolKitSVGRenderer/Config/SVGRenderConfig.swift
@@ -31,7 +31,7 @@ public struct SVGRenderConfig: Sendable {
         straightFlags: Bool = false,
         graceSlurs: Bool = true,
         graceNoteSpacing: Double = 1.05,
-        textRendering: TextRendering = .fontFace
+        textRendering: TextRendering = .outlines
     ) {
         self.pageSize = pageSize
         self.margins = margins
@@ -60,12 +60,14 @@ public struct SVGRenderConfig: Sendable {
 
 /// How the emitter puts glyphs on the page.
 ///
-/// The embedded-font default is self-contained *for browsers only*: no non-browser SVG
-/// rasteriser honours `@font-face`. resvg, librsvg, CairoSVG, Skia, QtSvg, Inkscape and
-/// CoreGraphics all resolve `font-family` through a host font database that the document
-/// cannot populate, so a score rendered by any of them shows staff lines and stems but no
-/// noteheads, clefs, or rests unless the host installed the faces out-of-band — a silent,
-/// plausible-looking failure rather than an error.
+/// Defaults to ``outlines``, because embedding the faces is self-contained *for browsers
+/// only*: no non-browser SVG rasteriser honours `@font-face`. resvg, librsvg, CairoSVG,
+/// Skia, QtSvg, Inkscape and CoreGraphics all resolve `font-family` through a host font
+/// database that the document cannot populate, so a score rendered by any of them shows
+/// staff lines and stems but no noteheads, clefs, or rests unless the host installed the
+/// faces out-of-band — a silent, plausible-looking failure rather than an error. Even
+/// where the host did install them, the installed faces and the embedded ones can drift,
+/// so the same document rasterises differently on two machines.
 ///
 /// Emitting outlines moves that geometry into the document, which is the only way the same
 /// score rasterises identically on macOS and in a Linux container.
@@ -74,11 +76,14 @@ public enum TextRendering: String, Sendable, CaseIterable {
     /// Text stays selectable and searchable; correct rendering needs a browser, or a host
     /// that has installed the faces itself (see ``CeolKitFonts``).
     case fontFace
-    /// `<path>` outlines only, and no `@font-face` block. Renders identically everywhere
-    /// and drops the embedded faces, but the text is no longer selectable or searchable.
+    /// `<path>` outlines only, and no `@font-face` block. The default: renders identically
+    /// everywhere and drops the embedded faces, at the cost of text that is no longer
+    /// selectable or searchable — use ``both`` where that matters.
     case outlines
     /// Outlines for the geometry, plus non-painting `<text>` elements carrying the same
-    /// strings so the document stays selectable, searchable, and accessible.
+    /// strings so the document stays selectable, searchable, and accessible. Renders like
+    /// ``outlines`` everywhere, but keeps the embedded faces and so the document size that
+    /// goes with them.
     case both
 
     /// Whether the document embeds the bundled faces as `@font-face` sources.

--- a/Sources/CeolKitSVGRenderer/Emission/SVGBuilder.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGBuilder.swift
@@ -1,10 +1,41 @@
+/// The bundled faces as base64 `@font-face` sources.
+///
+/// Loaded only when the document actually embeds them: at roughly 1.5 MB of base64 for the
+/// three faces, reading and encoding them for an outline-only document would be the most
+/// expensive thing the emitter did, and all of it wasted.
+struct EmbeddedFaces: Sendable {
+    let bravura: String
+    let libertinusSerif: String
+    let libertinusSerifItalic: String
+}
+
 /// Lightweight SVG element builder used exclusively by `SVGEmitter`.
 ///
 /// Accumulates element strings and wraps them in a complete SVG document via
-/// `buildDocument(width:height:bravuraBase64:)`. Only the element types the
+/// `buildDocument(width:height:embeddedFaces:)`. Only the element types the
 /// emitter needs are supported — this is not a general XML library.
+///
+/// When configured for outline rendering it also accumulates a glyph dictionary: each
+/// distinct glyph is written once into `<defs>` and every occurrence becomes a `<use>`,
+/// so a notehead drawn two hundred times on a page costs one outline.
 struct SVGBuilder: Sendable {
     private(set) var elements: [String] = []
+
+    let textRendering: TextRendering
+    /// The parsed faces outlines are read from. `nil` leaves every run on `<text>`.
+    let fonts: OutlineFontSet?
+
+    /// Glyph outline path data by `<defs>` id; an empty string records a glyph that is
+    /// known to have no outline (a space, say) so it is not decoded again.
+    private var glyphPaths: [String: String] = [:]
+    /// Ids of the non-empty glyphs, in the order they were first drawn, so that the
+    /// emitted `<defs>` block is stable rather than dictionary-ordered.
+    private var glyphOrder: [String] = []
+
+    init(textRendering: TextRendering = .fontFace, fonts: OutlineFontSet? = nil) {
+        self.textRendering = textRendering
+        self.fonts = fonts
+    }
 
     mutating func line(
         x1: Double, y1: Double, x2: Double, y2: Double,
@@ -26,13 +57,25 @@ struct SVGBuilder: Sendable {
         fontStyle: String? = nil,
         className: String? = nil
     ) {
-        var attrs = "x=\"\(fmt(x))\" y=\"\(fmt(y))\""
-        attrs += " font-family=\"\(esc(fontFamily))\" font-size=\"\(fmt(fontSize))\""
-        attrs += " fill=\"\(esc(fill))\""
-        if textAnchor != "start"  { attrs += " text-anchor=\"\(esc(textAnchor))\"" }
-        if let style = fontStyle  { attrs += " font-style=\"\(esc(style))\"" }
-        if let cls   = className  { attrs += " class=\"\(esc(cls))\"" }
-        elements.append("<text \(attrs)>\(esc(content))</text>")
+        if textRendering.emitsOutlines,
+           let resolved = fonts?.resolve(family: fontFamily, italic: fontStyle == "italic") {
+            appendOutlineRun(content, x: x, y: y,
+                             face: resolved.key, font: resolved.font,
+                             fontSize: fontSize, fill: fill,
+                             textAnchor: textAnchor, className: className)
+            guard textRendering == .both else { return }
+            // A non-painting copy of the run, so the document stays selectable, searchable,
+            // and legible to a screen reader even though the geometry comes from the paths.
+            appendTextElement(content, x: x, y: y, fontFamily: fontFamily, fontSize: fontSize,
+                              fill: "none", textAnchor: textAnchor, fontStyle: fontStyle,
+                              className: className)
+            return
+        }
+        // Reached in `.fontFace`, and for any family this renderer does not bundle. Losing
+        // the content outright would be worse than emitting a run the host may not resolve.
+        appendTextElement(content, x: x, y: y, fontFamily: fontFamily, fontSize: fontSize,
+                          fill: fill, textAnchor: textAnchor, fontStyle: fontStyle,
+                          className: className)
     }
 
     mutating func path(
@@ -66,42 +109,133 @@ struct SVGBuilder: Sendable {
     }
 
     func buildDocument(width: Double, height: Double,
-                       bravuraBase64: String,
-                       libertinusSerifBase64: String,
-                       libertinusSerifItalicBase64: String) -> String {
-        let defs = """
-          <defs>
-            <style>
-              @font-face {
-                font-family: "Bravura";
-                src: url('data:font/otf;base64,\(bravuraBase64)') format('opentype');
-              }
-              @font-face {
-                font-family: "Libertinus Serif";
-                src: url('data:font/otf;base64,\(libertinusSerifBase64)') format('opentype');
-              }
-              @font-face {
-                font-family: "Libertinus Serif";
-                font-style: italic;
-                src: url('data:font/otf;base64,\(libertinusSerifItalicBase64)') format('opentype');
-              }
-            </style>
-          </defs>
-        """
-        let body = elements.map { "  " + $0 }.joined(separator: "\n")
-        let vb = "0 0 \(fmt(width)) \(fmt(height))"
-        return """
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="\(vb)" width="\(fmt(width))" height="\(fmt(height))">
-          \(defs)
-          \(body)
-          </svg>
-          """
+                       embeddedFaces: EmbeddedFaces?) -> String {
+        var defs: [String] = []
+        if let faces = embeddedFaces {
+            defs.append("    <style>")
+            defs += fontFaceRule(family: "Bravura", italic: false, base64: faces.bravura)
+            defs += fontFaceRule(family: "Libertinus Serif", italic: false,
+                                 base64: faces.libertinusSerif)
+            defs += fontFaceRule(family: "Libertinus Serif", italic: true,
+                                 base64: faces.libertinusSerifItalic)
+            defs.append("    </style>")
+        }
+        for id in glyphOrder {
+            defs.append("    <path id=\"\(id)\" d=\"\(glyphPaths[id] ?? "")\"/>")
+        }
+
+        // The xlink namespace is declared only when glyphs are drawn, because only `<use>`
+        // needs it: the elements carry both the SVG 2 `href` and the SVG 1.1 `xlink:href`,
+        // rasterisers being split on which they honour, and an undeclared prefix would make
+        // the document ill-formed XML.
+        let xlink = glyphOrder.isEmpty ? "" : " xmlns:xlink=\"http://www.w3.org/1999/xlink\""
+        var lines = ["<svg xmlns=\"http://www.w3.org/2000/svg\"\(xlink)" +
+                     " viewBox=\"0 0 \(fmt(width)) \(fmt(height))\"" +
+                     " width=\"\(fmt(width))\" height=\"\(fmt(height))\">"]
+        if !defs.isEmpty {
+            lines.append("  <defs>")
+            lines += defs
+            lines.append("  </defs>")
+        }
+        lines += elements.map { "  " + $0 }
+        lines.append("</svg>")
+        return lines.joined(separator: "\n")
+    }
+
+    private func fontFaceRule(family: String, italic: Bool, base64: String) -> [String] {
+        var rule = ["      @font-face {", "        font-family: \"\(family)\";"]
+        if italic { rule.append("        font-style: italic;") }
+        rule.append("        src: url('data:font/otf;base64,\(base64)') format('opentype');")
+        rule.append("      }")
+        return rule
+    }
+
+    // MARK: - Text
+
+    private mutating func appendTextElement(
+        _ content: String, x: Double, y: Double,
+        fontFamily: String, fontSize: Double, fill: String,
+        textAnchor: String, fontStyle: String?, className: String?
+    ) {
+        var attrs = "x=\"\(fmt(x))\" y=\"\(fmt(y))\""
+        attrs += " font-family=\"\(esc(fontFamily))\" font-size=\"\(fmt(fontSize))\""
+        attrs += " fill=\"\(esc(fill))\""
+        if textAnchor != "start"  { attrs += " text-anchor=\"\(esc(textAnchor))\"" }
+        if let style = fontStyle  { attrs += " font-style=\"\(esc(style))\"" }
+        if let cls   = className  { attrs += " class=\"\(esc(cls))\"" }
+        elements.append("<text \(attrs)>\(esc(content))</text>")
+    }
+
+    /// Lays out `content` one glyph per Unicode scalar and emits a `<use>` per glyph.
+    ///
+    /// There is no shaping, kerning, or ligature substitution here. That is not a shortcut
+    /// taken against the `<text>` path this replaces — a rasteriser handed the same string
+    /// and these faces applies no `GPOS`/`GSUB` either unless it runs a full shaper, so
+    /// nominal advances are what the font-face route was already producing.
+    private mutating func appendOutlineRun(
+        _ content: String, x: Double, y: Double,
+        face: OutlineFontSet.FaceKey, font: OpenTypeFont,
+        fontSize: Double, fill: String, textAnchor: String, className: String?
+    ) {
+        let scale = fontSize / font.unitsPerEm
+        // An unencoded scalar falls back to glyph 0, whose .notdef box is what a rasteriser
+        // would have drawn: a visible gap beats a run that silently shortens.
+        let glyphs = content.unicodeScalars.map { font.glyphID(for: $0) ?? 0 }
+        guard !glyphs.isEmpty else { return }
+
+        var penX = x
+        switch textAnchor {
+        case "middle":
+            penX -= glyphs.reduce(0) { $0 + font.advance(forGlyph: $1) } * scale / 2
+        case "end":
+            penX -= glyphs.reduce(0) { $0 + font.advance(forGlyph: $1) } * scale
+        default:
+            break
+        }
+
+        for glyph in glyphs {
+            if let id = registerGlyph(face: face, glyph: glyph, font: font) {
+                var attrs = "href=\"#\(id)\" xlink:href=\"#\(id)\""
+                attrs += " transform=\"translate(\(fmt(penX)) \(fmt(y)))"
+                attrs += " scale(\(fmtScale(scale)) \(fmtScale(-scale)))\""
+                if fill != "black" { attrs += " fill=\"\(esc(fill))\"" }
+                if let cls = className { attrs += " class=\"\(esc(cls))\"" }
+                elements.append("<use \(attrs)/>")
+            }
+            penX += font.advance(forGlyph: glyph) * scale
+        }
+    }
+
+    /// Ensures `glyph` has a `<defs>` entry and returns its id, or `nil` when the glyph has
+    /// no outline to draw — a space, or one whose charstring the interpreter could not read.
+    private mutating func registerGlyph(face: OutlineFontSet.FaceKey, glyph: Int,
+                                        font: OpenTypeFont) -> String? {
+        let id = "\(face.rawValue)-g\(glyph)"
+        if let existing = glyphPaths[id] {
+            return existing.isEmpty ? nil : id
+        }
+        let pathData = ((try? font.outline(forGlyph: glyph)) ?? GlyphPath()).pathData
+        glyphPaths[id] = pathData
+        guard !pathData.isEmpty else { return nil }
+        glyphOrder.append(id)
+        return id
     }
 
     // MARK: - Helpers
 
     func fmt(_ v: Double) -> String {
-        var s = String(format: "%.3f", v)
+        trimmed(String(format: "%.3f", v))
+    }
+
+    /// Glyph scale factors are ratios like `24/1000`, so page-coordinate precision would
+    /// quantise them to whole percents — a 2% size error on every glyph. Six decimals keeps
+    /// the error below a millionth of an em.
+    func fmtScale(_ v: Double) -> String {
+        trimmed(String(format: "%.6f", v))
+    }
+
+    private func trimmed(_ formatted: String) -> String {
+        var s = formatted
         if s.contains(".") {
             while s.hasSuffix("0") { s.removeLast() }
             if s.hasSuffix(".") { s.removeLast() }

--- a/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
@@ -38,8 +38,10 @@ private struct SlurAnchor {
 
 /// Pass 5: converts a `ResolvedLayout` into one self-contained SVG document per page.
 ///
-/// Each SVG embeds Bravura as a base64 `@font-face` source so the output is
-/// fully self-contained regardless of the viewer's font environment.
+/// How self-contained depends on `config.textRendering`: the default embeds each face as a
+/// base64 `@font-face` source, which browsers honour and no other rasteriser does, while
+/// `.outlines` writes the glyph geometry into the document and needs no font environment
+/// at all. See ``TextRendering``.
 struct SVGEmitter: Sendable {
     let config: SVGRenderConfig
     let metadata: BravuraMetadata
@@ -56,9 +58,16 @@ struct SVGEmitter: Sendable {
     // MARK: - Public entry point
 
     func emit(_ layout: ResolvedLayout) throws -> [String] {
-        let bravuraBase64             = try CeolKitFonts.base64(for: .bravura)
-        let libertinusSerifBase64     = try LibertinusSerifMetrics.loadBase64()
-        let libertinusSerifItalicBase64 = try LibertinusSerifMetrics.loadItalicBase64()
+        // Each is skipped when the mode does not need it: reading and base64-encoding three
+        // OTFs is the emitter's most expensive step, and parsing them for outlines is not
+        // free either.
+        let embeddedFaces = config.textRendering.embedsFontFaces
+            ? EmbeddedFaces(
+                bravura: try CeolKitFonts.base64(for: .bravura),
+                libertinusSerif: try LibertinusSerifMetrics.loadBase64(),
+                libertinusSerifItalic: try LibertinusSerifMetrics.loadItalicBase64())
+            : nil
+        let fonts = config.textRendering.emitsOutlines ? try OutlineFontSet.shared() : nil
         // Threaded across every page/system so ties and slurs that span a system or page
         // break (#27) are resolved with dangling arcs instead of being silently dropped.
         var pendingTies:  [TieAnchor]  = []
@@ -67,9 +76,7 @@ struct SVGEmitter: Sendable {
         documents.reserveCapacity(layout.pages.count)
         for (pageIndex, page) in layout.pages.enumerated() {
             let document = emitPage(page, pageNumber: pageIndex + 1, layout: layout,
-                                     bravuraBase64: bravuraBase64,
-                                     libertinusSerifBase64: libertinusSerifBase64,
-                                     libertinusSerifItalicBase64: libertinusSerifItalicBase64,
+                                     embeddedFaces: embeddedFaces, fonts: fonts,
                                      pendingTies: &pendingTies, pendingSlurs: &pendingSlurs)
             documents.append(document)
         }
@@ -79,11 +86,9 @@ struct SVGEmitter: Sendable {
     // MARK: - Page
 
     private func emitPage(_ page: ResolvedPage, pageNumber: Int, layout: ResolvedLayout,
-                           bravuraBase64: String,
-                           libertinusSerifBase64: String,
-                           libertinusSerifItalicBase64: String,
+                           embeddedFaces: EmbeddedFaces?, fonts: OutlineFontSet?,
                            pendingTies: inout [TieAnchor], pendingSlurs: inout [SlurAnchor]) -> String {
-        var builder = SVGBuilder()
+        var builder = SVGBuilder(textRendering: config.textRendering, fonts: fonts)
         emitScrollSyncMetadata(for: page, pageNumber: pageNumber, builder: &builder)
         emitTitleBlock(page.titleRows, builder: &builder)
         for system in page.systems {
@@ -97,9 +102,7 @@ struct SVGEmitter: Sendable {
         return builder.buildDocument(
             width: layout.pageSize.width,
             height: layout.pageSize.height,
-            bravuraBase64: bravuraBase64,
-            libertinusSerifBase64: libertinusSerifBase64,
-            libertinusSerifItalicBase64: libertinusSerifItalicBase64
+            embeddedFaces: embeddedFaces
         )
     }
 

--- a/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
@@ -38,10 +38,10 @@ private struct SlurAnchor {
 
 /// Pass 5: converts a `ResolvedLayout` into one self-contained SVG document per page.
 ///
-/// How self-contained depends on `config.textRendering`: the default embeds each face as a
-/// base64 `@font-face` source, which browsers honour and no other rasteriser does, while
-/// `.outlines` writes the glyph geometry into the document and needs no font environment
-/// at all. See ``TextRendering``.
+/// How self-contained depends on `config.textRendering`: the default writes the glyph
+/// geometry into the document, which needs no font environment at all, while `.fontFace`
+/// embeds each face as a base64 `@font-face` source, which browsers honour and no other
+/// rasteriser does. See ``TextRendering``.
 struct SVGEmitter: Sendable {
     let config: SVGRenderConfig
     let metadata: BravuraMetadata

--- a/Sources/CeolKitSVGRenderer/Font/CFFTable.swift
+++ b/Sources/CeolKitSVGRenderer/Font/CFFTable.swift
@@ -1,0 +1,231 @@
+/// The `CFF ` table: charstrings and the subroutine sets they call into.
+///
+/// Only what outline extraction needs is read. The charset, encoding, and String INDEX are
+/// skipped — glyphs are reached through the face's `cmap`, never by PostScript name, so the
+/// ~400 standard strings those tables index into would be dead weight.
+struct CFFTable: Sendable {
+
+    let bytes: FontBytes
+    /// Byte ranges of each glyph's charstring, indexed by glyph ID.
+    let charStrings: [Range<Int>]
+    let globalSubrs: [Range<Int>]
+
+    /// Local subroutines for a non-CID face; empty when the face is CID-keyed.
+    private let singleLocalSubrs: [Range<Int>]
+    /// Local subroutines per Font DICT, for CID-keyed faces.
+    private let fdLocalSubrs: [[Range<Int>]]
+    /// Font DICT index per glyph, for CID-keyed faces.
+    private let fdSelect: [Int]
+
+    var glyphCount: Int { charStrings.count }
+
+    /// The local subroutine set a glyph's charstring may call.
+    ///
+    /// A CID-keyed face partitions its glyphs across Font DICTs, each with its own Private
+    /// DICT and therefore its own subroutines, so this cannot be a single font-wide array.
+    /// Neither bundled face is CID-keyed today, but a face that became one would otherwise
+    /// produce silently mangled outlines rather than an error.
+    func localSubrs(forGlyph glyph: Int) -> [Range<Int>] {
+        guard !fdLocalSubrs.isEmpty else { return singleLocalSubrs }
+        guard fdSelect.indices.contains(glyph) else { return [] }
+        let fd = fdSelect[glyph]
+        return fdLocalSubrs.indices.contains(fd) ? fdLocalSubrs[fd] : []
+    }
+
+    // MARK: - Parsing
+
+    init(bytes: FontBytes, offset: Int) throws {
+        self.bytes = bytes
+
+        let headerSize = try bytes.u8(offset + 2, "CFF")
+        // Name INDEX, then Top DICT INDEX, then String INDEX, then Global Subr INDEX —
+        // each immediately after the last, so they can only be reached in sequence.
+        let nameIndex   = try Self.readIndex(bytes, at: offset + headerSize)
+        let topDictIndex = try Self.readIndex(bytes, at: nameIndex.end)
+        let stringIndex = try Self.readIndex(bytes, at: topDictIndex.end)
+        globalSubrs = try Self.readIndex(bytes, at: stringIndex.end).items
+
+        guard let topDictRange = topDictIndex.items.first else {
+            throw OpenTypeError.malformedCFF("Top DICT INDEX is empty")
+        }
+        let topDict = try Self.readDict(bytes, in: topDictRange)
+
+        if let type = topDict[1200 + 6]?.first, type != 2 {
+            throw OpenTypeError.malformedCFF("CharstringType \(Int(type)) is not supported")
+        }
+
+        guard let charStringsOffset = topDict[17]?.first.map({ offset + Int($0) }) else {
+            throw OpenTypeError.malformedCFF("Top DICT has no CharStrings offset")
+        }
+        charStrings = try Self.readIndex(bytes, at: charStringsOffset).items
+
+        if topDict[1200 + 30] != nil {
+            // CID-keyed: subroutines live in the Private DICT of each Font DICT.
+            singleLocalSubrs = []
+            guard let fdArrayOffset = topDict[1200 + 36]?.first.map({ offset + Int($0) }),
+                  let fdSelectOffset = topDict[1200 + 37]?.first.map({ offset + Int($0) }) else {
+                throw OpenTypeError.malformedCFF("CID font is missing FDArray or FDSelect")
+            }
+            fdLocalSubrs = try Self.readIndex(bytes, at: fdArrayOffset).items.map { fontDictRange in
+                let fontDict = try Self.readDict(bytes, in: fontDictRange)
+                return try Self.readLocalSubrs(bytes, privateEntry: fontDict[18], cffOffset: offset)
+            }
+            fdSelect = try Self.readFDSelect(bytes, at: fdSelectOffset, glyphCount: charStrings.count)
+        } else {
+            singleLocalSubrs = try Self.readLocalSubrs(bytes, privateEntry: topDict[18], cffOffset: offset)
+            fdLocalSubrs = []
+            fdSelect = []
+        }
+    }
+
+    /// The Subrs INDEX named by a `Private` DICT entry, whose operands are `[size, offset]`.
+    ///
+    /// The Subrs offset inside a Private DICT is relative to that DICT's own start, not to
+    /// the table — the one place in CFF where an offset is not table-relative.
+    private static func readLocalSubrs(_ bytes: FontBytes, privateEntry: [Double]?,
+                                       cffOffset: Int) throws -> [Range<Int>] {
+        guard let entry = privateEntry, entry.count >= 2 else { return [] }
+        let privateOffset = cffOffset + Int(entry[1])
+        let privateSize = Int(entry[0])
+        guard privateSize >= 0, privateOffset >= 0,
+              privateOffset + privateSize <= bytes.count else {
+            throw OpenTypeError.malformedCFF("Private DICT lies outside the table")
+        }
+        let privateDict = try readDict(bytes, in: privateOffset..<(privateOffset + privateSize))
+        guard let subrsOffset = privateDict[19]?.first else { return [] }
+        return try readIndex(bytes, at: privateOffset + Int(subrsOffset)).items
+    }
+
+    private static func readFDSelect(_ bytes: FontBytes, at offset: Int,
+                                     glyphCount: Int) throws -> [Int] {
+        switch try bytes.u8(offset, "FDSelect") {
+        case 0:
+            return try (0..<glyphCount).map { try bytes.u8(offset + 1 + $0, "FDSelect") }
+        case 3:
+            let rangeCount = try bytes.u16(offset + 1, "FDSelect")
+            var select = [Int](repeating: 0, count: glyphCount)
+            let sentinel = try bytes.u16(offset + 3 + 3 * rangeCount, "FDSelect")
+            for i in 0..<rangeCount {
+                let record = offset + 3 + 3 * i
+                let first = try bytes.u16(record, "FDSelect")
+                let fd = try bytes.u8(record + 2, "FDSelect")
+                let next = i + 1 < rangeCount
+                    ? try bytes.u16(record + 3, "FDSelect")
+                    : sentinel
+                for glyph in first..<min(next, glyphCount) where glyph >= 0 {
+                    select[glyph] = fd
+                }
+            }
+            return select
+        default:
+            throw OpenTypeError.malformedCFF("unsupported FDSelect format")
+        }
+    }
+
+    // MARK: INDEX
+
+    /// A CFF INDEX: a count, an offset array, then the concatenated items.
+    ///
+    /// Offsets are one-based and measured from the byte *before* the data, which is why
+    /// `dataBase` subtracts one rather than pointing at the first item.
+    static func readIndex(_ bytes: FontBytes, at offset: Int) throws -> (items: [Range<Int>], end: Int) {
+        let count = try bytes.u16(offset, "CFF INDEX")
+        guard count > 0 else { return ([], offset + 2) }
+
+        let offSize = try bytes.u8(offset + 2, "CFF INDEX")
+        guard (1...4).contains(offSize) else {
+            throw OpenTypeError.malformedCFF("INDEX offSize \(offSize) out of range")
+        }
+        let offsetArray = offset + 3
+        let dataBase = offsetArray + (count + 1) * offSize - 1
+
+        func itemOffset(_ i: Int) throws -> Int {
+            let at = offsetArray + i * offSize
+            switch offSize {
+            case 1:  return try bytes.u8(at, "CFF INDEX")
+            case 2:  return try bytes.u16(at, "CFF INDEX")
+            case 3:  return try bytes.u24(at, "CFF INDEX")
+            default: return try bytes.u32(at, "CFF INDEX")
+            }
+        }
+
+        var items: [Range<Int>] = []
+        items.reserveCapacity(count)
+        var previous = try itemOffset(0)
+        for i in 1...count {
+            let next = try itemOffset(i)
+            guard next >= previous, dataBase + next <= bytes.count else {
+                throw OpenTypeError.malformedCFF("INDEX item \(i - 1) lies outside the table")
+            }
+            items.append((dataBase + previous)..<(dataBase + next))
+            previous = next
+        }
+        return (items, dataBase + previous)
+    }
+
+    // MARK: DICT
+
+    /// A CFF DICT as operator-to-operand-list. Two-byte (escaped) operators are keyed as
+    /// `1200 + op`, keeping the whole thing in one flat dictionary.
+    static func readDict(_ bytes: FontBytes, in range: Range<Int>) throws -> [Int: [Double]] {
+        var dict: [Int: [Double]] = [:]
+        var operands: [Double] = []
+        var i = range.lowerBound
+        while i < range.upperBound {
+            let b0 = try bytes.u8(i, "CFF DICT")
+            switch b0 {
+            case 12:
+                dict[1200 + (try bytes.u8(i + 1, "CFF DICT"))] = operands
+                operands = []
+                i += 2
+            case 0...21:
+                dict[b0] = operands
+                operands = []
+                i += 1
+            case 28:
+                operands.append(Double(try bytes.i16(i + 1, "CFF DICT")))
+                i += 3
+            case 29:
+                operands.append(Double(Int32(truncatingIfNeeded: try bytes.u32(i + 1, "CFF DICT"))))
+                i += 5
+            case 30:
+                let (value, length) = try readRealNumber(bytes, at: i + 1)
+                operands.append(value)
+                i += 1 + length
+            case 32...246:
+                operands.append(Double(b0 - 139))
+                i += 1
+            case 247...250:
+                operands.append(Double((b0 - 247) * 256 + (try bytes.u8(i + 1, "CFF DICT")) + 108))
+                i += 2
+            case 251...254:
+                operands.append(Double(-(b0 - 251) * 256 - (try bytes.u8(i + 1, "CFF DICT")) - 108))
+                i += 2
+            default:
+                throw OpenTypeError.malformedCFF("reserved DICT byte \(b0)")
+            }
+        }
+        return dict
+    }
+
+    /// A nibble-encoded real operand, returning its value and how many bytes it occupied.
+    private static func readRealNumber(_ bytes: FontBytes, at offset: Int) throws -> (Double, Int) {
+        var text = ""
+        var i = offset
+        while true {
+            let byte = try bytes.u8(i, "CFF DICT")
+            i += 1
+            for nibble in [byte >> 4, byte & 0x0F] {
+                switch nibble {
+                case 0...9: text += String(nibble)
+                case 0xA:   text += "."
+                case 0xB:   text += "E"
+                case 0xC:   text += "E-"
+                case 0xE:   text += "-"
+                case 0xF:   return (Double(text) ?? 0, i - offset)
+                default:    break  // 0xD is reserved
+                }
+            }
+        }
+    }
+}

--- a/Sources/CeolKitSVGRenderer/Font/CeolKitFonts.swift
+++ b/Sources/CeolKitSVGRenderer/Font/CeolKitFonts.swift
@@ -5,9 +5,14 @@ import CoreText
 
 /// Access to the fonts bundled with CeolKitSVGRenderer.
 ///
-/// The emitted SVG embeds every face via `@font-face` data URIs, so browser-based
-/// consumers need nothing from this type. Native rasterizers (e.g. SVGKit, which
-/// resolves `font-family` through CoreText/NSFontManager) ignore `@font-face` and
+/// Only needed by hosts that rasterize `TextRendering/fontFace` output themselves.
+/// Setting `SVGRenderConfig.textRendering` to ``TextRendering/outlines`` emits the glyph
+/// geometry into the document instead, which needs no font environment at all and is the
+/// better answer wherever it is available — nothing below applies to those documents.
+///
+/// In `.fontFace` mode the emitted SVG embeds every face via `@font-face` data URIs, so
+/// browser-based consumers need nothing from this type. Native rasterizers (e.g. SVGKit,
+/// which resolves `font-family` through CoreText/NSFontManager) ignore `@font-face` and
 /// can only match fonts already known to the process or to the system font
 /// configuration. Such hosts must make the faces resolvable by family name before
 /// rasterizing, or the score renders with staff lines and stems but no noteheads,
@@ -16,7 +21,9 @@ import CoreText
 /// On Apple platforms call ``register()`` once at startup. Elsewhere there is no
 /// process font manager to register with; use ``install(into:)`` or ``data(for:)``
 /// to hand the faces to whatever font system the rasterizer consults (fontconfig,
-/// resvg's `fontdb`, FreeType, …).
+/// resvg's `fontdb`, FreeType, …). Note that this makes correct output depend on the
+/// host's font database matching the bundled faces: the two can drift, and the same
+/// document then rasterizes differently on two machines.
 public enum CeolKitFonts {
 
     /// A font face bundled with CeolKitSVGRenderer.

--- a/Sources/CeolKitSVGRenderer/Font/CeolKitFonts.swift
+++ b/Sources/CeolKitSVGRenderer/Font/CeolKitFonts.swift
@@ -5,10 +5,11 @@ import CoreText
 
 /// Access to the fonts bundled with CeolKitSVGRenderer.
 ///
-/// Only needed by hosts that rasterize `TextRendering/fontFace` output themselves.
-/// Setting `SVGRenderConfig.textRendering` to ``TextRendering/outlines`` emits the glyph
-/// geometry into the document instead, which needs no font environment at all and is the
-/// better answer wherever it is available — nothing below applies to those documents.
+/// Not needed by default. `SVGRenderConfig.textRendering` defaults to
+/// ``TextRendering/outlines``, which writes the glyph geometry into the document, so those
+/// documents carry no dependency on the host's font environment and nothing below applies
+/// to them. This type exists for hosts that have opted into ``TextRendering/fontFace`` and
+/// rasterize it themselves.
 ///
 /// In `.fontFace` mode the emitted SVG embeds every face via `@font-face` data URIs, so
 /// browser-based consumers need nothing from this type. Native rasterizers (e.g. SVGKit,

--- a/Sources/CeolKitSVGRenderer/Font/GlyphPath.swift
+++ b/Sources/CeolKitSVGRenderer/Font/GlyphPath.swift
@@ -1,0 +1,66 @@
+/// A glyph outline expressed in the font's own design units, y-up.
+///
+/// Outlines are stored untransformed so that one definition can serve every size and
+/// position the glyph is drawn at: the emitter writes each distinct glyph once into
+/// `<defs>` and positions every occurrence with a `<use>` transform. A notehead that
+/// appears two hundred times on a page therefore costs one outline.
+///
+/// Font units are integral in both bundled faces, so the emitted path data is compact
+/// and loses nothing to rounding — all the size-dependent arithmetic happens in the
+/// `<use>` transform instead.
+struct GlyphPath: Sendable, Equatable {
+
+    struct Point: Sendable, Equatable {
+        var x: Double
+        var y: Double
+    }
+
+    enum Segment: Sendable, Equatable {
+        case move(to: Point)
+        case line(to: Point)
+        case curve(control1: Point, control2: Point, to: Point)
+        case close
+    }
+
+    var segments: [Segment] = []
+
+    var isEmpty: Bool { segments.isEmpty }
+
+    /// The outline as an SVG `d` attribute, in font units and the font's y-up orientation.
+    ///
+    /// Emitted with absolute commands: the saving from relative encoding is small next to
+    /// the base64 font payload this replaces, and absolute data is far easier to check by
+    /// eye against a glyph's bounding box when a placement looks wrong.
+    var pathData: String {
+        var out = ""
+        out.reserveCapacity(segments.count * 12)
+        for segment in segments {
+            switch segment {
+            case .move(let p):
+                out += "M\(fmt(p.x)) \(fmt(p.y))"
+            case .line(let p):
+                out += "L\(fmt(p.x)) \(fmt(p.y))"
+            case .curve(let c1, let c2, let end):
+                out += "C\(fmt(c1.x)) \(fmt(c1.y)) \(fmt(c2.x)) \(fmt(c2.y)) \(fmt(end.x)) \(fmt(end.y))"
+            case .close:
+                out += "Z"
+            }
+        }
+        return out
+    }
+
+    /// Formats a font-unit coordinate as compactly as it can be written exactly.
+    ///
+    /// Type 2 charstrings carry integers almost exclusively, but the format also permits
+    /// 16.16 fixed-point operands, so fractional values are kept to three decimals — a
+    /// thousandth of a font unit, i.e. a millionth of an em.
+    private func fmt(_ value: Double) -> String {
+        if value == value.rounded(), abs(value) < 1e15 {
+            return String(Int(value))
+        }
+        var s = String(format: "%.3f", value)
+        while s.hasSuffix("0") { s.removeLast() }
+        if s.hasSuffix(".") { s.removeLast() }
+        return s
+    }
+}

--- a/Sources/CeolKitSVGRenderer/Font/OpenTypeFont.swift
+++ b/Sources/CeolKitSVGRenderer/Font/OpenTypeFont.swift
@@ -1,0 +1,274 @@
+import Foundation
+
+/// Errors raised while reading a bundled OpenType face.
+///
+/// Every case names something the parser can prove about the input rather than a generic
+/// failure, because the only way these fire in practice is a bad resource swap — and then
+/// the message is the whole diagnosis.
+enum OpenTypeError: Error, Equatable {
+    /// A read ran past the end of the data.
+    case truncated(table: String, offset: Int)
+    /// The file is not an sfnt, or is a collection rather than a single face.
+    case notAnOpenTypeFont
+    /// A table CeolKit requires is absent from the table directory.
+    case missingTable(String)
+    /// The face has no `cmap` subtable in a format the parser reads (4 or 12).
+    case noUsableCharacterMap
+    /// The `CFF ` table is structurally invalid.
+    case malformedCFF(String)
+    /// A Type 2 charstring used an operator the interpreter does not implement.
+    case unsupportedCharstringOperator(String)
+    /// A charstring nested subroutine calls deeper than the format permits.
+    case charstringTooDeep
+    /// The glyph index is outside the font's CharStrings INDEX.
+    case glyphIndexOutOfRange(Int)
+    /// A bundled face could not be read out of the module bundle at all.
+    case faceUnavailable(String)
+}
+
+// MARK: - Byte access
+
+/// Big-endian primitive reads over a font's bytes, bounds-checked.
+///
+/// Font files are attacker-adjacent input in the general case and simply untrusted here,
+/// so every accessor is throwing rather than trapping: a malformed resource must surface
+/// as a Swift error the renderer can report, never as a crash inside a server process.
+struct FontBytes: Sendable {
+    let bytes: [UInt8]
+
+    init(_ data: Data) { bytes = [UInt8](data) }
+    init(_ bytes: [UInt8]) { self.bytes = bytes }
+
+    var count: Int { bytes.count }
+
+    func u8(_ offset: Int, _ table: String = "?") throws -> Int {
+        guard offset >= 0, offset < bytes.count else {
+            throw OpenTypeError.truncated(table: table, offset: offset)
+        }
+        return Int(bytes[offset])
+    }
+
+    func u16(_ offset: Int, _ table: String = "?") throws -> Int {
+        guard offset >= 0, offset + 1 < bytes.count else {
+            throw OpenTypeError.truncated(table: table, offset: offset)
+        }
+        return Int(bytes[offset]) << 8 | Int(bytes[offset + 1])
+    }
+
+    func i16(_ offset: Int, _ table: String = "?") throws -> Int {
+        Int(Int16(truncatingIfNeeded: try u16(offset, table)))
+    }
+
+    func u24(_ offset: Int, _ table: String = "?") throws -> Int {
+        try u16(offset, table) << 8 | (try u8(offset + 2, table))
+    }
+
+    func u32(_ offset: Int, _ table: String = "?") throws -> Int {
+        guard offset >= 0, offset + 3 < bytes.count else {
+            throw OpenTypeError.truncated(table: table, offset: offset)
+        }
+        return Int(bytes[offset]) << 24 | Int(bytes[offset + 1]) << 16
+             | Int(bytes[offset + 2]) << 8 | Int(bytes[offset + 3])
+    }
+
+    func tag(_ offset: Int) throws -> String {
+        guard offset >= 0, offset + 3 < bytes.count else {
+            throw OpenTypeError.truncated(table: "sfnt", offset: offset)
+        }
+        return String(decoding: bytes[offset..<(offset + 4)], as: UTF8.self)
+    }
+}
+
+// MARK: - Font
+
+/// A parsed OpenType/CFF face, sufficient to lay out and outline a run of text.
+///
+/// This exists because no SVG rasteriser outside a browser honours `@font-face`: every
+/// one of them resolves `font-family` through a host font database that CeolKit cannot
+/// populate portably. Reading the outlines here and emitting them as geometry moves the
+/// rendering off the host's font environment and into the document, which is the only way
+/// the same score rasterises identically on macOS and in a Linux container.
+///
+/// Scope is deliberately the minimum that serves that goal — `cmap`, `hmtx` and CFF
+/// charstrings. There is no shaping, no kerning, no ligature substitution: the emitter
+/// draws one glyph per Unicode scalar at its nominal advance, which is what the `<text>`
+/// path it replaces effectively got from these faces anyway.
+struct OpenTypeFont: Sendable {
+
+    /// Design units per em, from `head`. Both bundled faces use 1000.
+    let unitsPerEm: Double
+
+    private let cmap: [UInt32: Int]
+    private let advances: [Double]
+    private let charstrings: Type2Interpreter
+
+    var glyphCount: Int { charstrings.glyphCount }
+
+    // MARK: Parsing
+
+    static func parse(_ data: Data) throws -> OpenTypeFont {
+        let bytes = FontBytes(data)
+        let tables = try readTableDirectory(bytes)
+
+        guard let head = tables["head"] else { throw OpenTypeError.missingTable("head") }
+        let unitsPerEm = try bytes.u16(head + 18, "head")
+        guard unitsPerEm > 0 else { throw OpenTypeError.malformedCFF("unitsPerEm is zero") }
+
+        guard let maxp = tables["maxp"] else { throw OpenTypeError.missingTable("maxp") }
+        let numGlyphs = try bytes.u16(maxp + 4, "maxp")
+
+        guard let cmapOffset = tables["cmap"] else { throw OpenTypeError.missingTable("cmap") }
+        let cmap = try readCharacterMap(bytes, at: cmapOffset, numGlyphs: numGlyphs)
+
+        guard let hhea = tables["hhea"] else { throw OpenTypeError.missingTable("hhea") }
+        guard let hmtx = tables["hmtx"] else { throw OpenTypeError.missingTable("hmtx") }
+        let advances = try readAdvances(bytes, hhea: hhea, hmtx: hmtx, numGlyphs: numGlyphs)
+
+        guard let cffOffset = tables["CFF "] else { throw OpenTypeError.missingTable("CFF ") }
+        let cff = try CFFTable(bytes: bytes, offset: cffOffset)
+
+        return OpenTypeFont(
+            unitsPerEm: Double(unitsPerEm),
+            cmap: cmap,
+            advances: advances,
+            charstrings: Type2Interpreter(cff: cff)
+        )
+    }
+
+    private static func readTableDirectory(_ bytes: FontBytes) throws -> [String: Int] {
+        let version = try bytes.u32(0, "sfnt")
+        // 'OTTO' is a CFF-flavoured face; 0x00010000 and 'true' are glyf-flavoured. Only
+        // CFF is read here, but the directory layout is shared, so accept both and let the
+        // missing `CFF ` table be the error a TrueType face produces.
+        let isCollection = (try? bytes.tag(0)) == "ttcf"
+        guard !isCollection else { throw OpenTypeError.notAnOpenTypeFont }
+        guard version == 0x4F54_544F || version == 0x0001_0000 || version == 0x7472_7565 else {
+            throw OpenTypeError.notAnOpenTypeFont
+        }
+        let numTables = try bytes.u16(4, "sfnt")
+        var tables: [String: Int] = [:]
+        tables.reserveCapacity(numTables)
+        for i in 0..<numTables {
+            let record = 12 + 16 * i
+            tables[try bytes.tag(record)] = try bytes.u32(record + 8, "sfnt")
+        }
+        return tables
+    }
+
+    /// Horizontal advances per glyph, in font units.
+    ///
+    /// `hmtx` stores full metrics only for the first `numberOfHMetrics` glyphs; every glyph
+    /// beyond that repeats the last recorded advance. Both Libertinus faces rely on this
+    /// (2589 metrics for 2640 glyphs), so the tail is not a theoretical case.
+    private static func readAdvances(_ bytes: FontBytes, hhea: Int, hmtx: Int,
+                                     numGlyphs: Int) throws -> [Double] {
+        let numberOfHMetrics = max(1, try bytes.u16(hhea + 34, "hhea"))
+        var advances: [Double] = []
+        advances.reserveCapacity(numGlyphs)
+        var last = 0.0
+        for gid in 0..<numGlyphs {
+            if gid < numberOfHMetrics {
+                last = Double(try bytes.u16(hmtx + 4 * gid, "hmtx"))
+            }
+            advances.append(last)
+        }
+        return advances
+    }
+
+    // MARK: Character map
+
+    private static func readCharacterMap(_ bytes: FontBytes, at cmap: Int,
+                                         numGlyphs: Int) throws -> [UInt32: Int] {
+        let numSubtables = try bytes.u16(cmap + 2, "cmap")
+        // Preference order: full-repertoire Unicode first, then BMP, then the symbol
+        // encoding. Bravura publishes its SMuFL codepoints under (3,1) and (3,10) alike,
+        // so any of these resolves them; the order just avoids losing astral planes.
+        let preference: [(Int, Int)] = [(3, 10), (0, 4), (0, 6), (3, 1), (0, 3), (0, 2), (0, 1), (0, 0)]
+        var bestRank = preference.count
+        var subtableOffset: Int?
+        for i in 0..<numSubtables {
+            let record = cmap + 4 + 8 * i
+            let platform = try bytes.u16(record, "cmap")
+            let encoding = try bytes.u16(record + 2, "cmap")
+            guard let rank = preference.firstIndex(where: { $0 == (platform, encoding) }),
+                  rank < bestRank else { continue }
+            bestRank = rank
+            subtableOffset = cmap + (try bytes.u32(record + 4, "cmap"))
+        }
+        guard let subtable = subtableOffset else { throw OpenTypeError.noUsableCharacterMap }
+
+        switch try bytes.u16(subtable, "cmap") {
+        case 4:  return try readCmapFormat4(bytes, at: subtable)
+        case 12: return try readCmapFormat12(bytes, at: subtable, numGlyphs: numGlyphs)
+        default: throw OpenTypeError.noUsableCharacterMap
+        }
+    }
+
+    private static func readCmapFormat4(_ bytes: FontBytes, at base: Int) throws -> [UInt32: Int] {
+        let segCount = try bytes.u16(base + 6, "cmap4") / 2
+        let endCodes      = base + 14
+        let startCodes    = endCodes + 2 * segCount + 2   // +2 skips reservedPad
+        let idDeltas      = startCodes + 2 * segCount
+        let idRangeOffsets = idDeltas + 2 * segCount
+
+        var map: [UInt32: Int] = [:]
+        for seg in 0..<segCount {
+            let end   = try bytes.u16(endCodes + 2 * seg, "cmap4")
+            let start = try bytes.u16(startCodes + 2 * seg, "cmap4")
+            guard start <= end, end != 0xFFFF || start != 0xFFFF else { continue }
+            let delta = try bytes.i16(idDeltas + 2 * seg, "cmap4")
+            let rangeOffsetAddress = idRangeOffsets + 2 * seg
+            let rangeOffset = try bytes.u16(rangeOffsetAddress, "cmap4")
+            for code in start...end {
+                let gid: Int
+                if rangeOffset == 0 {
+                    gid = (code + delta) & 0xFFFF
+                } else {
+                    let address = rangeOffsetAddress + rangeOffset + 2 * (code - start)
+                    let raw = try bytes.u16(address, "cmap4")
+                    gid = raw == 0 ? 0 : (raw + delta) & 0xFFFF
+                }
+                if gid != 0 { map[UInt32(code)] = gid }
+            }
+        }
+        return map
+    }
+
+    private static func readCmapFormat12(_ bytes: FontBytes, at base: Int,
+                                         numGlyphs: Int) throws -> [UInt32: Int] {
+        let groupCount = try bytes.u32(base + 12, "cmap12")
+        var map: [UInt32: Int] = [:]
+        for group in 0..<groupCount {
+            let record = base + 16 + 12 * group
+            let start = try bytes.u32(record, "cmap12")
+            let end   = try bytes.u32(record + 4, "cmap12")
+            let startGlyph = try bytes.u32(record + 8, "cmap12")
+            // A well-formed group cannot cover more codepoints than the font has glyphs;
+            // rejecting the rest keeps a corrupt length field from materialising a
+            // multi-million-entry dictionary.
+            guard start <= end, end - start < numGlyphs else { continue }
+            for code in start...end {
+                let gid = startGlyph + (code - start)
+                if gid != 0, gid < numGlyphs { map[UInt32(code)] = gid }
+            }
+        }
+        return map
+    }
+
+    // MARK: Lookup
+
+    /// The glyph index for `scalar`, or `nil` if the face does not encode it.
+    func glyphID(for scalar: Unicode.Scalar) -> Int? {
+        cmap[scalar.value]
+    }
+
+    /// The horizontal advance of `glyph` in font units, or `0` for an unknown index.
+    func advance(forGlyph glyph: Int) -> Double {
+        advances.indices.contains(glyph) ? advances[glyph] : 0
+    }
+
+    /// The outline of `glyph` in font units, y-up.
+    func outline(forGlyph glyph: Int) throws -> GlyphPath {
+        try charstrings.outline(forGlyph: glyph)
+    }
+}

--- a/Sources/CeolKitSVGRenderer/Font/OutlineFontSet.swift
+++ b/Sources/CeolKitSVGRenderer/Font/OutlineFontSet.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// The bundled faces, parsed for outline extraction and resolved the way the emitter asks
+/// for them — by the `font-family` and `font-style` it would otherwise have written into a
+/// `<text>` element.
+///
+/// Parsing is done once per process. Each face costs a few hundred kilobytes of tables and
+/// a `cmap` dictionary, which is far cheaper than re-reading the OTF per page, and none of
+/// it is mutable once built.
+struct OutlineFontSet: Sendable {
+
+    /// Identifies a face in the emitted document, so every glyph gets a stable `<defs>` id.
+    enum FaceKey: String, Sendable, CaseIterable {
+        case bravura
+        case libertinusSerif
+        case libertinusSerifItalic
+    }
+
+    private let fonts: [FaceKey: OpenTypeFont]
+
+    /// The process-wide set, parsed on first use.
+    ///
+    /// `static let` gives thread-safe once-only initialisation without a lock. The failure
+    /// is stored rather than thrown from the initialiser so that a broken resource reports
+    /// the same error on every render instead of only the first.
+    static func shared() throws -> OutlineFontSet {
+        try cached.get()
+    }
+
+    private static let cached: Result<OutlineFontSet, OpenTypeError> = {
+        var fonts: [FaceKey: OpenTypeFont] = [:]
+        for (key, face) in [
+            (FaceKey.bravura, CeolKitFonts.Face.bravura),
+            (FaceKey.libertinusSerif, CeolKitFonts.Face.libertinusSerifRegular),
+            (FaceKey.libertinusSerifItalic, CeolKitFonts.Face.libertinusSerifItalic)
+        ] {
+            guard let data = try? CeolKitFonts.data(for: face) else {
+                return .failure(.faceUnavailable(face.rawValue))
+            }
+            do {
+                fonts[key] = try OpenTypeFont.parse(data)
+            } catch let error as OpenTypeError {
+                return .failure(error)
+            } catch {
+                return .failure(.faceUnavailable(face.rawValue))
+            }
+        }
+        return .success(OutlineFontSet(fonts: fonts))
+    }()
+
+    /// The face the emitter's `font-family` / `font-style` pair names, or `nil` for a
+    /// family this renderer does not bundle.
+    func resolve(family: String, italic: Bool) -> (key: FaceKey, font: OpenTypeFont)? {
+        let key: FaceKey
+        switch family {
+        case CeolKitFonts.Face.bravura.familyName:
+            key = .bravura
+        case CeolKitFonts.Face.libertinusSerifRegular.familyName:
+            key = italic ? .libertinusSerifItalic : .libertinusSerif
+        default:
+            return nil
+        }
+        guard let font = fonts[key] else { return nil }
+        return (key, font)
+    }
+}

--- a/Sources/CeolKitSVGRenderer/Font/Type2Interpreter.swift
+++ b/Sources/CeolKitSVGRenderer/Font/Type2Interpreter.swift
@@ -1,0 +1,407 @@
+/// Executes Type 2 charstrings, producing glyph outlines in font units.
+///
+/// Type 2 is a stack machine whose operators encode deltas rather than absolute points, so
+/// an outline can only be recovered by running the program — there is no table of contours
+/// to read. Hinting operators are parsed but discarded: they exist to snap stems to a pixel
+/// grid at small sizes, which is a rasteriser's job and not something an SVG `<path>` can
+/// express anyway. They still have to be *counted*, because `hintmask` is followed by a
+/// variable number of raw mask bytes that would otherwise be read as operators.
+struct Type2Interpreter: Sendable {
+
+    let cff: CFFTable
+
+    var glyphCount: Int { cff.glyphCount }
+
+    func outline(forGlyph glyph: Int) throws -> GlyphPath {
+        guard cff.charStrings.indices.contains(glyph) else {
+            throw OpenTypeError.glyphIndexOutOfRange(glyph)
+        }
+        var machine = Machine(
+            cff: cff,
+            localSubrs: cff.localSubrs(forGlyph: glyph),
+            globalSubrs: cff.globalSubrs
+        )
+        try machine.run(cff.charStrings[glyph], depth: 0)
+        machine.closeContour()
+        return machine.path
+    }
+}
+
+// MARK: - The machine
+
+private struct Machine {
+
+    /// The format caps the operand stack at 48 and subroutine nesting at 10. Both are
+    /// enforced so a corrupt charstring fails cleanly instead of exhausting memory or
+    /// the Swift stack.
+    private static let maxStack = 48
+    private static let maxDepth = 10
+
+    let cff: CFFTable
+    let localSubrs: [Range<Int>]
+    let globalSubrs: [Range<Int>]
+    private let localBias: Int
+    private let globalBias: Int
+
+    var stack: [Double] = []
+    var x = 0.0
+    var y = 0.0
+    var stemCount = 0
+    /// Set once the leading optional width operand has been dealt with — it may only
+    /// appear before the charstring's first stack-clearing operator.
+    var widthConsumed = false
+    var contourOpen = false
+    var finished = false
+    var path = GlyphPath()
+
+    init(cff: CFFTable, localSubrs: [Range<Int>], globalSubrs: [Range<Int>]) {
+        self.cff = cff
+        self.localSubrs = localSubrs
+        self.globalSubrs = globalSubrs
+        localBias = Machine.bias(localSubrs.count)
+        globalBias = Machine.bias(globalSubrs.count)
+    }
+
+    /// Subroutine numbers are stored biased so that small indices can use the compact
+    /// single-byte operand encoding.
+    private static func bias(_ count: Int) -> Int {
+        if count < 1240 { return 107 }
+        if count < 33900 { return 1131 }
+        return 32768
+    }
+
+    // MARK: Execution
+
+    mutating func run(_ range: Range<Int>, depth: Int) throws {
+        guard depth <= Machine.maxDepth else { throw OpenTypeError.charstringTooDeep }
+        let bytes = cff.bytes
+        var i = range.lowerBound
+
+        while i < range.upperBound, !finished {
+            let b0 = try bytes.u8(i, "charstring")
+            i += 1
+
+            // Operands: everything from 32 up, plus the 16-bit escape at 28.
+            if b0 == 28 {
+                try push(Double(try bytes.i16(i, "charstring")))
+                i += 2
+                continue
+            }
+            if b0 >= 32 {
+                switch b0 {
+                case 32...246:
+                    try push(Double(b0 - 139))
+                case 247...250:
+                    try push(Double((b0 - 247) * 256 + (try bytes.u8(i, "charstring")) + 108))
+                    i += 1
+                case 251...254:
+                    try push(Double(-(b0 - 251) * 256 - (try bytes.u8(i, "charstring")) - 108))
+                    i += 1
+                default:  // 255: 16.16 fixed point
+                    let raw = Int32(truncatingIfNeeded: try bytes.u32(i, "charstring"))
+                    try push(Double(raw) / 65536.0)
+                    i += 4
+                }
+                continue
+            }
+
+            switch b0 {
+            case 1, 3, 18, 23:  // hstem, vstem, hstemhm, vstemhm
+                consumeWidthIfOddArgumentCount()
+                stemCount += stack.count / 2
+                stack.removeAll(keepingCapacity: true)
+
+            case 19, 20:  // hintmask, cntrmask
+                // Any operands still pending are an implicit vstem declaration.
+                consumeWidthIfOddArgumentCount()
+                stemCount += stack.count / 2
+                stack.removeAll(keepingCapacity: true)
+                i += (stemCount + 7) / 8
+
+            case 21:  // rmoveto
+                consumeWidth(ifArgumentsExceed: 2)
+                moveTo(deltaX: stack.count >= 2 ? stack[stack.count - 2] : 0,
+                       deltaY: stack.count >= 2 ? stack[stack.count - 1] : 0)
+                stack.removeAll(keepingCapacity: true)
+
+            case 22:  // hmoveto
+                consumeWidth(ifArgumentsExceed: 1)
+                moveTo(deltaX: stack.last ?? 0, deltaY: 0)
+                stack.removeAll(keepingCapacity: true)
+
+            case 4:  // vmoveto
+                consumeWidth(ifArgumentsExceed: 1)
+                moveTo(deltaX: 0, deltaY: stack.last ?? 0)
+                stack.removeAll(keepingCapacity: true)
+
+            case 5:  // rlineto
+                var j = 0
+                while j + 1 < stack.count {
+                    lineTo(deltaX: stack[j], deltaY: stack[j + 1])
+                    j += 2
+                }
+                stack.removeAll(keepingCapacity: true)
+
+            case 6, 7:  // hlineto, vlineto — alternating axes
+                var horizontal = (b0 == 6)
+                var j = 0
+                while j < stack.count {
+                    let value = stack[j]
+                    lineTo(deltaX: horizontal ? value : 0, deltaY: horizontal ? 0 : value)
+                    horizontal.toggle()
+                    j += 1
+                }
+                stack.removeAll(keepingCapacity: true)
+
+            case 8:  // rrcurveto
+                var j = 0
+                while j + 5 < stack.count {
+                    relativeCurve(Array(stack[j..<(j + 6)]))
+                    j += 6
+                }
+                stack.removeAll(keepingCapacity: true)
+
+            case 24:  // rcurveline — curves, then one line
+                var j = 0
+                while stack.count - j >= 8 {
+                    relativeCurve(Array(stack[j..<(j + 6)]))
+                    j += 6
+                }
+                if j + 1 < stack.count {
+                    lineTo(deltaX: stack[j], deltaY: stack[j + 1])
+                }
+                stack.removeAll(keepingCapacity: true)
+
+            case 25:  // rlinecurve — lines, then one curve
+                var j = 0
+                while stack.count - j >= 8 {
+                    lineTo(deltaX: stack[j], deltaY: stack[j + 1])
+                    j += 2
+                }
+                if j + 5 < stack.count {
+                    relativeCurve(Array(stack[j..<(j + 6)]))
+                }
+                stack.removeAll(keepingCapacity: true)
+
+            case 26:  // vvcurveto
+                var j = 0
+                var dx1 = 0.0
+                if stack.count % 4 == 1, !stack.isEmpty {
+                    dx1 = stack[0]
+                    j = 1
+                }
+                while j + 3 < stack.count {
+                    let control1 = point(x + dx1, y + stack[j])
+                    let control2 = point(control1.x + stack[j + 1], control1.y + stack[j + 2])
+                    curveTo(control1, control2, point(control2.x, control2.y + stack[j + 3]))
+                    dx1 = 0
+                    j += 4
+                }
+                stack.removeAll(keepingCapacity: true)
+
+            case 27:  // hhcurveto
+                var j = 0
+                var dy1 = 0.0
+                if stack.count % 4 == 1, !stack.isEmpty {
+                    dy1 = stack[0]
+                    j = 1
+                }
+                while j + 3 < stack.count {
+                    let control1 = point(x + stack[j], y + dy1)
+                    let control2 = point(control1.x + stack[j + 1], control1.y + stack[j + 2])
+                    curveTo(control1, control2, point(control2.x + stack[j + 3], control2.y))
+                    dy1 = 0
+                    j += 4
+                }
+                stack.removeAll(keepingCapacity: true)
+
+            case 30, 31:  // vhcurveto, hvcurveto — alternating start tangents
+                var horizontal = (b0 == 31)
+                var j = 0
+                while stack.count - j >= 4 {
+                    // A trailing fifth operand on the final curve gives the otherwise
+                    // implied zero delta of the end point's off-axis coordinate.
+                    let isLast = (stack.count - j == 5)
+                    let extra = isLast ? stack[j + 4] : 0
+                    let control1: GlyphPath.Point
+                    let control2: GlyphPath.Point
+                    let end: GlyphPath.Point
+                    if horizontal {
+                        control1 = point(x + stack[j], y)
+                        control2 = point(control1.x + stack[j + 1], control1.y + stack[j + 2])
+                        end = point(control2.x + extra, control2.y + stack[j + 3])
+                    } else {
+                        control1 = point(x, y + stack[j])
+                        control2 = point(control1.x + stack[j + 1], control1.y + stack[j + 2])
+                        end = point(control2.x + stack[j + 3], control2.y + extra)
+                    }
+                    curveTo(control1, control2, end)
+                    j += isLast ? 5 : 4
+                    horizontal.toggle()
+                }
+                stack.removeAll(keepingCapacity: true)
+
+            case 10, 29:  // callsubr, callgsubr
+                let subrs = (b0 == 10) ? localSubrs : globalSubrs
+                let bias = (b0 == 10) ? localBias : globalBias
+                guard let operand = stack.popLast() else {
+                    throw OpenTypeError.unsupportedCharstringOperator("callsubr with empty stack")
+                }
+                let index = Int(operand) + bias
+                guard subrs.indices.contains(index) else {
+                    throw OpenTypeError.malformedCFF("subroutine \(index) out of range")
+                }
+                try run(subrs[index], depth: depth + 1)
+                if finished { return }
+
+            case 11:  // return
+                return
+
+            case 14:  // endchar
+                consumeWidthForEndchar()
+                if stack.count >= 4 {
+                    // `seac`-style accent composition. Neither bundled face uses it, and
+                    // supporting it means dragging in the CFF charset and the 391 standard
+                    // strings to resolve the component glyph names.
+                    throw OpenTypeError.unsupportedCharstringOperator("endchar (seac)")
+                }
+                stack.removeAll(keepingCapacity: true)
+                finished = true
+                return
+
+            case 12:
+                let b1 = try bytes.u8(i, "charstring")
+                i += 1
+                try runEscaped(b1)
+
+            default:
+                throw OpenTypeError.unsupportedCharstringOperator("reserved operator \(b0)")
+            }
+        }
+    }
+
+    /// The two-byte (`12 x`) operators. Only the four flex variants are implemented; the
+    /// arithmetic, storage, and conditional operators are legal Type 2 but appear in no
+    /// real font, and guessing at them would produce silently wrong outlines.
+    private mutating func runEscaped(_ op: Int) throws {
+        switch op {
+        case 35:  // flex — two curves plus a flex depth that only affects hinting
+            guard stack.count >= 13 else { break }
+            relativeCurve(Array(stack[0..<6]))
+            relativeCurve(Array(stack[6..<12]))
+
+        case 34:  // hflex — horizontal flex, returning to the starting y
+            guard stack.count >= 7 else { break }
+            let startY = y
+            var control1 = point(x + stack[0], y)
+            var control2 = point(control1.x + stack[1], control1.y + stack[2])
+            curveTo(control1, control2, point(control2.x + stack[3], control2.y))
+            control1 = point(x + stack[4], y)
+            control2 = point(control1.x + stack[5], startY)
+            curveTo(control1, control2, point(control2.x + stack[6], startY))
+
+        case 36:  // hflex1 — as hflex, but the first curve may leave the baseline
+            guard stack.count >= 9 else { break }
+            let startY = y
+            var control1 = point(x + stack[0], y + stack[1])
+            var control2 = point(control1.x + stack[2], control1.y + stack[3])
+            curveTo(control1, control2, point(control2.x + stack[4], control2.y))
+            control1 = point(x + stack[5], y)
+            control2 = point(control1.x + stack[6], control1.y + stack[7])
+            curveTo(control1, control2, point(control2.x + stack[8], startY))
+
+        case 37:  // flex1 — the final point's minor axis returns to the start
+            guard stack.count >= 11 else { break }
+            let startX = x
+            let startY = y
+            let deltaX = stack[0] + stack[2] + stack[4] + stack[6] + stack[8]
+            let deltaY = stack[1] + stack[3] + stack[5] + stack[7] + stack[9]
+            var control1 = point(x + stack[0], y + stack[1])
+            var control2 = point(control1.x + stack[2], control1.y + stack[3])
+            curveTo(control1, control2, point(control2.x + stack[4], control2.y + stack[5]))
+            control1 = point(x + stack[6], y + stack[7])
+            control2 = point(control1.x + stack[8], control1.y + stack[9])
+            let end = abs(deltaX) > abs(deltaY)
+                ? point(control2.x + stack[10], startY)
+                : point(startX, control2.y + stack[10])
+            curveTo(control1, control2, end)
+
+        default:
+            throw OpenTypeError.unsupportedCharstringOperator("12 \(op)")
+        }
+        stack.removeAll(keepingCapacity: true)
+    }
+
+    // MARK: Width
+
+    /// Drops the leading width operand of stem and `*moveto` operators, which is present
+    /// only when the operator carries more arguments than its signature calls for.
+    private mutating func consumeWidth(ifArgumentsExceed expected: Int) {
+        guard !widthConsumed else { return }
+        widthConsumed = true
+        if stack.count > expected { stack.removeFirst() }
+    }
+
+    /// Stem hints come in pairs, so an odd operand count means the first is a width.
+    private mutating func consumeWidthIfOddArgumentCount() {
+        guard !widthConsumed else { return }
+        widthConsumed = true
+        if stack.count % 2 == 1 { stack.removeFirst() }
+    }
+
+    /// `endchar` takes either nothing or four `seac` arguments, so only counts of one and
+    /// five carry a width.
+    private mutating func consumeWidthForEndchar() {
+        guard !widthConsumed else { return }
+        widthConsumed = true
+        if stack.count == 1 || stack.count == 5 { stack.removeFirst() }
+    }
+
+    // MARK: Path building
+
+    private mutating func push(_ value: Double) throws {
+        guard stack.count < Machine.maxStack else {
+            throw OpenTypeError.malformedCFF("charstring operand stack overflow")
+        }
+        stack.append(value)
+    }
+
+    private func point(_ atX: Double, _ atY: Double) -> GlyphPath.Point {
+        GlyphPath.Point(x: atX, y: atY)
+    }
+
+    mutating func closeContour() {
+        if contourOpen {
+            path.segments.append(.close)
+            contourOpen = false
+        }
+    }
+
+    private mutating func moveTo(deltaX: Double, deltaY: Double) {
+        closeContour()
+        x += deltaX
+        y += deltaY
+        path.segments.append(.move(to: point(x, y)))
+        contourOpen = true
+    }
+
+    private mutating func lineTo(deltaX: Double, deltaY: Double) {
+        x += deltaX
+        y += deltaY
+        path.segments.append(.line(to: point(x, y)))
+    }
+
+    private mutating func curveTo(_ control1: GlyphPath.Point, _ control2: GlyphPath.Point,
+                                  _ end: GlyphPath.Point) {
+        path.segments.append(.curve(control1: control1, control2: control2, to: end))
+        x = end.x
+        y = end.y
+    }
+
+    /// Six relative deltas: two control points and an end point.
+    private mutating func relativeCurve(_ deltas: [Double]) {
+        let control1 = point(x + deltas[0], y + deltas[1])
+        let control2 = point(control1.x + deltas[2], control1.y + deltas[3])
+        curveTo(control1, control2, point(control2.x + deltas[4], control2.y + deltas[5]))
+    }
+}

--- a/Sources/ckprobe/Options.swift
+++ b/Sources/ckprobe/Options.swift
@@ -8,6 +8,7 @@
 //  it for six flags.
 //
 
+import CeolKitSVGRenderer
 import Foundation
 
 struct Options {
@@ -21,6 +22,9 @@ struct Options {
     /// Directory to write `page0.svg`, `page1.svg`, … into.
     var outputDirectory: URL?
     var json: Bool = false
+    /// Emit glyph geometry instead of `<text>` + `@font-face`, so the SVG rasterises
+    /// without the faces installed — which is what `rsvg-convert` actually needs.
+    var textRendering: TextRendering = .fontFace
 
     static let usage = """
         usage: ckprobe <file.abc> [options]
@@ -35,10 +39,12 @@ struct Options {
                                 are reported unstretched.
           --out <dir>           Write page0.svg, page1.svg, … into <dir>.
           --json                Emit JSON instead of the text report.
+          --outlines            Emit glyph outlines instead of <text> + @font-face.
+          --both                Emit outlines plus non-painting <text>.
           -h, --help            Show this message.
 
-        To look at a page:
-          ckprobe tune.abc --out /tmp/out
+        To look at a page (rsvg-convert ignores @font-face, hence --outlines):
+          ckprobe tune.abc --out /tmp/out --outlines
           rsvg-convert -w 1500 /tmp/out/page0.svg -o /tmp/page0.png
         """
 
@@ -54,6 +60,7 @@ struct Options {
         var natural = false
         var outputDirectory: URL?
         var json = false
+        var textRendering = TextRendering.fontFace
 
         /// Consumes the value that follows a flag.
         func value(after index: inout Int, of flag: String, in args: [String]) throws -> String {
@@ -95,6 +102,12 @@ struct Options {
             case "--json":
                 json = true
 
+            case "--outlines":
+                textRendering = .outlines
+
+            case "--both":
+                textRendering = .both
+
             default:
                 guard !argument.hasPrefix("-") else {
                     throw ParseError(description: "unknown option '\(argument)'")
@@ -116,7 +129,8 @@ struct Options {
             sweep: sweep,
             natural: natural,
             outputDirectory: outputDirectory,
-            json: json
+            json: json,
+            textRendering: textRendering
         )
     }
 }

--- a/Sources/ckprobe/Options.swift
+++ b/Sources/ckprobe/Options.swift
@@ -22,9 +22,9 @@ struct Options {
     /// Directory to write `page0.svg`, `page1.svg`, … into.
     var outputDirectory: URL?
     var json: Bool = false
-    /// Emit glyph geometry instead of `<text>` + `@font-face`, so the SVG rasterises
-    /// without the faces installed — which is what `rsvg-convert` actually needs.
-    var textRendering: TextRendering = .fontFace
+    /// Defaults to whatever the library defaults to, so `ckprobe` sees what a consumer
+    /// sees unless asked otherwise.
+    var textRendering: TextRendering = SVGRenderConfig().textRendering
 
     static let usage = """
         usage: ckprobe <file.abc> [options]
@@ -39,12 +39,15 @@ struct Options {
                                 are reported unstretched.
           --out <dir>           Write page0.svg, page1.svg, … into <dir>.
           --json                Emit JSON instead of the text report.
-          --outlines            Emit glyph outlines instead of <text> + @font-face.
+          --outlines            Emit glyph outlines only (the default).
           --both                Emit outlines plus non-painting <text>.
+          --font-face           Emit <text> + @font-face instead of outlines.  Only
+                                renders correctly in a browser, or on a host that has
+                                the bundled faces installed.
           -h, --help            Show this message.
 
-        To look at a page (rsvg-convert ignores @font-face, hence --outlines):
-          ckprobe tune.abc --out /tmp/out --outlines
+        To look at a page:
+          ckprobe tune.abc --out /tmp/out
           rsvg-convert -w 1500 /tmp/out/page0.svg -o /tmp/page0.png
         """
 
@@ -60,7 +63,7 @@ struct Options {
         var natural = false
         var outputDirectory: URL?
         var json = false
-        var textRendering = TextRendering.fontFace
+        var textRendering = SVGRenderConfig().textRendering
 
         /// Consumes the value that follows a flag.
         func value(after index: inout Int, of flag: String, in args: [String]) throws -> String {
@@ -107,6 +110,9 @@ struct Options {
 
             case "--both":
                 textRendering = .both
+
+            case "--font-face":
+                textRendering = .fontFace
 
             default:
                 guard !argument.hasPrefix("-") else {

--- a/Sources/ckprobe/main.swift
+++ b/Sources/ckprobe/main.swift
@@ -44,8 +44,10 @@ func parse(_ abc: String) -> ParseResult {
         .parse(abc, options: .default)
 }
 
+let renderConfig = SVGRenderConfig(textRendering: options.textRendering)
+
 func render(_ abc: String) throws -> [String] {
-    try SVGRenderer().render(parse(abc).score)
+    try SVGRenderer(config: renderConfig).render(parse(abc).score)
 }
 
 // MARK: - Sweep mode
@@ -74,7 +76,7 @@ let result = parse(abc)
 
 let svgs: [String]
 do {
-    svgs = try SVGRenderer().render(result.score)
+    svgs = try SVGRenderer(config: renderConfig).render(result.score)
 } catch {
     fail("render failed: \(error)")
 }

--- a/Tests/CeolKitSVGRendererTests/InlineTempoTests.swift
+++ b/Tests/CeolKitSVGRendererTests/InlineTempoTests.swift
@@ -32,7 +32,7 @@ struct InlineTempoTests {
             ABCD [Q:1/4=120] | EFGA |]
             """
         let score = CeolKitParser().parse(abc, options: .default).score
-        let pages = try SVGRenderer().render(score)
+        let pages = try textProbeRenderer().render(score)
         let svg = try #require(pages.first)
 
         // "= 120" appears in tempo text like "♩ = 120"; it cannot appear in SVG attributes.
@@ -57,7 +57,7 @@ struct InlineTempoTests {
             ABCD [Q:1/4=120] | EFGA |]
             """
         let score = CeolKitParser().parse(abc, options: .default).score
-        let pages = try SVGRenderer().render(score)
+        let pages = try textProbeRenderer().render(score)
         let svg = try #require(pages.first)
 
         // "= 80" must come from the header Q: rendered in the title block (issue #26 Part 1).

--- a/Tests/CeolKitSVGRendererTests/IntegrationTests.swift
+++ b/Tests/CeolKitSVGRendererTests/IntegrationTests.swift
@@ -211,8 +211,27 @@ private func simpleJigScore() -> Score {
 
     // MARK: Snapshot
 
+    /// The default: glyph geometry in the document, no font environment required.
     @Test func simpleJigScoreMatchesSnapshot() throws {
         let svg = try SVGRenderer().render(simpleJigScore())[0]
+
+        // Replace the outline data of each `<defs>` glyph, for the same reason the base64
+        // blob is stripped below: this snapshot is about structure and placement — which
+        // glyphs are defined, and where each `<use>` puts them — and a few thousand curve
+        // coordinates would bury that. The outlines themselves are checked against
+        // Bravura's own metadata bounding boxes in `OpenTypeFontTests`.
+        let sanitized = svg.replacing(
+            /(<path id="[^"]+" d=")[^"]+"/,
+            with: { "\($0.output.1)<OUTLINE>\"" }
+        )
+
+        assertSnapshot(of: sanitized, as: .lines)
+    }
+
+    /// The opt-in mode, kept under snapshot so that the documents hosts with their own font
+    /// environment depend on cannot drift unnoticed.
+    @Test func simpleJigScoreWithEmbeddedFontsMatchesSnapshot() throws {
+        let svg = try textProbeRenderer().render(simpleJigScore())[0]
 
         // Strip the embedded Bravura base64 blob so the snapshot stays small
         // and diffs focus on SVG structure rather than font data.

--- a/Tests/CeolKitSVGRendererTests/MidLineMeterChangeTests.swift
+++ b/Tests/CeolKitSVGRendererTests/MidLineMeterChangeTests.swift
@@ -53,7 +53,7 @@ struct MidLineMeterChangeTests {
             ABCD [M:6/8] | EFG |]
             """
         let score = CeolKitParser().parse(abc, options: .default).score
-        let pages = try SVGRenderer().render(score)
+        let pages = try textProbeRenderer().render(score)
         let svg = try #require(pages.first)
 
         let six  = glyphChar(.timeSig6)
@@ -86,7 +86,7 @@ struct MidLineMeterChangeTests {
     func bobCooperMidLineChanges() throws {
         let loader = try TuneLoader()
         let result = CeolKitParser().parse(loader.tunebook, options: .default)
-        let pages = try SVGRenderer().render(result.score)
+        let pages = try textProbeRenderer().render(result.score)
 
         // Bob Cooper is tune X:1; it appears on page 1.
         let svg = try #require(pages.first { $0.contains("Bob Cooper") },
@@ -131,7 +131,7 @@ struct MidLineMeterChangeTests {
             ABCDEFGA [M:6/8] | BCD |]
             """
         let score = CeolKitParser().parse(abc, options: .default).score
-        let pages = try SVGRenderer().render(score)
+        let pages = try textProbeRenderer().render(score)
         let svg = try #require(pages.first)
 
         let six = glyphChar(.timeSig6)

--- a/Tests/CeolKitSVGRendererTests/OutlineRenderingTests.swift
+++ b/Tests/CeolKitSVGRendererTests/OutlineRenderingTests.swift
@@ -1,0 +1,258 @@
+import CeolKitModel
+import CeolKitParser
+import Foundation
+import Testing
+@testable import CeolKitSVGRenderer
+
+// MARK: - Helpers
+
+/// A tune exercising every kind of run the emitter produces: notation glyphs, a centred
+/// title, a right-anchored composer, and an italicised rhythm line.
+private let sampleABC = """
+    %abc-2.2
+    X:1
+    T:Outline Test
+    C:A. Composer
+    R:march
+    M:4/4
+    L:1/8
+    K:D
+    |: A>BAB cdec | d2f2 e2d2 :|
+    """
+
+private func render(_ textRendering: TextRendering, abc: String = sampleABC) throws -> [String] {
+    let score = CeolKitParser().parse(abc, options: .default).score
+    return try SVGRenderer(config: SVGRenderConfig(textRendering: textRendering)).render(score)
+}
+
+/// Axis-aligned bounds of an outline, with curves flattened finely enough that the sampling
+/// error is orders of magnitude below the tolerance the caller compares at.
+private func bounds(of path: GlyphPath) -> (minX: Double, minY: Double, maxX: Double, maxY: Double)? {
+    var minX = Double.infinity, minY = Double.infinity
+    var maxX = -Double.infinity, maxY = -Double.infinity
+    var current = GlyphPath.Point(x: 0, y: 0)
+    var sawPoint = false
+
+    func include(_ p: GlyphPath.Point) {
+        minX = min(minX, p.x); maxX = max(maxX, p.x)
+        minY = min(minY, p.y); maxY = max(maxY, p.y)
+        sawPoint = true
+    }
+
+    for segment in path.segments {
+        switch segment {
+        case .move(let p), .line(let p):
+            include(p)
+            current = p
+        case .curve(let c1, let c2, let end):
+            // Sample the cubic rather than taking the control hull, which would overstate
+            // the extent and make the comparison against the metadata meaningless.
+            let steps = 64
+            for step in 1...steps {
+                let t = Double(step) / Double(steps)
+                let u = 1 - t
+                let x = u * u * u * current.x + 3 * u * u * t * c1.x
+                      + 3 * u * t * t * c2.x + t * t * t * end.x
+                let y = u * u * u * current.y + 3 * u * u * t * c1.y
+                      + 3 * u * t * t * c2.y + t * t * t * end.y
+                include(GlyphPath.Point(x: x, y: y))
+            }
+            current = end
+        case .close:
+            break
+        }
+    }
+    return sawPoint ? (minX, minY, maxX, maxY) : nil
+}
+
+// MARK: - Font parsing
+
+@Suite("OpenType outline extraction")
+struct OpenTypeFontTests {
+
+    @Test(arguments: CeolKitFonts.Face.allCases)
+    func everyBundledFaceParses(face: CeolKitFonts.Face) throws {
+        let font = try OpenTypeFont.parse(try CeolKitFonts.data(for: face))
+        #expect(font.unitsPerEm == 1000)
+        #expect(font.glyphCount > 1000)
+    }
+
+    /// Cross-checks the charstring interpreter against a source of truth that is already in
+    /// the repository and was produced by different software: Bravura's own metadata records
+    /// each glyph's ink extent, so a misread curve, a mishandled `hintmask`, or a dropped
+    /// subroutine call moves a bound and fails here.
+    ///
+    /// SMuFL fixes one staff space at a quarter of the em, which is how font units convert
+    /// to the staff spaces `glyphBBoxes` is expressed in.
+    @Test func bravuraOutlinesMatchMetadataBoundingBoxes() throws {
+        let font = try OpenTypeFont.parse(try CeolKitFonts.data(for: .bravura))
+        let metadata = try BravuraMetadata.load()
+        let staffSpace = font.unitsPerEm / 4
+
+        for glyph in SMuFLGlyph.allCases {
+            let expected = try #require(metadata.glyphBBoxes[glyph.rawValue],
+                                        "no metadata bBox for \(glyph.rawValue)")
+            let gid = try #require(font.glyphID(for: glyph.unicodeScalar),
+                                   "Bravura does not encode \(glyph.rawValue)")
+            let outline = try font.outline(forGlyph: gid)
+            let box = try #require(bounds(of: outline), "\(glyph.rawValue) has no outline")
+
+            // Half a font unit. The bound is loose enough only to absorb upstream's own
+            // imprecision: Bravura 1.392's metadata disagrees with its outlines by up to
+            // 0.0016 staff spaces on four flag glyphs (`flag8thDown` worst, at bBoxSW y
+            // -0.0575672 against a true extent of -0.056) — the same four whose boxes moved
+            // in the 1.38 → 1.392 bump. Any real interpreter fault — a dropped subroutine,
+            // a miscounted `hintmask` — moves a bound by whole font units at minimum.
+            let tolerance = 0.002
+            #expect(abs(box.minX / staffSpace - expected.swX) < tolerance,
+                    "\(glyph.rawValue) swX: \(box.minX / staffSpace) vs \(expected.swX)")
+            #expect(abs(box.minY / staffSpace - expected.swY) < tolerance,
+                    "\(glyph.rawValue) swY: \(box.minY / staffSpace) vs \(expected.swY)")
+            #expect(abs(box.maxX / staffSpace - expected.neX) < tolerance,
+                    "\(glyph.rawValue) neX: \(box.maxX / staffSpace) vs \(expected.neX)")
+            #expect(abs(box.maxY / staffSpace - expected.neY) < tolerance,
+                    "\(glyph.rawValue) neY: \(box.maxY / staffSpace) vs \(expected.neY)")
+        }
+    }
+
+    @Test func resolvesLatinTextAndPrivateUseCodepoints() throws {
+        let serif = try OpenTypeFont.parse(try CeolKitFonts.data(for: .libertinusSerifRegular))
+        let bravura = try OpenTypeFont.parse(try CeolKitFonts.data(for: .bravura))
+
+        // Accented characters matter: tune titles are full of them.
+        for scalar in "AZaz0123456789ÓéÜß".unicodeScalars {
+            let gid = try #require(serif.glyphID(for: scalar), "no glyph for \(scalar)")
+            #expect(!(try serif.outline(forGlyph: gid)).isEmpty)
+            #expect(serif.advance(forGlyph: gid) > 0)
+        }
+        #expect(bravura.glyphID(for: SMuFLGlyph.gClef.unicodeScalar) != nil)
+        #expect(serif.glyphID(for: SMuFLGlyph.gClef.unicodeScalar) == nil)
+    }
+
+    /// A space has to advance the pen without contributing geometry — the case that would
+    /// silently collapse multi-word titles if advances came from bounding boxes.
+    @Test func spaceAdvancesWithoutAnOutline() throws {
+        let serif = try OpenTypeFont.parse(try CeolKitFonts.data(for: .libertinusSerifRegular))
+        let space = try #require(serif.glyphID(for: " "))
+        #expect((try serif.outline(forGlyph: space)).isEmpty)
+        #expect(serif.advance(forGlyph: space) > 0)
+    }
+
+    @Test func rejectsDataThatIsNotAFont() {
+        #expect(throws: OpenTypeError.notAnOpenTypeFont) {
+            try OpenTypeFont.parse(Data("this is not a font at all".utf8))
+        }
+    }
+}
+
+// MARK: - Emission
+
+@Suite("Text-as-outlines emission")
+struct OutlineEmissionTests {
+
+    /// The mode's entire purpose: a document that carries no dependency on the host's font
+    /// environment. Any surviving `<text>`, `font-family`, or `@font-face` means the mode
+    /// half-applied and the output would render differently depending on the machine.
+    @Test func outlineDocumentsCarryNoFontDependency() throws {
+        for page in try render(.outlines) {
+            #expect(!page.contains("<text"))
+            #expect(!page.contains("font-family"))
+            #expect(!page.contains("@font-face"))
+            #expect(!page.contains("base64"))
+        }
+    }
+
+    @Test func outlineDocumentsDrawGlyphsAsReusedPaths() throws {
+        let page = try #require(try render(.outlines).first)
+        let definitions = page.components(separatedBy: "<path id=\"").count - 1
+        let uses = page.components(separatedBy: "<use ").count - 1
+        #expect(definitions > 0)
+        // Every drawn glyph must resolve to a definition, and a page of music repeats
+        // noteheads and stems enough that reuse is the whole point of the `<defs>` block.
+        #expect(uses > definitions)
+        #expect(page.contains("xmlns:xlink"))
+        // Both spellings, because rasterisers are split on which of them they honour.
+        #expect(page.contains("href=\"#"))
+        #expect(page.contains("xlink:href=\"#"))
+    }
+
+    /// Each glyph is defined once no matter how often it is drawn, and at whatever size,
+    /// because the size lives in the `<use>` transform rather than in the path data.
+    @Test func repeatedGlyphsShareOneDefinition() throws {
+        let page = try #require(try render(.outlines).first)
+        var ids: [String] = []
+        for chunk in page.components(separatedBy: "<path id=\"").dropFirst() {
+            ids.append(String(chunk.prefix(while: { $0 != "\"" })))
+        }
+        #expect(ids.count == Set(ids).count, "a glyph was defined more than once")
+    }
+
+    /// Dropping ~1.5 MB of base64 more than pays for the outlines of the few dozen glyphs a
+    /// page actually draws.
+    @Test func outlineDocumentsAreSmallerThanEmbeddedFonts() throws {
+        let outlined = try #require(try render(.outlines).first)
+        let embedded = try #require(try render(.fontFace).first)
+        #expect(outlined.count * 4 < embedded.count)
+    }
+
+    @Test func bothModeKeepsTheTextSelectableWithoutPaintingIt() throws {
+        let page = try #require(try render(.both).first)
+        #expect(page.contains("<use "))
+        #expect(page.contains("@font-face"))
+        #expect(page.contains("<text "))
+        // Every text element is present for selection and search only; the geometry on the
+        // page comes from the paths, so none of them may paint.
+        for chunk in page.components(separatedBy: "<text ").dropFirst() {
+            let element = chunk.prefix(while: { $0 != ">" })
+            #expect(element.contains("fill=\"none\""), "painting <text> in .both: \(element)")
+        }
+        #expect(page.contains("Outline Test"))
+    }
+
+    /// `.fontFace` is the default and must stay byte-for-byte what it was, so that adopting
+    /// this feature is opt-in for every existing consumer.
+    @Test func fontFaceModeIsUnchangedAndDefault() throws {
+        #expect(SVGRenderConfig().textRendering == .fontFace)
+        let page = try #require(try render(.fontFace).first)
+        #expect(page.contains("<text "))
+        #expect(page.contains("@font-face"))
+        #expect(!page.contains("<use "))
+        #expect(!page.contains("xmlns:xlink"))
+    }
+
+    /// A centred run has to be measured from the font's advance widths before it can be
+    /// placed, since there is no `text-anchor` to defer to once it is geometry.
+    @Test func anchoredRunsArePositionedFromAdvanceWidths() throws {
+        let outlined = try #require(try render(.outlines).first)
+        let centre = SVGRenderConfig().pageSize.width / 2
+
+        // The title is centred on the page, so its first glyph starts well to the left of
+        // the centre line and the run as a whole straddles it.
+        let titleGlyphs = outlined
+            .components(separatedBy: "<use ")
+            .dropFirst()
+            .compactMap { chunk -> Double? in
+                guard let range = chunk.range(of: "translate(") else { return nil }
+                let rest = chunk[range.upperBound...].prefix(while: { $0 != " " })
+                return Double(rest)
+            }
+        let title = try #require(titleGlyphs.first)
+        #expect(title < centre - 20, "centred title run was not shifted left of centre")
+        #expect(title > centre - 200)
+    }
+
+    /// Scale factors are ratios like 24/1000. Emitting them at the three-decimal precision
+    /// used for page coordinates would round 0.0204 to 0.020 — a 2% size error on every
+    /// glyph on the page.
+    @Test func glyphScaleFactorsKeepEnoughPrecision() throws {
+        let page = try #require(try render(.outlines, abc: sampleABC.replacing(
+            "X:1", with: "%%ceolkit:scale 0.85\nX:1")).first)
+        let scales = page
+            .components(separatedBy: "scale(")
+            .dropFirst()
+            .compactMap { Double($0.prefix(while: { $0 != " " })) }
+        #expect(!scales.isEmpty)
+        // Three decimals could not represent a value this fine; six can.
+        #expect(scales.contains { $0 != (($0 * 1000).rounded() / 1000) })
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/OutlineRenderingTests.swift
+++ b/Tests/CeolKitSVGRendererTests/OutlineRenderingTests.swift
@@ -209,14 +209,27 @@ struct OutlineEmissionTests {
         #expect(page.contains("Outline Test"))
     }
 
-    /// `.fontFace` is the default and must stay byte-for-byte what it was, so that adopting
-    /// this feature is opt-in for every existing consumer.
-    @Test func fontFaceModeIsUnchangedAndDefault() throws {
-        #expect(SVGRenderConfig().textRendering == .fontFace)
+    /// Consumers get font-independent output without asking for it. This is the whole point
+    /// of the default: the failure mode it avoids is silent, so anyone who would have needed
+    /// to opt in is exactly the person who would not have known to.
+    @Test func outlinesAreTheDefault() throws {
+        #expect(SVGRenderConfig().textRendering == .outlines)
+        let page = try #require(try SVGRenderer()
+            .render(CeolKitParser().parse(sampleABC, options: .default).score).first)
+        #expect(page.contains("<use "))
+        #expect(!page.contains("@font-face"))
+        #expect(!page.contains("<text"))
+    }
+
+    /// `.fontFace` remains available and unchanged for hosts that want selectable text and
+    /// control their own font environment.
+    @Test func fontFaceModeIsStillAvailableAndUnchanged() throws {
         let page = try #require(try render(.fontFace).first)
         #expect(page.contains("<text "))
         #expect(page.contains("@font-face"))
         #expect(!page.contains("<use "))
+        // The xlink namespace is declared only when something references a glyph, so
+        // `.fontFace` documents are byte-for-byte what they were before outlines existed.
         #expect(!page.contains("xmlns:xlink"))
     }
 

--- a/Tests/CeolKitSVGRendererTests/SVGEmitterTests.swift
+++ b/Tests/CeolKitSVGRendererTests/SVGEmitterTests.swift
@@ -7,8 +7,9 @@ import CeolKitModel
 private let dummyRange = SourceRange(file: nil, byteOffset: 0, length: 0, line: 0, column: 0)
 private let dummyBar   = BarLine(kind: .single, source: dummyRange)
 
-/// Default staffSize = 7.0, so staffHeight = 28.0
-private let config = SVGRenderConfig()
+/// Default staffSize = 7.0, so staffHeight = 28.0.  Pinned to `.fontFace` because every
+/// assertion below reads a glyph's position out of a `<text>` element — see `textProbeRenderer`.
+private let config = SVGRenderConfig(textRendering: .fontFace)
 private let metadata = try! BravuraMetadata.load()
 
 /// Builds a minimal `ResolvedLayout` from the given systems.

--- a/Tests/CeolKitSVGRendererTests/StyleTests.swift
+++ b/Tests/CeolKitSVGRendererTests/StyleTests.swift
@@ -107,7 +107,7 @@ struct StyleTests {
     var score: Score { result.score }
 
     @Test func pageIsLandscapeLetter() throws {
-        let pages = try SVGRenderer().render(score)
+        let pages = try textProbeRenderer().render(score)
         let svg = try #require(pages.first)
         // US Letter landscape: 792 × 612 points
         #expect(svg.contains("width=\"792\""))
@@ -115,7 +115,7 @@ struct StyleTests {
     }
 
     @Test func sevenLinesOfMusicAreRendered() throws {
-        let pages = try SVGRenderer().render(score)
+        let pages = try textProbeRenderer().render(score)
         let combined = pages.joined()
         // One treble clef glyph is emitted per system.
         let clefChar = String(SMuFLGlyph.gClef.character)
@@ -124,7 +124,7 @@ struct StyleTests {
     }
 
     @Test func tuneRendersOnOnePage() throws {
-        let pages = try SVGRenderer().render(score)
+        let pages = try textProbeRenderer().render(score)
         // we should be able to fit a tune title, rhythm & composer line, 7 systems, and a footer
         // onto a single landscape 8.5 x 11 page. If we can't, then something is taking up too much
         // space.
@@ -132,7 +132,7 @@ struct StyleTests {
     }
 
     @Test func keySignatureAppearsAtStartOfEveryLine() throws {
-        let pages = try SVGRenderer().render(score)
+        let pages = try textProbeRenderer().render(score)
         let combined = pages.joined()
         // D major has 2 sharps (F# and C#); one key signature per system × 7 systems = 14 sharps.
         let sharpChar = String(SMuFLGlyph.accidentalSharp.character)
@@ -141,7 +141,7 @@ struct StyleTests {
     }
 
     @Test func cutTimeAppearsOnFirstLineOnly() throws {
-        let pages = try SVGRenderer().render(score)
+        let pages = try textProbeRenderer().render(score)
         let combined = pages.joined()
         let cutTimeChar = String(SMuFLGlyph.timeSigCutCommon.character)
         let cutTimeCount = combined.components(separatedBy: cutTimeChar).count - 1
@@ -149,7 +149,7 @@ struct StyleTests {
     }
 
     @Test func repeatDotsAreRendered() throws {
-        let pages = try SVGRenderer().render(score)
+        let pages = try textProbeRenderer().render(score)
         let combined = pages.joined()
         let dotChar = String(SMuFLGlyph.repeatDot.character)
         let dotCount = combined.components(separatedBy: dotChar).count - 1
@@ -315,7 +315,7 @@ struct StyleTests {
 
     @Test func titleIsDrawnForEachTune() throws {
         let result = parse(multitune)
-        let pages = try SVGRenderer().render(result.score)
+        let pages = try textProbeRenderer().render(result.score)
         let combined = pages.joined()
 
         #expect(pages.count == 1, "The two tunes should fit on a single landscape page")
@@ -328,7 +328,7 @@ struct StyleTests {
     // must be strictly above the topmost rendered music element (minimum Y among all <line>
     // elements, which includes staff lines, stems, bar lines, and ledger lines).
     @Test func titleTextIsAboveHighestNoteStem() throws {
-        let pages = try SVGRenderer().render(score)
+        let pages = try textProbeRenderer().render(score)
         let svg   = try #require(pages.first)
 
         // Collect the Y baseline of every title text element.
@@ -394,7 +394,7 @@ struct StyleTests {
         G|
         """
         let s = parse(abc).score
-        let pages = try SVGRenderer().render(s)
+        let pages = try textProbeRenderer().render(s)
         let svg = try #require(pages.first)
         #expect(svg.contains(String(SMuFLGlyph.flag8thUp.character)),
                 "curved flag glyph should appear with %%straightflags false")
@@ -422,8 +422,8 @@ struct StyleTests {
         K:C
         G|
         """
-        let svgStraight = try #require(try SVGRenderer().render(parse(abcStraight).score).first)
-        let svgCurved   = try #require(try SVGRenderer().render(parse(abcCurved).score).first)
+        let svgStraight = try #require(try textProbeRenderer().render(parse(abcStraight).score).first)
+        let svgCurved   = try #require(try textProbeRenderer().render(parse(abcCurved).score).first)
 
         // Curved flag should be absent when straight flags are active.
         #expect(!svgStraight.contains(String(SMuFLGlyph.flag16thUp.character)),
@@ -455,8 +455,8 @@ struct StyleTests {
         K:C
         {G}C|
         """
-        let svgStraight = try #require(try SVGRenderer().render(parse(abcStraight).score).first)
-        let svgCurved   = try #require(try SVGRenderer().render(parse(abcCurved).score).first)
+        let svgStraight = try #require(try textProbeRenderer().render(parse(abcStraight).score).first)
+        let svgCurved   = try #require(try textProbeRenderer().render(parse(abcCurved).score).first)
 
         // Curved 32nd-flag glyph must be absent in straight mode.
         #expect(!svgStraight.contains(String(SMuFLGlyph.flag32ndUp.character)),
@@ -484,12 +484,12 @@ struct StyleTests {
         {G}C|
         """
         let s = parse(abc).score
-        let pages = try SVGRenderer().render(s)
+        let pages = try textProbeRenderer().render(s)
         #expect(!pages.isEmpty)
     }
 
     @Test func graceSlursDirectiveSetsConfigValue() throws {
-        let renderer = SVGRenderer()
+        let renderer = textProbeRenderer()
         let abcFalse = "%%graceslurs false\nX:1\nT:T\nM:4/4\nL:1/4\nK:C\nC|"
         let abcTrue  = "%%graceslurs true\nX:1\nT:T\nM:4/4\nL:1/4\nK:C\nC|"
         let scoreFalse = parse(abcFalse).score
@@ -523,7 +523,7 @@ struct StyleTests {
         CDEF|
         """
         let score = parse(abc).score
-        let pages = try SVGRenderer().render(score)
+        let pages = try textProbeRenderer().render(score)
         let combined = pages.joined()
         let currentYear = String(Calendar.current.component(.year, from: Date()))
         #expect(combined.contains(currentYear),
@@ -535,7 +535,7 @@ struct StyleTests {
         // The parser stores the raw payload; the renderer must unescape \% → % before strftime.
         let abc = "%%dateformat \\%Y\n%%footer \"$D\"\nX:1\nT:T\nM:4/4\nL:1/4\nK:C\nC|"
         let score = parse(abc).score
-        let pages = try SVGRenderer().render(score)
+        let pages = try textProbeRenderer().render(score)
         let combined = pages.joined()
         let currentYear = String(Calendar.current.component(.year, from: Date()))
         #expect(combined.contains(currentYear),
@@ -555,7 +555,7 @@ struct StyleTests {
         C|
         """
         let score = parse(abc).score
-        let pages = try SVGRenderer().render(score)
+        let pages = try textProbeRenderer().render(score)
         let combined = pages.joined()
         let currentYear = String(Calendar.current.component(.year, from: Date()))
         #expect(combined.contains(currentYear),

--- a/Tests/CeolKitSVGRendererTests/TextProbeRenderer.swift
+++ b/Tests/CeolKitSVGRendererTests/TextProbeRenderer.swift
@@ -1,0 +1,23 @@
+import CeolKitModel
+@testable import CeolKitSVGRenderer
+
+/// A renderer pinned to ``TextRendering/fontFace``, for suites that read layout back out of
+/// the emitted `<text>` elements.
+///
+/// Those suites are about *where things landed* — a title's baseline, a mid-line time
+/// signature's x, a grace note's spacing — and `<text>` is the most direct probe available:
+/// one element per run, carrying its x, y, family, and content as attributes. Outline
+/// output states the same facts through `<use transform="translate(…)">`, but reading
+/// positions back out of a transform would make those tests as much a test of the parsing
+/// helper as of the layout.
+///
+/// So the mode is pinned rather than the assertions rewritten. That keeps each suite about
+/// its own subject, and keeps `.fontFace` exercised end-to-end now that it is no longer the
+/// default. Coverage of the default is not lost: both modes are driven by the same
+/// `SVGBuilder.text` calls with the same arguments, and `OutlineEmissionTests` asserts on
+/// the outline output directly.
+func textProbeRenderer(_ config: SVGRenderConfig = SVGRenderConfig()) -> SVGRenderer {
+    var pinned = config
+    pinned.textRendering = .fontFace
+    return SVGRenderer(config: pinned)
+}

--- a/Tests/CeolKitSVGRendererTests/TieSlurIntegrationTests.swift
+++ b/Tests/CeolKitSVGRendererTests/TieSlurIntegrationTests.swift
@@ -69,8 +69,9 @@ struct TieSlurIntegrationTests {
 
     // MARK: - Renderer-level: exactly one arc, ending at A not B
 
-    /// Rendering `c A2- | A2 B` must produce exactly one SVG `<path>` element
-    /// (the tie arc from A to A).
+    /// Rendering `c A2- | A2 B` must produce exactly one drawn `<path d=…>` element
+    /// (the tie arc from A to A).  Glyph outlines in `<defs>` are `<path id=…>`,
+    /// so matching on `d=` counts only what is actually drawn on the page.
     @Test("Tie renders exactly one arc")
     func tieRendersOneArc() throws {
         let tune  = try #require(parseTune("c A2- | A2 B |"))
@@ -79,12 +80,13 @@ struct TieSlurIntegrationTests {
                           tunes: [tune], freeText: [], typesetText: [], diagnostics: [])
         let pages = try SVGRenderer().render(score)
         let svg   = try #require(pages.first)
-        let pathCount = svg.components(separatedBy: "<path").count - 1
+        let pathCount = svg.components(separatedBy: "<path d=").count - 1
         #expect(pathCount == 1, "Expected exactly 1 tie arc, got \(pathCount)")
     }
 
-    /// Rendering `c (A2 | A2) B` must produce exactly one SVG `<path>` element
-    /// (the slur arc from A to A).
+    /// Rendering `c (A2 | A2) B` must produce exactly one drawn `<path d=…>` element
+    /// (the slur arc from A to A).  Glyph outlines in `<defs>` are `<path id=…>`,
+    /// so matching on `d=` counts only what is actually drawn on the page.
     @Test("Slur renders exactly one arc")
     func slurRendersOneArc() throws {
         let tune  = try #require(parseTune("c (A2 | A2) B |"))
@@ -93,7 +95,7 @@ struct TieSlurIntegrationTests {
                           tunes: [tune], freeText: [], typesetText: [], diagnostics: [])
         let pages = try SVGRenderer().render(score)
         let svg   = try #require(pages.first)
-        let pathCount = svg.components(separatedBy: "<path").count - 1
+        let pathCount = svg.components(separatedBy: "<path d=").count - 1
         #expect(pathCount == 1, "Expected exactly 1 slur arc, got \(pathCount)")
     }
 }

--- a/Tests/CeolKitSVGRendererTests/TitleBlockIntegrationTests.swift
+++ b/Tests/CeolKitSVGRendererTests/TitleBlockIntegrationTests.swift
@@ -33,21 +33,21 @@ struct TitleBlockIntegrationTests {
 
     @Test("SVG contains the tune title text")
     func titlePresentInSVG() throws {
-        let pages = try SVGRenderer().render(parseScore(kalabakan))
+        let pages = try textProbeRenderer().render(parseScore(kalabakan))
         let firstPage = try #require(pages.first)
         #expect(firstPage.contains("Kalabakan (Borneo)"))
     }
 
     @Test("SVG contains the rhythm field text when %%writefields R is set")
     func rhythmPresentInSVG() throws {
-        let pages = try SVGRenderer().render(parseScore(kalabakan))
+        let pages = try textProbeRenderer().render(parseScore(kalabakan))
         let firstPage = try #require(pages.first)
         #expect(firstPage.contains("Reel"))
     }
 
     @Test("SVG contains the composer field text")
     func composerPresentInSVG() throws {
-        let pages = try SVGRenderer().render(parseScore(kalabakan))
+        let pages = try textProbeRenderer().render(parseScore(kalabakan))
         let firstPage = try #require(pages.first)
         #expect(firstPage.contains("P/M A. MacDonald"))
     }
@@ -56,7 +56,7 @@ struct TitleBlockIntegrationTests {
 
     @Test("Title baseline Y is less than the first system's staff Y (title is above staff)")
     func titleAboveStaff() throws {
-        let pages = try SVGRenderer().render(parseScore(kalabakan))
+        let pages = try textProbeRenderer().render(parseScore(kalabakan))
         let svg = try #require(pages.first)
 
         let titleYValues: [Double] = svg
@@ -101,7 +101,7 @@ struct TitleBlockIntegrationTests {
     @Test("Title appears in SVG by default with no %%writefields directive")
     func defaultShowsTitle() throws {
         let abc = "X:1\nT:My Tune\nM:4/4\nL:1/4\nK:C\nCDEF|"
-        let pages = try SVGRenderer().render(parseScore(abc))
+        let pages = try textProbeRenderer().render(parseScore(abc))
         let svg = try #require(pages.first)
         #expect(svg.contains("My Tune"))
     }
@@ -109,7 +109,7 @@ struct TitleBlockIntegrationTests {
     @Test("%%writefields T false suppresses title in SVG")
     func writeFieldsTFalseSuppressesTitle() throws {
         let abc = "%%writefields T false\nX:1\nT:Test\nM:4/4\nL:1/4\nK:C\nCDEF|"
-        let pages = try SVGRenderer().render(parseScore(abc))
+        let pages = try textProbeRenderer().render(parseScore(abc))
         let svg = try #require(pages.first)
         #expect(!svg.contains(">Test<"))
     }

--- a/Tests/CeolKitSVGRendererTests/TunebookTests.swift
+++ b/Tests/CeolKitSVGRendererTests/TunebookTests.swift
@@ -71,7 +71,7 @@ struct TunebookTests {
         let tunebook = loader.tunebook
         let result = CeolKitParser().parse(tunebook, options: .default)
         let score = result.score
-        let renderer = SVGRenderer()
+        let renderer = textProbeRenderer()
         let pages = try renderer.render(score)
 
         #expect(pages.count == 16, "Expected to find 16 pages")
@@ -82,7 +82,7 @@ struct TunebookTests {
         let tunebook = loader.tunebook
         let result = CeolKitParser().parse(tunebook, options: .default)
         let score = result.score
-        let renderer = SVGRenderer()
+        let renderer = textProbeRenderer()
         let pages = try renderer.render(score)
 
         let firstPage = try #require(pages.first)
@@ -116,7 +116,7 @@ struct TunebookTests {
         let tunebook = loader.tunebook
         let result = CeolKitParser().parse(tunebook, options: .default)
         let score = result.score
-        let pages = try SVGRenderer().render(score)
+        let pages = try textProbeRenderer().render(score)
 
         // Page 3 contains The Radar Racketeer (R:Jig, C:Murray Blair & Adrian Melvin).
         // %%writefields TRCQ true is in the preamble, so R should appear in every tune's title block.

--- a/Tests/CeolKitSVGRendererTests/__Snapshots__/IntegrationTests/simpleJigScoreMatchesSnapshot.1.txt
+++ b/Tests/CeolKitSVGRendererTests/__Snapshots__/IntegrationTests/simpleJigScoreMatchesSnapshot.1.txt
@@ -1,38 +1,43 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 612 792" width="612" height="792">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 612 792" width="612" height="792">
   <defs>
-    <style>
-      @font-face {
-        font-family: "Bravura";
-        src: url('data:font/otf;base64,<BRAVURA>') format('opentype');
-      }
-      @font-face {
-        font-family: "Libertinus Serif";
-        src: url('data:font/otf;base64,<BRAVURA>') format('opentype');
-      }
-      @font-face {
-        font-family: "Libertinus Serif";
-        font-style: italic;
-        src: url('data:font/otf;base64,<BRAVURA>') format('opentype');
-      }
-    </style>
+    <path id="libertinusSerif-g52" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g74" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g78" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g81" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g77" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g70" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g43" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g72" d="<OUTLINE>"/>
+    <path id="bravura-g74" d="<OUTLINE>"/>
+    <path id="bravura-g128" d="<OUTLINE>"/>
+    <path id="bravura-g130" d="<OUTLINE>"/>
+    <path id="bravura-g158" d="<OUTLINE>"/>
   </defs>
   <!-- ceolkit-meta: {"page": 1, "anchors": [{"abcLine": 0, "y": 57}]} -->
-  <text x="306" y="47.25" font-family="Libertinus Serif" font-size="18" fill="black" text-anchor="middle">Simple Jig</text>
+  <use href="#libertinusSerif-g52" xlink:href="#libertinusSerif-g52" transform="translate(268.929 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g74" xlink:href="#libertinusSerif-g74" transform="translate(277.659 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g78" xlink:href="#libertinusSerif-g78" transform="translate(282.537 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g81" xlink:href="#libertinusSerif-g81" transform="translate(296.757 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g77" xlink:href="#libertinusSerif-g77" transform="translate(306.099 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g70" xlink:href="#libertinusSerif-g70" transform="translate(310.851 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g43" xlink:href="#libertinusSerif-g43" transform="translate(323.397 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g74" xlink:href="#libertinusSerif-g74" transform="translate(329.193 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g72" xlink:href="#libertinusSerif-g72" transform="translate(334.071 47.25) scale(0.018 -0.018)"/>
   <line x1="36" y1="57" x2="202.827" y2="57" stroke="black" stroke-width="0.78"/>
   <line x1="36" y1="63" x2="202.827" y2="63" stroke="black" stroke-width="0.78"/>
   <line x1="36" y1="69" x2="202.827" y2="69" stroke="black" stroke-width="0.78"/>
   <line x1="36" y1="75" x2="202.827" y2="75" stroke="black" stroke-width="0.78"/>
   <line x1="36" y1="81" x2="202.827" y2="81" stroke="black" stroke-width="0.78"/>
-  <text x="37.5" y="75" font-family="Bravura" font-size="24" fill="black"></text>
-  <text x="55.104" y="63" font-family="Bravura" font-size="24" fill="black"></text>
-  <text x="55.104" y="75" font-family="Bravura" font-size="24" fill="black"></text>
+  <use href="#bravura-g74" xlink:href="#bravura-g74" transform="translate(37.5 75) scale(0.024 -0.024)"/>
+  <use href="#bravura-g128" xlink:href="#bravura-g128" transform="translate(55.104 63) scale(0.024 -0.024)"/>
+  <use href="#bravura-g130" xlink:href="#bravura-g130" transform="translate(55.104 75) scale(0.024 -0.024)"/>
   <line x1="137.036" y1="57" x2="137.036" y2="81" stroke="black" stroke-width="0.96"/>
-  <text x="83.124" y="75" font-family="Bravura" font-size="24" fill="black"></text>
-  <text x="91.609" y="72" font-family="Bravura" font-size="24" fill="black"></text>
-  <text x="100.095" y="69" font-family="Bravura" font-size="24" fill="black"></text>
-  <text x="108.58" y="66" font-family="Bravura" font-size="24" fill="black"></text>
-  <text x="117.065" y="63" font-family="Bravura" font-size="24" fill="black"></text>
-  <text x="125.55" y="60" font-family="Bravura" font-size="24" fill="black"></text>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(83.124 75) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(91.609 72) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(100.095 69) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(108.58 66) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(117.065 63) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(125.55 60) scale(0.024 -0.024)"/>
   <line x1="90.204" y1="48" x2="90.204" y2="75" stroke="black" stroke-width="0.72"/>
   <line x1="98.689" y1="48" x2="98.689" y2="72" stroke="black" stroke-width="0.72"/>
   <line x1="107.175" y1="48" x2="107.175" y2="69" stroke="black" stroke-width="0.72"/>
@@ -42,12 +47,12 @@
   <line x1="90.204" y1="48" x2="125.55" y2="48" stroke="black" stroke-width="3"/>
   <line x1="198.027" y1="57" x2="198.027" y2="81" stroke="black" stroke-width="0.96"/>
   <line x1="202.827" y1="57" x2="202.827" y2="81" stroke="black" stroke-width="3"/>
-  <text x="144.116" y="75" font-family="Bravura" font-size="24" fill="black"></text>
-  <text x="152.601" y="72" font-family="Bravura" font-size="24" fill="black"></text>
-  <text x="161.086" y="69" font-family="Bravura" font-size="24" fill="black"></text>
-  <text x="169.572" y="66" font-family="Bravura" font-size="24" fill="black"></text>
-  <text x="178.057" y="63" font-family="Bravura" font-size="24" fill="black"></text>
-  <text x="186.542" y="60" font-family="Bravura" font-size="24" fill="black"></text>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(144.116 75) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(152.601 72) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(161.086 69) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(169.572 66) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(178.057 63) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(186.542 60) scale(0.024 -0.024)"/>
   <line x1="151.196" y1="48" x2="151.196" y2="75" stroke="black" stroke-width="0.72"/>
   <line x1="159.681" y1="48" x2="159.681" y2="72" stroke="black" stroke-width="0.72"/>
   <line x1="168.166" y1="48" x2="168.166" y2="69" stroke="black" stroke-width="0.72"/>

--- a/Tests/CeolKitSVGRendererTests/__Snapshots__/IntegrationTests/simpleJigScoreWithEmbeddedFontsMatchesSnapshot.1.txt
+++ b/Tests/CeolKitSVGRendererTests/__Snapshots__/IntegrationTests/simpleJigScoreWithEmbeddedFontsMatchesSnapshot.1.txt
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 612 792" width="612" height="792">
+  <defs>
+    <style>
+      @font-face {
+        font-family: "Bravura";
+        src: url('data:font/otf;base64,<BRAVURA>') format('opentype');
+      }
+      @font-face {
+        font-family: "Libertinus Serif";
+        src: url('data:font/otf;base64,<BRAVURA>') format('opentype');
+      }
+      @font-face {
+        font-family: "Libertinus Serif";
+        font-style: italic;
+        src: url('data:font/otf;base64,<BRAVURA>') format('opentype');
+      }
+    </style>
+  </defs>
+  <!-- ceolkit-meta: {"page": 1, "anchors": [{"abcLine": 0, "y": 57}]} -->
+  <text x="306" y="47.25" font-family="Libertinus Serif" font-size="18" fill="black" text-anchor="middle">Simple Jig</text>
+  <line x1="36" y1="57" x2="202.827" y2="57" stroke="black" stroke-width="0.78"/>
+  <line x1="36" y1="63" x2="202.827" y2="63" stroke="black" stroke-width="0.78"/>
+  <line x1="36" y1="69" x2="202.827" y2="69" stroke="black" stroke-width="0.78"/>
+  <line x1="36" y1="75" x2="202.827" y2="75" stroke="black" stroke-width="0.78"/>
+  <line x1="36" y1="81" x2="202.827" y2="81" stroke="black" stroke-width="0.78"/>
+  <text x="37.5" y="75" font-family="Bravura" font-size="24" fill="black"></text>
+  <text x="55.104" y="63" font-family="Bravura" font-size="24" fill="black"></text>
+  <text x="55.104" y="75" font-family="Bravura" font-size="24" fill="black"></text>
+  <line x1="137.036" y1="57" x2="137.036" y2="81" stroke="black" stroke-width="0.96"/>
+  <text x="83.124" y="75" font-family="Bravura" font-size="24" fill="black"></text>
+  <text x="91.609" y="72" font-family="Bravura" font-size="24" fill="black"></text>
+  <text x="100.095" y="69" font-family="Bravura" font-size="24" fill="black"></text>
+  <text x="108.58" y="66" font-family="Bravura" font-size="24" fill="black"></text>
+  <text x="117.065" y="63" font-family="Bravura" font-size="24" fill="black"></text>
+  <text x="125.55" y="60" font-family="Bravura" font-size="24" fill="black"></text>
+  <line x1="90.204" y1="48" x2="90.204" y2="75" stroke="black" stroke-width="0.72"/>
+  <line x1="98.689" y1="48" x2="98.689" y2="72" stroke="black" stroke-width="0.72"/>
+  <line x1="107.175" y1="48" x2="107.175" y2="69" stroke="black" stroke-width="0.72"/>
+  <line x1="108.58" y1="48" x2="108.58" y2="66" stroke="black" stroke-width="0.72"/>
+  <line x1="117.065" y1="48" x2="117.065" y2="63" stroke="black" stroke-width="0.72"/>
+  <line x1="125.55" y1="48" x2="125.55" y2="60" stroke="black" stroke-width="0.72"/>
+  <line x1="90.204" y1="48" x2="125.55" y2="48" stroke="black" stroke-width="3"/>
+  <line x1="198.027" y1="57" x2="198.027" y2="81" stroke="black" stroke-width="0.96"/>
+  <line x1="202.827" y1="57" x2="202.827" y2="81" stroke="black" stroke-width="3"/>
+  <text x="144.116" y="75" font-family="Bravura" font-size="24" fill="black"></text>
+  <text x="152.601" y="72" font-family="Bravura" font-size="24" fill="black"></text>
+  <text x="161.086" y="69" font-family="Bravura" font-size="24" fill="black"></text>
+  <text x="169.572" y="66" font-family="Bravura" font-size="24" fill="black"></text>
+  <text x="178.057" y="63" font-family="Bravura" font-size="24" fill="black"></text>
+  <text x="186.542" y="60" font-family="Bravura" font-size="24" fill="black"></text>
+  <line x1="151.196" y1="48" x2="151.196" y2="75" stroke="black" stroke-width="0.72"/>
+  <line x1="159.681" y1="48" x2="159.681" y2="72" stroke="black" stroke-width="0.72"/>
+  <line x1="168.166" y1="48" x2="168.166" y2="69" stroke="black" stroke-width="0.72"/>
+  <line x1="169.572" y1="48" x2="169.572" y2="66" stroke="black" stroke-width="0.72"/>
+  <line x1="178.057" y1="48" x2="178.057" y2="63" stroke="black" stroke-width="0.72"/>
+  <line x1="186.542" y1="48" x2="186.542" y2="60" stroke="black" stroke-width="0.72"/>
+  <line x1="151.196" y1="48" x2="186.542" y2="48" stroke="black" stroke-width="3"/>
+</svg>


### PR DESCRIPTION
Closes #36.

> **Stacked on #46.** Base is `feature/bravura-1.392` so the diff shows only this work;
> retarget to `develop` after that merges. Outlines are read from the OTF that ships, so
> the font bump wants to land first.

## What changed

`SVGRenderConfig.textRendering`: `.outlines` (**default**), `.fontFace`, `.both`.

In `.outlines` the glyph geometry is written into the document and the `@font-face` block
is dropped entirely. `.both` adds non-painting `<text>` so the document stays selectable
and searchable. `.fontFace` is the old behaviour, byte-for-byte unchanged.

**The default was flipped deliberately.** The failure this avoids is silent — a score with
staff lines and stems but no noteheads reads as a layout bug, not a missing font — so the
host that would have needed to opt in is exactly the host that would not have known to.

## Approach: a pure-Swift OpenType/CFF reader

The alternative was a dependency (FreeType, or a Rust shaper through FFI), which would
have been the first system library in a package whose only dependency today is
test-only. The reader covers sfnt table directory, `cmap` formats 4 and 12, `hmtx`, CFF
INDEX/DICT structures, and a Type 2 charstring interpreter.

It reads only what outline extraction needs, and **rejects rather than guesses** at what it
does not: `seac` accent composition and the arithmetic charstring operators throw, since no
bundled face uses either and a wrong guess would produce silently mangled glyphs. CID-keyed
faces are handled, though neither bundled face is one — the alternative was a landmine for
whoever swaps a font later.

## Verification

Cross-checked against **fontTools** during development:

| | result |
|---|---|
| Glyph outlines, all 3 faces | **8739 / 8739** byte-identical path data |
| `cmap` mappings | **8139 / 8139** agree |
| Advance widths | every glyph agrees |
| `unitsPerEm` | agrees |

That can't run in CI, so the committed test uses an oracle already in the tree: the 41
`SMuFLGlyph` outlines are checked against Bravura's own `glyphBBoxes`. A misread curve, a
mishandled `hintmask`, or a dropped subroutine call moves a bound and fails.

That test also turned up something worth recording: **Bravura 1.392's metadata disagrees
with its own outlines** by up to 0.0016 staff spaces on four flag glyphs — the same four
whose boxes moved in the 1.38 → 1.392 bump. fontTools' `BoundsPen` agrees with this
extraction, not with the metadata. Hence a tolerance of half a font unit, documented in the
test.

Rendered end-to-end through `rsvg-convert`, which is one of the rasterisers in the issue's
table. Also worth knowing: my machine has Bravura installed but **not** Libertinus, so
`.fontFace` output silently substitutes a different serif for every title, composer, and
footer while the notation renders fine — the drift described in the issue, visible on a
machine where it supposedly "works". `.outlines` renders correctly. `.both` is
pixel-identical to `.outlines`.

## Size

Each distinct glyph is defined once in `<defs>` and drawn with `<use>`, the size living in
the transform rather than the path data, so one definition serves every size it appears at.
A tunebook page: **1.57 MB → 121 KB**, 401 glyph placements over 66 definitions.

`<use>` carries both `href` and `xlink:href`, rasterisers being split on which they honour.

## Breaking change for consumers

Emitted documents change shape (`<use>` against `<defs>` rather than `<text>`), and text is
no longer selectable unless the host asks for `.both`. Anything inspecting emitted `<text>`
elements needs updating — as this repo's own suites did, extensively.

Suites that read layout back out of `<text>` attributes are pinned to `.fontFace` via a
shared `textProbeRenderer`: `<text>` is the direct probe for what they assert, and
re-deriving positions from a `<use>` transform would test the parsing helper as much as the
layout. That also keeps `.fontFace` exercised end-to-end now that nothing else reaches it.
The tie/slur arc counts moved to matching `<path d=` instead, which distinguishes drawn arcs
from `<defs>` outlines, so those keep running against the real default.

## Also

- `ckprobe` follows the library default and gains `--font-face`.
- The integration snapshot records default output, with outline data elided the way the
  base64 blob already was; a second snapshot pins `.fontFace`.
- `CeolKitSVGGeometry` is unaffected — it reads lines and rects — and `ckprobe`'s geometry
  report works against outline documents.

## Testing

`swift test` — 607 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)