### PR TITLE
Fix #41 - give every measure a real source range

### DIFF
--- a/Sources/CeolKitModel/Measure.swift
+++ b/Sources/CeolKitModel/Measure.swift
@@ -12,6 +12,13 @@ public struct Measure: Sendable {
     public let events: [Event]                   // notes, rests, chords, grace groups, ties, …
     public let closingBar: BarLine               // bar at end; may carry repeat info
     public let endingNumber: [Int]?              // |1, |2, [1,2 variant endings
+    /// The text this measure occupies: from its first event that has a position
+    /// in the source through the end of `closingBar`.
+    ///
+    /// `line`/`column` are those of the start, so a measure carried over a line
+    /// break reports the line its music begins on. The opening barline is not
+    /// included — it commonly sits at the end of the previous source line, and it
+    /// is already the `closingBar` of the preceding measure.
     public let source: SourceRange
     /// Non-nil when an inline `[M:…]` field changed the meter before this measure.
     /// A renderer should draw the corresponding time-signature glyph before the first note.

--- a/Sources/CeolKitModel/SourceRange.swift
+++ b/Sources/CeolKitModel/SourceRange.swift
@@ -26,3 +26,8 @@ public struct SourceRange: Hashable, Identifiable, Sendable, Codable {
         self.column = column
     }
 }
+
+public extension SourceRange {
+    /// Last-resort position for something the parser synthesised with no text behind it.
+    static let emptySourceRange = SourceRange(file: nil, byteOffset: 0, length: 0, line: 1, column: 1)
+}

--- a/Sources/CeolKitParser/Semantic/EventSource.swift
+++ b/Sources/CeolKitParser/Semantic/EventSource.swift
@@ -1,0 +1,77 @@
+//
+//  EventSource.swift
+//  CeolKit
+//
+//  Source-position helpers shared by the semantic pass: where an event sits in
+//  the ABC text, and how a measure's extent is derived from the events it holds.
+//
+
+import Foundation
+import CeolKitModel
+
+/// Last-resort position for something the parser synthesised with no text behind it.
+let emptySourceRange = SourceRange(file: nil, byteOffset: 0, length: 0, line: 1, column: 1)
+
+/// The position an event occupies in the source, when it has one.
+///
+/// `.directiveAnchor` and `.tempoChange` are positionless: they are effects of a
+/// field elsewhere in the line, not text of their own.
+func eventSourceRange(_ event: Event) -> SourceRange? {
+    switch event {
+    case .note(let n): return n.source
+    case .rest(let r): return r.source
+    case .chord(let c): return c.source
+    case .grace(let g): return g.source
+    case .tuplet(let t): return t.source
+    case .spacer(let s): return s.source
+    case .directiveAnchor: return nil
+    case .tempoChange: return nil
+    }
+}
+
+/// True for the zero-width spacers the semantic pass emits at every whitespace
+/// run to break beam groups.
+func isSpacerEvent(_ event: Event) -> Bool {
+    if case .spacer = event { return true }
+    return false
+}
+
+/// A range starting at `start` and reaching the end of `end`.
+///
+/// Line and column stay those of `start`, so a measure reports the line its
+/// music begins on even when it runs past a line break.
+func sourceSpan(from start: SourceRange, through end: SourceRange) -> SourceRange {
+    let endOffset = max(start.byteOffset + start.length, end.byteOffset + end.length)
+    return SourceRange(
+        file: start.file ?? end.file,
+        byteOffset: start.byteOffset,
+        length: endOffset - start.byteOffset,
+        line: start.line,
+        column: start.column
+    )
+}
+
+/// The extent a `Measure` should report: from its first event that occupies
+/// source text through the end of its closing barline.
+///
+/// Leading spacers are skipped — idiomatic ABC puts a space right after every
+/// barline, and a beam break is not where the measure starts. The opening
+/// barline is likewise not the start: it commonly sits at the end of the
+/// *previous* source line, which would misreport the measure's line. It is used
+/// only when the measure has no positioned events at all (e.g. a bar carrying
+/// nothing but a variant-ending number).
+func measureSourceSpan(
+    events: [Event],
+    openingBar: BarLine?,
+    closingBar: BarLine,
+    fallback: SourceRange
+) -> SourceRange {
+    let start = events.lazy
+        .filter { !isSpacerEvent($0) }
+        .compactMap(eventSourceRange)
+        .first
+        ?? events.lazy.compactMap(eventSourceRange).first
+        ?? openingBar?.source
+        ?? fallback
+    return sourceSpan(from: start, through: closingBar.source)
+}

