### PR TITLE
Release 1.2.1

### DIFF
--- a/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
@@ -577,9 +577,11 @@ struct SVGEmitter: Sendable {
                          stroke: "black", strokeWidth: thin)
 
         case .double:
-            builder.line(x1: bar.x,       y1: topY, x2: bar.x,       y2: bottomY,
+            // Right-anchored: trailing thin bar at bar.x, leading thin bar to its left,
+            // so the pair ends where the staff lines end at a system break.
+            builder.line(x1: bar.x - sep, y1: topY, x2: bar.x - sep, y2: bottomY,
                          stroke: "black", strokeWidth: thin)
-            builder.line(x1: bar.x + sep, y1: topY, x2: bar.x + sep, y2: bottomY,
+            builder.line(x1: bar.x,       y1: topY, x2: bar.x,       y2: bottomY,
                          stroke: "black", strokeWidth: thin)
 
         case .final:

--- a/Sources/CeolKitSVGRenderer/Layout/MeasureSizer.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/MeasureSizer.swift
@@ -169,10 +169,11 @@ public struct MeasureSizer: Sendable {
 
     /// Right padding after the last event column.
     ///
-    /// Compound closing bars (final, repeat-end) are drawn right-anchored so their
-    /// thick bar's trailing edge aligns with other lines' thin bar edges.  The thin
-    /// bar sits `wideSep` to the left of that anchor, so the padding must be large
-    /// enough to keep the thin bar clear of the last note.
+    /// Compound closing bars (final, repeat-end, double) are drawn right-anchored so
+    /// their trailing edge aligns with other lines' thin bar edges.  The leading bar
+    /// sits to the left of that anchor — `wideSep` for the thick-barred kinds, `sep`
+    /// for the thin-thin double bar — so the padding must be large enough to keep it
+    /// clear of the last note.
     private func rightPadding(for measure: Measure) -> Double {
         let s       = config.staffSize
         let sep     = metadata.engravingDefaults.barlineSeparation * s
@@ -180,6 +181,8 @@ public struct MeasureSizer: Sendable {
         switch measure.closingBar.kind {
         case .final, .repeatEnd, .repeatEndSection, .repeatBoth:
             return wideSep + s * 0.5
+        case .double:
+            return sep + s * 0.5
         default:
             return s * 0.5
         }

--- a/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
@@ -352,24 +352,30 @@ public struct VerticalLayoutEngine: Sendable {
                 )
             }
 
-            // At the start of a system (i == 0), suppress any opening bar that was
-            // inherited from the previous system's closing bar (e.g. a lone `|`).
-            // Only explicit section-start markers ([|, [|:, |:, ::) are drawn at a
-            // system start; everything else would appear as a spurious bar line between
-            // the clef/key signature and the first note.
-            let openingBar: ResolvedBarLine?
-            if i == 0, let bar = jm.source.measure.openingBar {
-                switch bar.kind {
-                case .start, .sectionRepeatStart, .repeatStart, .repeatBoth:
-                    openingBar = ResolvedBarLine(x: measureOrigin.x, kind: bar.kind)
-                default:
-                    openingBar = nil
+            // A bar line between two measures belongs to both of them: the semantic
+            // pass stores the same `BarLine` as the left measure's `closingBar` and
+            // the right measure's `openingBar`.  Both resolve to the same x, so only
+            // one of the two is kept — the closing one — and the duplicate opening
+            // bar is dropped rather than emitted a second time on top of itself.
+            //
+            // At the start of a system (i == 0) the inherited bar is the *previous
+            // system's* closing bar, so it is dropped too, except for explicit
+            // section-start markers ([|, [|:, |:, ::), which are conventionally
+            // restated at the start of a line.  Anything else would appear as a
+            // spurious bar line between the clef/key signature and the first note.
+            let openingBar: ResolvedBarLine? = {
+                guard let bar = jm.source.measure.openingBar else { return nil }
+                guard i > 0 else {
+                    switch bar.kind {
+                    case .start, .sectionRepeatStart, .repeatStart, .repeatBoth:
+                        return ResolvedBarLine(x: measureOrigin.x, kind: bar.kind)
+                    default:
+                        return nil
+                    }
                 }
-            } else {
-                openingBar = jm.source.measure.openingBar.map {
-                    ResolvedBarLine(x: measureOrigin.x, kind: $0.kind)
-                }
-            }
+                guard bar != measures[i - 1].source.measure.closingBar else { return nil }
+                return ResolvedBarLine(x: measureOrigin.x, kind: bar.kind)
+            }()
             let closingBar = ResolvedBarLine(
                 x: measureOrigin.x + jm.finalWidth,
                 kind: jm.source.measure.closingBar.kind

--- a/Tests/CeolKitSVGRendererTests/SVGEmitterTests.swift
+++ b/Tests/CeolKitSVGRendererTests/SVGEmitterTests.swift
@@ -289,6 +289,31 @@ private let quarterUNL = Fraction(numerator: 1, denominator: 4)
         #expect(lineCount == 7)
     }
 
+    /// A `||` closing a system is right-anchored, so both thin bars land on the staff:
+    /// the trailing one at the staff's right end and the leading one `sep` to its left.
+    /// Regression test for #54, where the second bar was drawn past the end of the staff.
+    @Test func doubleBarLineIsRightAnchoredWithinTheStaff() throws {
+        let barX = 236.0
+        let measure = ResolvedMeasure(
+            origin: Point(x: 36, y: 50),
+            width: 200,
+            events: [],
+            openingBar: nil,
+            closingBar: ResolvedBarLine(x: barX, kind: .double)
+        )
+        let svgs = try emitter.emit(layout(systems: [system(measures: [measure])]))
+        let svg  = try #require(svgs.first)
+        let b = SVGBuilder()
+        let sep = metadata.engravingDefaults.barlineSeparation * config.staffSize
+
+        // Staff lines end at the measure's right edge, which is where the trailing bar sits.
+        #expect(svg.contains("x2=\"\(b.fmt(barX))\""))
+        #expect(svg.contains("x1=\"\(b.fmt(barX))\" y1="))
+        #expect(svg.contains("x1=\"\(b.fmt(barX - sep))\" y1="))
+        // Nothing is drawn to the right of the staff.
+        #expect(!svg.contains("x1=\"\(b.fmt(barX + sep))\""))
+    }
+
     // MARK: Empty layout
 
     @Test func emptyLayoutProducesEmptyArray() throws {

--- a/Tests/CeolKitSVGRendererTests/VerticalLayoutTests.swift
+++ b/Tests/CeolKitSVGRendererTests/VerticalLayoutTests.swift
@@ -13,6 +13,17 @@ private func emptyMeasure(line: Int = 0) -> Measure {
     return Measure(openingBar: nil, events: [], closingBar: dummyBar, endingNumber: nil, source: source)
 }
 
+/// Distinct source range per bar, so two `BarLine`s compare unequal unless they
+/// really are the same symbol.
+private func barSource(byteOffset: Int) -> SourceRange {
+    SourceRange(file: nil, byteOffset: byteOffset, length: 1, line: 0, column: byteOffset)
+}
+
+private func measure(opening: BarLine?, closing: BarLine) -> Measure {
+    Measure(openingBar: opening, events: [], closingBar: closing,
+            endingNumber: nil, source: dummyRange)
+}
+
 private func measureWith(events: [Event]) -> Measure {
     Measure(openingBar: nil, events: events, closingBar: dummyBar, endingNumber: nil, source: dummyRange)
 }
@@ -144,6 +155,38 @@ private let metadata      = try! BravuraMetadata.load()
         for m in layout.pages[0].systems[0].measures {
             #expect(abs(m.closingBar.x - (m.origin.x + m.width)) < 1e-9)
         }
+    }
+
+    // A bar line shared by two adjacent measures is resolved once, as the left
+    // measure's closing bar; the right measure's inherited opening bar is dropped
+    // so it is not emitted a second time on top of itself (issue #54).
+    @Test func sharedBarLineIsNotResolvedTwice() {
+        let shared = BarLine(kind: .double, source: barSource(byteOffset: 10))
+        let system = justifiedSystem(
+            measures: [
+                measure(opening: nil, closing: shared),
+                measure(opening: shared, closing: dummyBar)
+            ],
+            isLast: true
+        )
+        let measures = engine.layout([system]).pages[0].systems[0].measures
+        #expect(measures[0].closingBar.kind == .double)
+        #expect(measures[1].openingBar == nil)
+    }
+
+    // A bar that is *not* the preceding measure's closing bar is still drawn — only
+    // the inherited duplicate is suppressed.
+    @Test func distinctOpeningBarIsStillResolved() {
+        let system = justifiedSystem(
+            measures: [
+                measure(opening: nil, closing: BarLine(kind: .single, source: barSource(byteOffset: 10))),
+                measure(opening: BarLine(kind: .repeatStart, source: barSource(byteOffset: 20)),
+                        closing: dummyBar)
+            ],
+            isLast: true
+        )
+        let measures = engine.layout([system]).pages[0].systems[0].measures
+        #expect(measures[1].openingBar?.kind == .repeatStart)
     }
 
     // ResolvedSystem.abcLine (issue #25) is taken from the first measure's source line.


### PR DESCRIPTION
Cuts release 1.2.1 from `develop`.

Verified locally before opening: `swift build` clean, `swift test` green — 661 tests in 46 suites.

## What's in it

* Fix #54 — right-anchor `||` and stop drawing shared bar lines twice (#55)

A patch release: one rendering fix, no API changes.

When a system ended with a thin-thin double bar, the staff lines stopped at the first bar
and the second one hung `barlineSeparation` past the end of the staff — and past the page's
right margin. `.double` is now right-anchored like every other compound bar, so the pair
ends where the staff ends, and `MeasureSizer` reserves the space it occupies.

Fixing that exposed a second problem: because the semantic pass stores the same `BarLine`
as one measure's `closingBar` and the next measure's `openingBar`, *every* interior bar
line was being emitted twice, drawn on top of itself. The layout engine now resolves each
shared bar once.

## Behaviour changes for consumers

None to the API. Rendered output changes in two ways:

* A system ending in `||` engraves correctly. Any layout containing one shifts by a
  fraction of a point, since that measure now reserves room for the leading bar.
* SVG output is smaller — roughly 15–20 fewer `<line>` elements per page on a typical
  tunebook page, with no visual difference. Verified page by page against
  `tunebook.abc`: on 15 of its 16 pages the set of distinct `<line>` elements is
  byte-identical to 1.2.0, the duplicates simply gone.