--- a/Sources/CeolKitParser/Semantic/EventSource.swift
+++ b/Sources/CeolKitParser/Semantic/EventSource.swift
@@ -9,9 +9,6 @@
 import Foundation
 import CeolKitModel
 
-/// Last-resort position for something the parser synthesised with no text behind it.
-let emptySourceRange = SourceRange(file: nil, byteOffset: 0, length: 0, line: 1, column: 1)
-
 /// The position an event occupies in the source, when it has one.
 ///
 /// `.directiveAnchor` and `.tempoChange` are positionless: they are effects of a

--- a/Sources/CeolKitParser/Semantic/SemanticPass.swift
+++ b/Sources/CeolKitParser/Semantic/SemanticPass.swift
@@ -47,7 +47,7 @@ struct SemanticPass {
             dialect = dialectHint ?? .loose
         }
 
-        let fileSource = file.tunes.first?.source ?? emptySource
+        let fileSource = file.tunes.first?.source ?? emptySourceRange
 
         var tunes: [Tune] = []
         for (idx, abcTune) in file.tunes.enumerated() {
@@ -395,8 +395,8 @@ struct SemanticPass {
         case .endingNumber(let nums, _):
             ctx.pendingEndingNumber = nums
 
-        case .space:
-            ctx.emitSpaceBreak()
+        case .space(let src):
+            ctx.emitSpaceBreak(source: src)
             ctx.lastElementWasSpace = true
 
         case .brokenRhythm:
@@ -768,10 +768,6 @@ struct SemanticPass {
         )
     }
 
-    private var emptySource: SourceRange {
-        SourceRange(file: nil, byteOffset: 0, length: 0, line: 1, column: 1)
-    }
-
     // Chord symbol parsing: minimal stub — preserves raw text without structural parsing
     private func parseChordSymbol(_ raw: String, source: SourceRange) -> ChordSymbol? {
         guard !raw.isEmpty else { return nil }
@@ -1005,9 +1001,15 @@ struct SemanticPass {
         if !acc.currentEvents.isEmpty {
             let finalBar = BarLine(
                 kind: .final,
-                source: acc.currentEvents.last.flatMap { eventSource($0) } ?? emptySource
+                source: acc.currentEvents.reversed().lazy
+                    .compactMap(eventSourceRange).first ?? emptySourceRange
             )
-            let src = acc.currentEvents.first.flatMap { eventSource($0) } ?? emptySource
+            let src = measureSourceSpan(
+                events: acc.currentEvents,
+                openingBar: acc.lastBarLine,
+                closingBar: finalBar,
+                fallback: acc.measureSource
+            )
             let finalMeasure = Measure(
                 openingBar: acc.lastBarLine,
                 events: acc.currentEvents,
@@ -1075,19 +1077,6 @@ struct SemanticPass {
             )
         }
         return (beamResolved, diagnostics)
-    }
-
-    private func eventSource(_ event: Event) -> SourceRange? {
-        switch event {
-        case .note(let n): return n.source
-        case .rest(let r): return r.source
-        case .chord(let c): return c.source
-        case .grace(let g): return g.source
-        case .tuplet(let t): return t.source
-        case .spacer(let s): return s.source
-        case .directiveAnchor: return nil
-        case .tempoChange: return nil
-        }
     }
 
     private func defaultVoiceProperties() -> VoiceProperties {
@@ -1187,7 +1176,12 @@ struct VoiceAccumulator {
             lastBarLine = barLine
             return
         }
-        let src = currentEvents.first.flatMap { eventSource($0) } ?? measureSource
+        let src = measureSourceSpan(
+            events: currentEvents,
+            openingBar: lastBarLine,
+            closingBar: barLine,
+            fallback: measureSource
+        )
         let meterTag = pendingMeter
         pendingMeter = nil
         let measure = Measure(
@@ -1201,19 +1195,6 @@ struct VoiceAccumulator {
         closedMeasures.append(measure)
         currentEvents = []
         lastBarLine = barLine
-    }
-
-    private func eventSource(_ event: Event) -> SourceRange? {
-        switch event {
-        case .note(let n): return n.source
-        case .rest(let r): return r.source
-        case .chord(let c): return c.source
-        case .grace(let g): return g.source
-        case .tuplet(let t): return t.source
-        case .spacer(let s): return s.source
-        case .directiveAnchor: return nil
-        case .tempoChange: return nil
-        }
     }
 }
 
@@ -1299,14 +1280,6 @@ private struct BodyContext {
         order.compactMap { id in voiceData[id].map { (id, $0) } }
     }
 
-    mutating func currentAccumulator() -> VoiceAccumulator {
-        if voiceData[currentVoiceId] == nil {
-            let src = SourceRange(file: nil, byteOffset: 0, length: 0, line: 1, column: 1)
-            voiceData[currentVoiceId] = VoiceAccumulator(source: src, unitNoteLength: unitNoteLength)
-        }
-        return voiceData[currentVoiceId]!
-    }
-
     mutating func emit(_ event: Event) {
         if inGrace {
             // Grace notes are accumulated; the note itself was already added to graceNotes
@@ -1321,19 +1294,18 @@ private struct BodyContext {
             return
         }
         voiceData[currentVoiceId, default: VoiceAccumulator(
-            source: SourceRange(file: nil, byteOffset: 0, length: 0, line: 1, column: 1),
+            source: eventSourceRange(event) ?? emptySourceRange,
             unitNoteLength: unitNoteLength
         )].currentEvents.append(event)
     }
 
-    mutating func emitSpaceBreak() {
-        let src = SourceRange(file: nil, byteOffset: 0, length: 0, line: 1, column: 1)
-        emit(.spacer(Spacer(width: 0, source: src)))
+    mutating func emitSpaceBreak(source: SourceRange) {
+        emit(.spacer(Spacer(width: 0, source: source)))
     }
 
     mutating func closeCurrentMeasure(barLine: BarLine) {
         voiceData[currentVoiceId, default: VoiceAccumulator(
-            source: SourceRange(file: nil, byteOffset: 0, length: 0, line: 1, column: 1),
+            source: barLine.source,
             unitNoteLength: unitNoteLength
         )].closeWith(barLine: barLine, endingNumber: pendingEndingNumber)
         pendingEndingNumber = nil
@@ -1375,7 +1347,7 @@ private struct BodyContext {
     }
 
     mutating func flushGrace(source: SourceRange? = nil) {
-        let src = source ?? graceSource ?? SourceRange(file: nil, byteOffset: 0, length: 0, line: 1, column: 1)
+        let src = source ?? graceSource ?? emptySourceRange
         let kind: GraceKind = graceAcciaccatura ? .acciaccatura : .appoggiatura
         let group = GraceGroup(kind: kind, notes: graceNotes, source: src)
         inGrace = false

--- a/Sources/CeolKitParser/Semantic/SemanticPass.swift
+++ b/Sources/CeolKitParser/Semantic/SemanticPass.swift
@@ -47,7 +47,7 @@ struct SemanticPass {
             dialect = dialectHint ?? .loose
         }
 
-        let fileSource = file.tunes.first?.source ?? emptySourceRange
+        let fileSource = file.tunes.first?.source ?? .emptySourceRange
 
         var tunes: [Tune] = []
         for (idx, abcTune) in file.tunes.enumerated() {
@@ -1002,7 +1002,7 @@ struct SemanticPass {
             let finalBar = BarLine(
                 kind: .final,
                 source: acc.currentEvents.reversed().lazy
-                    .compactMap(eventSourceRange).first ?? emptySourceRange
+                    .compactMap(eventSourceRange).first ?? .emptySourceRange
             )
             let src = measureSourceSpan(
                 events: acc.currentEvents,
@@ -1294,7 +1294,7 @@ private struct BodyContext {
             return
         }
         voiceData[currentVoiceId, default: VoiceAccumulator(
-            source: eventSourceRange(event) ?? emptySourceRange,
+            source: eventSourceRange(event) ?? .emptySourceRange,
             unitNoteLength: unitNoteLength
         )].currentEvents.append(event)
     }
@@ -1347,7 +1347,7 @@ private struct BodyContext {
     }
 
     mutating func flushGrace(source: SourceRange? = nil) {
-        let src = source ?? graceSource ?? emptySourceRange
+        let src = source ?? graceSource ?? .emptySourceRange
         let kind: GraceKind = graceAcciaccatura ? .acciaccatura : .appoggiatura
         let group = GraceGroup(kind: kind, notes: graceNotes, source: src)
         inGrace = false

--- a/Sources/ckprobe/Report.swift
+++ b/Sources/ckprobe/Report.swift
@@ -20,8 +20,9 @@ struct Report: Codable {
 
     struct Stave: Codable {
         let measureCount: Int
-        /// `Measure.source.line` for each measure.  A run of `1`s here is CeolKit #41,
-        /// not a source file that really is all on line 1.
+        /// `Measure.source.line` for each measure.  These should track the source
+        /// lines the music is written on; a run of `1`s means the semantic pass has
+        /// lost the positions again (the defect behind CeolKit #41).
         let measureSourceLines: [Int]
     }
 

--- a/Tests/CeolKitParserTests/MeasureSourceTests.swift
+++ b/Tests/CeolKitParserTests/MeasureSourceTests.swift
@@ -1,0 +1,149 @@
+import Testing
+import CeolKitModel
+import CeolKitParser
+
+/// Regression tests for #41: `Measure.source` used to be a fabricated
+/// `line 1, column 1, offset 0, length 0` for every measure that did not begin
+/// the stave, because the semantic pass dropped the whitespace element's real
+/// range and the measure adopted the resulting zeroed spacer.
+@Suite("Measure source ranges")
+struct MeasureSourceTests {
+
+    /// Byte offset of the first occurrence of `needle`, for expressing expected
+    /// ranges as "the range of this text" rather than as magic numbers.
+    private func offset(of needle: String, in source: String) -> Int {
+        guard let range = source.range(of: needle) else {
+            Issue.record("fixture does not contain \(needle)")
+            return -1
+        }
+        return source.utf8.distance(from: source.utf8.startIndex, to: range.lowerBound.samePosition(in: source.utf8)!)
+    }
+
+    private static let threeStaves = """
+    X:1
+    T:t
+    M:C
+    L:1/8
+    K:C
+    CDEF GABc | cBAG FEDC |
+    |: CDEF GABc | cBAG FEDC :|
+    CDEF GABc | cBAG FEDC |
+    """
+
+    @Test("Every measure reports the source line its music is on")
+    func measureLinesFollowTheSource() {
+        let measures = parse(Self.threeStaves).score.firstTune?.singleVoiceMeasures ?? []
+        #expect(measures.count == 6)
+        #expect(measures.map(\.source.line) == [6, 6, 7, 7, 8, 8])
+    }
+
+    @Test("No measure falls back to the synthetic default range")
+    func noMeasureUsesTheFabricatedDefault() {
+        let measures = parse(Self.threeStaves).score.firstTune?.singleVoiceMeasures ?? []
+        #expect(!measures.isEmpty)
+        for measure in measures {
+            #expect(measure.source.byteOffset > 0)
+            #expect(measure.source.length > 1)
+        }
+        // Distinct positions: no two measures claim the same spot in the file.
+        #expect(Set(measures.map(\.source.byteOffset)).count == measures.count)
+    }
+
+    @Test("A measure spans from its first note through its closing barline")
+    func measureSpansItsOwnText() {
+        let src = Self.threeStaves
+        let measures = parse(src).score.firstTune?.singleVoiceMeasures ?? []
+
+        // Stave 0, measure 0: "CDEF GABc |" — starts at the first note, ends
+        // after the barline that closes it.
+        let first = measures[0].source
+        #expect(first.byteOffset == offset(of: "CDEF GABc |", in: src))
+        #expect(first.column == 1)
+        #expect(src.utf8Slice(at: first) == "CDEF GABc |")
+
+        // Stave 1 opens with "|:" — the measure still starts at its first note,
+        // not at the barline, and not at the leading spacer after it.
+        let repeated = measures[2].source
+        #expect(repeated.line == 7)
+        #expect(src.utf8Slice(at: repeated) == "CDEF GABc |")
+
+        // Last measure of the repeated stave closes on ":|".
+        #expect(src.utf8Slice(at: measures[3].source) == "cBAG FEDC :|")
+    }
+
+    @Test("A measure with no closing barline still spans its events")
+    func finalMeasureWithoutBarline() {
+        let src = """
+        X:1
+        T:t
+        L:1/8
+        K:C
+        CDEF GABc | cBAG FEDC
+        """
+        let measures = parse(src).score.firstTune?.singleVoiceMeasures ?? []
+        #expect(measures.count == 2)
+        #expect(measures.map(\.source.line) == [5, 5])
+        #expect(src.utf8Slice(at: measures[1].source) == "cBAG FEDC")
+    }
+
+    @Test("A measure continued onto the next line spans the break")
+    func measureSpanningALineBreak() {
+        let src = """
+        X:1
+        T:t
+        M:C
+        L:1/8
+        K:C
+        CDEF GABc | cBAG
+        FEDC | CDEF GABc |
+        """
+        let measures = parse(src).score.firstTune?.singleVoiceMeasures ?? []
+        #expect(measures.count == 3)
+        // The second measure starts on line 6 and closes on line 7.
+        #expect(measures[1].source.line == 6)
+        #expect(src.utf8Slice(at: measures[1].source) == "cBAG\nFEDC |")
+        #expect(measures[2].source.line == 7)
+    }
+
+    @Test("Spacers carry the range of the whitespace they came from")
+    func spacersArePositioned() {
+        let src = Self.threeStaves
+        let measures = parse(src).score.firstTune?.singleVoiceMeasures ?? []
+        let spacers: [Spacer] = measures.flatMap { measure in
+            measure.events.compactMap { if case .spacer(let s) = $0 { s } else { nil } }
+        }
+        #expect(!spacers.isEmpty)
+        for spacer in spacers {
+            #expect(spacer.source.byteOffset > 0)
+            #expect(src.utf8Slice(at: spacer.source) == " ")
+        }
+    }
+
+    @Test("Measures stay positioned when the stave opens with a barline")
+    func staveOpeningWithBarline() {
+        let src = """
+        X:1
+        T:t
+        L:1/8
+        K:C
+        [|: CDEF GABc | cBAG FEDC :|]
+        [|: GABc CDEF | FEDC cBAG :|]
+        """
+        let measures = parse(src).score.firstTune?.singleVoiceMeasures ?? []
+        #expect(measures.count == 4)
+        #expect(measures.map(\.source.line) == [5, 5, 6, 6])
+        #expect(src.utf8Slice(at: measures[0].source) == "CDEF GABc |")
+        #expect(src.utf8Slice(at: measures[3].source) == "FEDC cBAG :|]")
+    }
+}
+
+private extension String {
+    /// The text a `SourceRange` covers, by UTF-8 offset and length.
+    func utf8Slice(at range: SourceRange) -> String? {
+        let bytes = Array(utf8)
+        guard range.byteOffset >= 0,
+              range.length >= 0,
+              range.byteOffset + range.length <= bytes.count else { return nil }
+        return String(decoding: bytes[range.byteOffset..<(range.byteOffset + range.length)], as: UTF8.self)
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/ScrollSyncAnchorTests.swift
+++ b/Tests/CeolKitSVGRendererTests/ScrollSyncAnchorTests.swift
@@ -1,0 +1,81 @@
+//
+//  ScrollSyncAnchorTests.swift
+//  CeolKitSVGRendererTests
+//
+//  End-to-end cover for issue #41: the `ceolkit-meta` scroll-sync anchors (#25)
+//  reported "abcLine": 1 for most systems, because `Measure.source` was a
+//  fabricated zero range for every measure that did not open its stave.
+//
+
+import CeolKitModel
+import CeolKitParser
+import CeolKitSVGGeometry
+import Foundation
+import Testing
+@testable import CeolKitSVGRenderer
+
+@Suite("Scroll-sync anchors")
+struct ScrollSyncAnchorTests {
+
+    /// Six music lines, three of which open with a barline — the shape that used
+    /// to collapse to line 1. Wide enough to keep one system per source line.
+    private static let sixLineTune = """
+    %abc-2.2
+    %%landscape 1
+    X:1
+    T:Archie Duncan
+    R:March
+    M:C
+    L:1/8
+    K:A
+    [|: cd | e2 ce a2 ec | d2 Bd f2 dB | e2 ce a2 ec | Bcde f2 ed |
+    e2 ce a2 ec | d2 Bd f2 dB | cBAB cdef | e2 A2 A2 :|
+    ef | a2 ea c'2 ac' | b2 fb d'2 bd' | a2 ea c'2 ac' | bagf e2 ef |
+    [|: a2 ea c'2 ac' | b2 fb d'2 bd' | c'bag fedc | B2 A2 A2 :|
+    cBAB cdef | e2 A2 A2 ef | a2 ea c'2 ac' | b2 fb d'2 bd' |
+    c'bag fedc | B2 A2 A2 z2 |]
+    """
+
+    private func anchorLines(_ abc: String) throws -> [Int] {
+        let score = CeolKitParser().parse(abc, options: .default).score
+        var config = SVGRenderConfig()
+        for scope in score.tunes.first?.directives ?? [] {
+            if case .landscape(true) = scope.directive { config.pageSize = config.pageSize.landscape }
+        }
+        let pages = try SVGRenderer(config: config).render(score)
+        return pages.flatMap { page in
+            CeolKitMeta.extract(from: page)?.anchors.map(\.abcLine) ?? []
+        }
+    }
+
+    @Test("Anchors report the source line of the music, not line 1")
+    func anchorsFollowSourceLines() throws {
+        let lines = try anchorLines(Self.sixLineTune)
+        #expect(!lines.isEmpty)
+        // The music starts on source line 9; nothing may claim the version line.
+        #expect(lines.allSatisfy { $0 >= 9 })
+    }
+
+    @Test("Anchors are non-decreasing and cover every music line")
+    func anchorsAdvanceThroughTheSource() throws {
+        let lines = try anchorLines(Self.sixLineTune)
+        #expect(lines == lines.sorted())
+        // Each of the six music lines (9…14) is the origin of at least one system.
+        #expect(Set(lines) == Set(9...14))
+    }
+
+    @Test("A tune whose staves each fit one system anchors one system per line")
+    func oneSystemPerSourceLine() throws {
+        let abc = """
+        X:1
+        T:t
+        M:C
+        L:1/8
+        K:C
+        CDEF GABc | cBAG FEDC |
+        |: CDEF GABc | cBAG FEDC :|
+        CDEF GABc | cBAG FEDC |
+        """
+        #expect(try anchorLines(abc) == [6, 7, 8])
+    }
+}


### PR DESCRIPTION
Fixes #41.

## The defect

`SemanticPass` dropped the `SourceRange` the AST already carries for a whitespace element and fabricated a zeroed one in its place. Because idiomatic ABC puts a space right after the barline, that spacer was the first event of nearly every measure — and a measure took its position from its first event. Most measures therefore reported `line 1, column 1, offset 0, length 0`, and the `ceolkit-meta` scroll-sync anchors from #25 claimed four of seven systems came from line 1.

## The fix

- **Thread the real range through.** `case .space(let src)` now feeds `emitSpaceBreak(source:)`, so `Spacer.source` is correct everywhere. That alone removes the fabricated range measures were adopting.
- **Make `Measure.source` a span**, not a point: from the measure's first *positioned, non-spacer* event through the end of its closing barline. This also fixes `length`, which was always `1` — the extent of the first token rather than of the measure.
- The opening barline is only a **fallback** for the start, not the preferred source. It commonly sits at the end of the *previous* source line, so taking the line from it would misreport measures at line boundaries. This is a deliberate departure from suggestion 2 in the issue.
- New `Sources/CeolKitParser/Semantic/EventSource.swift` holds the shared helpers (`eventSourceRange`, `sourceSpan(from:through:)`, `measureSourceSpan(...)`) and the single `emptySourceRange` sentinel, replacing five hardcoded copies and two duplicate private `eventSource` methods. The unused `currentAccumulator()` goes with them.
- `Measure.source` gains a doc comment stating the contract.

## Tests

643 pass, up from 633.

- `Tests/CeolKitParserTests/MeasureSourceTests.swift` (7) covers the domain model directly: source lines follow the music, no measure keeps the synthetic default, ranges slice back to exactly the measure's text, staves opening with `[|:`, a measure carried across a line break, an unterminated final measure, and positioned spacers.
- `Tests/CeolKitSVGRendererTests/ScrollSyncAnchorTests.swift` (3) renders end-to-end and decodes the emitted `ceolkit-meta`: anchors are non-decreasing, never claim line 1, and give `[6, 7, 8]` for the issue's repro.

Both were verified against the previous behaviour by reverting `SemanticPass` — measure lines came back as `[6, 1, 1, 1, 8, 1]` and the text slices as `"C"` / `""`, exactly the defect in the report.

## Left alone

- The `previous + 1` fallback in `VerticalLayoutEngine.resolvedAbcLine`, which the issue flagged as dead code. It is no longer masked by bogus line-1 values, and it remains the right guard for a system with no measures.
- `Source.range(line:column:)` computes `byteOffset` as `lineByteOffset + (column - 1)`, which is character- rather than byte-based. That is wrong for non-ASCII field text, but it is a separate pre-existing defect on the field path, not the music path this issue covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqNzDQMPUi6LRfb4b4KuzY