### PR TITLE
Fix #58 — engrave a tune's voices as the aligned staves of one system

### DIFF
--- a/Sources/CeolKitModel/Diagnostic.swift
+++ b/Sources/CeolKitModel/Diagnostic.swift
@@ -38,6 +38,10 @@ public enum DiagnosticCode: String, Codable, Sendable {
     case constructOutOfOrder
     case reservedCharacter
     case danglingTie
+    /// Two voices of the same tune disagree about how much music a source line holds,
+    /// so the staves of a system cannot be aligned from the source alone.  The renderer
+    /// pads the short voice with invisible full-measure rests and carries on.
+    case voiceLengthMismatch
     // Fields
     case unknownField
     case malformedFieldPayload

--- a/Sources/CeolKitSVGGeometry/SVGGeometry.swift
+++ b/Sources/CeolKitSVGGeometry/SVGGeometry.swift
@@ -97,6 +97,14 @@ public enum SVGGeometry {
     /// staff's own stroke width is the threshold between them, and it scales with
     /// `%%ceolkit:scale` exactly as the two things being separated do.
     ///
+    /// The stroke has to *start* at the staff's top line, but it is allowed to run past
+    /// the bottom one: in a multi-voice system every staff but the last has its barlines
+    /// carried down to the next staff so the system's barlines read as one stroke.  A note
+    /// stem never starts flush with the top line and outruns the bottom, so admitting the
+    /// overrun costs nothing.  The rule that joins a multi-voice system's staves at the
+    /// left edge outruns the staff too, and is excluded by the same stroke-width test that
+    /// excludes stems: the emitter draws it at the staff lines' own thickness.
+    ///
     /// This reads drawing output rather than the model, so it stays approximate: it
     /// rests on those three constants keeping their present order.
     static func barlines(in lines: [SVGLine], crossing staff: Staff) -> [Double] {
@@ -105,7 +113,7 @@ public enum SVGGeometry {
 
         let xs = lines
             .filter(\.isVertical)
-            .filter { abs($0.y1 - staff.topY) < tolerance && abs($0.y2 - bottomY) < tolerance }
+            .filter { abs($0.y1 - staff.topY) < tolerance && $0.y2 > bottomY - tolerance }
             .filter { line in
                 // Keep the stroke when either width is unknown: better to over-report
                 // than to silently drop barlines from output we don't fully recognise.

--- a/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
+++ b/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
@@ -16,6 +16,19 @@ public struct SVGRenderer: CeolKitRenderer {
 
     /// Returns one SVG string per page.
     public func render(_ score: Score) throws -> [String] {
+        var diagnostics: [Diagnostic] = []
+        return try render(score, diagnostics: &diagnostics)
+    }
+
+    /// Returns one SVG string per page, appending anything the *renderer* had to complain
+    /// about to `diagnostics`.
+    ///
+    /// Separate from `render(_:)` because rendering can discover problems parsing cannot:
+    /// laying two voices out as one system means the voices have to agree about where the
+    /// bar lines fall, and only the renderer is in a position to notice that they do not
+    /// (see `VoiceAligner`).  `Score.diagnostics` is already sealed by then, so the caller
+    /// that wants to report both concatenates them.
+    public func render(_ score: Score, diagnostics: inout [Diagnostic]) throws -> [String] {
         let metadata = try BravuraMetadata.load()
 
         // Apply score-level directives that affect the whole document.
@@ -65,44 +78,58 @@ public struct SVGRenderer: CeolKitRenderer {
             // set after `scaled(by:)` and never multiplied by the scale factor.
             tuneConfig.graceNoteSpacing = graceNoteSpacing
             let sizer = MeasureSizer(config: tuneConfig, metadata: metadata)
-            var tuneSystems: [JustifiedSystem] = []
-            var meterForFirstSystem: Meter? = tune.meter
-            for voice in tune.voices {
-                // Build (measure, breakAfter) pairs honouring stave boundaries.
-                // The semantic pass creates one Staff per source line-break, so the
-                // last measure of every non-final stave gets a .hard score line-break.
-                var pairs: [(measure: SizedMeasure, breakAfter: ScoreLineBreak?)] = []
-                let staves = voice.staves
-                for (si, stave) in staves.enumerated() {
-                    let isLastStave = si == staves.count - 1
-                    for (mi, m) in stave.measures.enumerated() {
-                        let forceBreak = !isLastStave && mi == stave.measures.count - 1
-                        pairs.append((
-                            measure: sizer.size(m, unitNoteLength: tune.unitNoteLength),
-                            breakAfter: forceBreak ? .hard : nil
-                        ))
+
+            // Bring the voices into agreement about how much music each source line holds,
+            // so the break points chosen below are legal for every one of them. Voices that
+            // disagree are padded and warned about rather than laid out sequentially.
+            let alignedStaves = VoiceAligner.align(tune.voices, into: &diagnostics)
+
+            // Flatten the aligned staves into one measure column per bar, carrying the
+            // stave boundaries as .hard breaks: the semantic pass makes one Staff per source
+            // line-break, so the last column of every non-final stave forces a system break.
+            var breaks: [ScoreLineBreak?] = []
+            var columnsPerVoice = [[SizedMeasure]](repeating: [], count: tune.voices.count)
+            for (si, stave) in alignedStaves.enumerated() {
+                let isLastStave = si == alignedStaves.count - 1
+                for column in 0..<stave.measureCount {
+                    breaks.append(!isLastStave && column == stave.measureCount - 1 ? .hard : nil)
+                    for voiceIndex in tune.voices.indices {
+                        columnsPerVoice[voiceIndex].append(
+                            sizer.size(stave.measures[voiceIndex][column],
+                                       unitNoteLength: tune.unitNoteLength))
                     }
                 }
-                guard !pairs.isEmpty else { continue }
-                // Header widths differ between the first system (has time sig) and later ones.
-                let firstHeaderW = systemHeaderWidth(
-                    clef: voice.properties.clef, keySignature: tune.key, meter: meterForFirstSystem,
-                    metadata: metadata, staffSize: tuneConfig.staffSize)
-                let laterHeaderW = systemHeaderWidth(
-                    clef: voice.properties.clef, keySignature: tune.key, meter: nil,
-                    metadata: metadata, staffSize: tuneConfig.staffSize)
-                let systems = breaker.breakIntoSystems(pairs, usableWidth: usableWidth,
-                                                       firstSystemHeaderWidth: firstHeaderW,
-                                                       laterSystemHeaderWidth: laterHeaderW,
-                                                       clef: voice.properties.clef,
-                                                       keySignature: tune.key,
-                                                       meter: meterForFirstSystem)
-                meterForFirstSystem = nil
-                let headerWidths = systems.enumerated().map { i, _ in i == 0 ? firstHeaderW : laterHeaderW }
-                let justified = justifier.justify(systems, usableWidth: usableWidth,
-                                                  justifyLastSystem: justifyLastSystem,
-                                                  systemHeaderWidths: headerWidths)
-                tuneSystems.append(contentsOf: justified)
+            }
+
+            var tuneGroups: [JustifiedSystemGroup] = []
+            if !breaks.isEmpty {
+                let voiceLines = tune.voices.enumerated().map { index, voice in
+                    LineBreaker.VoiceLine(measures: columnsPerVoice[index],
+                                          clef: voice.properties.clef,
+                                          keySignature: tune.key,
+                                          meter: tune.meter)
+                }
+                // Header widths differ between the first system (has time sig) and later
+                // ones, and are the max across the group: the staves of a system have to
+                // start at the same x even when one voice's clef or key signature is wider.
+                let firstHeaderW = tune.voices.reduce(0.0) { widest, voice in
+                    max(widest, systemHeaderWidth(clef: voice.properties.clef, keySignature: tune.key,
+                                                  meter: tune.meter, metadata: metadata,
+                                                  staffSize: tuneConfig.staffSize))
+                }
+                let laterHeaderW = tune.voices.reduce(0.0) { widest, voice in
+                    max(widest, systemHeaderWidth(clef: voice.properties.clef, keySignature: tune.key,
+                                                  meter: nil, metadata: metadata,
+                                                  staffSize: tuneConfig.staffSize))
+                }
+                let groups = breaker.breakIntoGroups(voiceLines, breaks: breaks,
+                                                     usableWidth: usableWidth,
+                                                     firstSystemHeaderWidth: firstHeaderW,
+                                                     laterSystemHeaderWidth: laterHeaderW)
+                let headerWidths = groups.indices.map { $0 == 0 ? firstHeaderW : laterHeaderW }
+                tuneGroups = justifier.justifyGroups(groups, usableWidth: usableWidth,
+                                                     justifyLastSystem: justifyLastSystem,
+                                                     systemHeaderWidths: headerWidths)
             }
 
             // Build the title block for this tune per §6.1.3.
@@ -116,7 +143,7 @@ public struct SVGRenderer: CeolKitRenderer {
             let (titleRows, titleBlockHeight) = SpecTitleBlockBuilder(
                 tune: tune, writeFields: tuneWriteFields, layoutConfig: effectiveConfig
             ).build()
-            tuneBlocks.append(TuneBlock(systems: tuneSystems, titleRows: titleRows,
+            tuneBlocks.append(TuneBlock(systemGroups: tuneGroups, titleRows: titleRows,
                                         titleBlockHeight: titleBlockHeight, scale: scale,
                                         graceNoteSpacing: graceNoteSpacing))
         }

--- a/Sources/CeolKitSVGRenderer/Config/SVGRenderConfig.swift
+++ b/Sources/CeolKitSVGRenderer/Config/SVGRenderConfig.swift
@@ -6,6 +6,13 @@ public struct SVGRenderConfig: Sendable {
     public var staffSize: Double
     /// Vertical gap added between systems within a single tune.
     public var systemGap: Double
+    /// Vertical gap added between the staves *within* one system — the staff group a
+    /// multi-voice tune draws for each source line.
+    ///
+    /// Deliberately smaller than ``systemGap``: the staves of a system are read together,
+    /// so they have to sit closer to each other than the system does to its neighbours,
+    /// or the group stops reading as a unit.  Only tunes with more than one voice use it.
+    public var staffGap: Double
     /// Vertical gap added after the last system of a tune, before the next tune's title block.
     public var tuneGap: Double
     public var justifyLastSystem: Bool
@@ -36,6 +43,7 @@ public struct SVGRenderConfig: Sendable {
         margins: EdgeInsets = EdgeInsets(top: 36, bottom: 36, left: 36, right: 36),
         staffSize: Double = 6.0,
         systemGap: Double? = nil,
+        staffGap: Double? = nil,
         tuneGap: Double? = nil,
         justifyLastSystem: Bool = false,
         straightFlags: Bool = false,
@@ -49,6 +57,7 @@ public struct SVGRenderConfig: Sendable {
         self.margins = margins
         self.staffSize = staffSize
         self.systemGap = systemGap ?? staffSize * 4
+        self.staffGap = staffGap ?? staffSize * 3
         self.tuneGap = tuneGap ?? staffSize * 16
         self.justifyLastSystem = justifyLastSystem
         self.straightFlags = straightFlags
@@ -67,6 +76,7 @@ public struct SVGRenderConfig: Sendable {
         var copy = self
         copy.staffSize = staffSize * factor
         copy.systemGap = systemGap * factor
+        copy.staffGap = staffGap * factor
         copy.tuneGap = tuneGap * factor
         return copy
     }

--- a/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
@@ -128,6 +128,12 @@ struct SVGEmitter: Sendable {
     /// Emits the `ceolkit-meta` comment (issue #25) listing each staff system's
     /// originating ABC source line and page Y coordinate, so editor consumers
     /// (e.g. ScoreEdit) can synchronise scroll position with the source.
+    ///
+    /// One anchor per staff drawn, including each staff of a multi-voice system — the
+    /// geometry reader pairs anchors with staves positionally, so the two counts have to
+    /// match.  The staves of a system all carry the system's line, which leaves the
+    /// sequence monotonic: a consumer keeping only strictly increasing anchors (#41) ends
+    /// up with exactly the top staff of each system, which is the one it wants.
     private func emitScrollSyncMetadata(for page: ResolvedPage, pageNumber: Int, builder: inout SVGBuilder) {
         let anchors = page.systems.map { system in
             "{\"abcLine\": \(system.abcLine), \"y\": \(builder.fmt(system.origin.y))}"
@@ -177,6 +183,7 @@ struct SVGEmitter: Sendable {
                              pendingTies: inout [TieAnchor], pendingSlurs: inout [SlurAnchor],
                              builder: inout SVGBuilder) {
         emitStaffLines(system, builder: &builder)
+        emitStaffGroupConnector(system, builder: &builder)
         emitClef(system, builder: &builder)
         if let keySig = system.keySignature {
             emitKeySignature(keySig, system: system, builder: &builder)
@@ -232,6 +239,27 @@ struct SVGEmitter: Sendable {
             builder.line(x1: leftX, y1: y, x2: rightX, y2: y,
                          stroke: "black", strokeWidth: thickness)
         }
+    }
+
+    /// The vertical rule at the left edge that joins the staves of a multi-voice system.
+    ///
+    /// Without it the staves of a system are just neighbouring staves; with it they read as
+    /// one system, which is what tells a player that the parts are to be followed together.
+    /// Drawn once per group, by its top staff.
+    ///
+    /// Deliberately just the joining rule, and no brace or bracket: which staves a brace or
+    /// bracket spans is a property of `%%score`/`%%staves`, which CeolKit does not parse yet.
+    ///
+    /// Drawn at the staff lines' own weight rather than a barline's.  It is a continuation
+    /// of the staff furniture, so that is what it should look like — and it is what lets
+    /// `CeolKitSVGGeometry` tell it apart from the barlines it now sits alongside, which
+    /// are thicker.
+    private func emitStaffGroupConnector(_ system: ResolvedSystem, builder: inout SVGBuilder) {
+        guard let group = system.staffGroup, group.isGroupLeader else { return }
+        let topY = system.origin.y + system.staffOrigin
+        let thickness = metadata.engravingDefaults.staffLineThickness * config.staffSize
+        builder.line(x1: system.origin.x, y1: topY, x2: system.origin.x, y2: group.bottomY,
+                     stroke: "black", strokeWidth: thickness)
     }
 
     // MARK: - Clef
@@ -371,11 +399,16 @@ struct SVGEmitter: Sendable {
                               builder: inout SVGBuilder) {
         let topY    = system.origin.y + system.staffOrigin
         let bottomY = topY + system.staffHeight
+        // In a multi-staff system the bar lines run on down to the next staff's top line, so
+        // the group's bar lines read as one stroke through the whole system.  Repeat dots
+        // still belong to the staff that owns them, so they keep `bottomY`.
+        let lineBottomY = system.staffGroup?.nextStaffTopY ?? bottomY
 
         if let opening = measure.openingBar {
-            emitBarLine(opening, topY: topY, bottomY: bottomY, builder: &builder)
+            emitBarLine(opening, topY: topY, bottomY: bottomY, lineBottomY: lineBottomY, builder: &builder)
         }
-        emitBarLine(measure.closingBar, topY: topY, bottomY: bottomY, builder: &builder)
+        emitBarLine(measure.closingBar, topY: topY, bottomY: bottomY,
+                    lineBottomY: lineBottomY, builder: &builder)
 
         if let meter = measure.meter {
             let thin = metadata.engravingDefaults.thinBarlineThickness * config.staffSize
@@ -564,37 +597,48 @@ struct SVGEmitter: Sendable {
 
     // MARK: - Bar lines
 
+    /// Draws one bar line.
+    ///
+    /// - Parameters:
+    ///   - topY: Y of this staff's top line.
+    ///   - bottomY: Y of this staff's bottom line.  Sizes the staff-relative furniture —
+    ///     the repeat dots, which always sit inside the staff that owns them.
+    ///   - lineBottomY: How far down the vertical strokes actually run.  Equal to `bottomY`
+    ///     on a single staff and on the last staff of a system; on any other staff of a
+    ///     multi-voice system it is the *next* staff's top line, so the bar line carries
+    ///     through the gap and the system's bar lines read as one stroke.
     private func emitBarLine(_ bar: ResolvedBarLine, topY: Double, bottomY: Double,
-                              builder: inout SVGBuilder) {
+                              lineBottomY: Double? = nil, builder: inout SVGBuilder) {
         let thin    = metadata.engravingDefaults.thinBarlineThickness  * config.staffSize
         let thick   = metadata.engravingDefaults.thickBarlineThickness * config.staffSize
         let sep     = metadata.engravingDefaults.barlineSeparation     * config.staffSize
         let wideSep = sep * 2.0
+        let footY   = lineBottomY ?? bottomY
 
         switch bar.kind {
         case .single, .dotted:
-            builder.line(x1: bar.x, y1: topY, x2: bar.x, y2: bottomY,
+            builder.line(x1: bar.x, y1: topY, x2: bar.x, y2: footY,
                          stroke: "black", strokeWidth: thin)
 
         case .double:
             // Right-anchored: trailing thin bar at bar.x, leading thin bar to its left,
             // so the pair ends where the staff lines end at a system break.
-            builder.line(x1: bar.x - sep, y1: topY, x2: bar.x - sep, y2: bottomY,
+            builder.line(x1: bar.x - sep, y1: topY, x2: bar.x - sep, y2: footY,
                          stroke: "black", strokeWidth: thin)
-            builder.line(x1: bar.x,       y1: topY, x2: bar.x,       y2: bottomY,
+            builder.line(x1: bar.x,       y1: topY, x2: bar.x,       y2: footY,
                          stroke: "black", strokeWidth: thin)
 
         case .final:
             // Right-anchored: thick bar trailing edge at bar.x, thin bar to its left.
-            builder.line(x1: bar.x - wideSep, y1: topY, x2: bar.x - wideSep, y2: bottomY,
+            builder.line(x1: bar.x - wideSep, y1: topY, x2: bar.x - wideSep, y2: footY,
                          stroke: "black", strokeWidth: thin)
-            builder.line(x1: bar.x,           y1: topY, x2: bar.x,           y2: bottomY,
+            builder.line(x1: bar.x,           y1: topY, x2: bar.x,           y2: footY,
                          stroke: "black", strokeWidth: thick)
 
         case .start:
-            builder.line(x1: bar.x,            y1: topY, x2: bar.x,            y2: bottomY,
+            builder.line(x1: bar.x,            y1: topY, x2: bar.x,            y2: footY,
                          stroke: "black", strokeWidth: thick)
-            builder.line(x1: bar.x + wideSep,  y1: topY, x2: bar.x + wideSep,  y2: bottomY,
+            builder.line(x1: bar.x + wideSep,  y1: topY, x2: bar.x + wideSep,  y2: footY,
                          stroke: "black", strokeWidth: thin)
 
         case .repeatEnd:
@@ -602,14 +646,14 @@ struct SVGEmitter: Sendable {
             let thickX = bar.x
             let thinX  = thickX - wideSep
             emitRepeatDots(isStartSide: false, nearX: thinX, topY: topY, bottomY: bottomY, builder: &builder)
-            builder.line(x1: thinX,  y1: topY, x2: thinX,  y2: bottomY, stroke: "black", strokeWidth: thin)
-            builder.line(x1: thickX, y1: topY, x2: thickX, y2: bottomY, stroke: "black", strokeWidth: thick)
+            builder.line(x1: thinX,  y1: topY, x2: thinX,  y2: footY, stroke: "black", strokeWidth: thin)
+            builder.line(x1: thickX, y1: topY, x2: thickX, y2: footY, stroke: "black", strokeWidth: thick)
 
         case .repeatStart:
             let thinX  = bar.x
             let thickX = thinX + wideSep
-            builder.line(x1: thinX,  y1: topY, x2: thinX,  y2: bottomY, stroke: "black", strokeWidth: thin)
-            builder.line(x1: thickX, y1: topY, x2: thickX, y2: bottomY, stroke: "black", strokeWidth: thick)
+            builder.line(x1: thinX,  y1: topY, x2: thinX,  y2: footY, stroke: "black", strokeWidth: thin)
+            builder.line(x1: thickX, y1: topY, x2: thickX, y2: footY, stroke: "black", strokeWidth: thick)
             emitRepeatDots(isStartSide: true, nearX: thickX, topY: topY, bottomY: bottomY, builder: &builder)
 
         case .repeatBoth:
@@ -618,15 +662,15 @@ struct SVGEmitter: Sendable {
             let thickX = bar.x
             let thinX  = thickX - wideSep
             emitRepeatDots(isStartSide: false, nearX: thinX, topY: topY, bottomY: bottomY, builder: &builder)
-            builder.line(x1: thinX,  y1: topY, x2: thinX,  y2: bottomY, stroke: "black", strokeWidth: thin)
-            builder.line(x1: thickX, y1: topY, x2: thickX, y2: bottomY, stroke: "black", strokeWidth: thick)
+            builder.line(x1: thinX,  y1: topY, x2: thinX,  y2: footY, stroke: "black", strokeWidth: thin)
+            builder.line(x1: thickX, y1: topY, x2: thickX, y2: footY, stroke: "black", strokeWidth: thick)
             emitRepeatDots(isStartSide: true, nearX: thickX, topY: topY, bottomY: bottomY, builder: &builder)
 
         case .sectionRepeatStart:
             let thickX = bar.x
             let thinX  = thickX + wideSep
-            builder.line(x1: thickX, y1: topY, x2: thickX, y2: bottomY, stroke: "black", strokeWidth: thick)
-            builder.line(x1: thinX,  y1: topY, x2: thinX,  y2: bottomY, stroke: "black", strokeWidth: thin)
+            builder.line(x1: thickX, y1: topY, x2: thickX, y2: footY, stroke: "black", strokeWidth: thick)
+            builder.line(x1: thinX,  y1: topY, x2: thinX,  y2: footY, stroke: "black", strokeWidth: thin)
             emitRepeatDots(isStartSide: true, nearX: thinX, topY: topY, bottomY: bottomY, builder: &builder)
 
         case .repeatEndSection:
@@ -634,8 +678,8 @@ struct SVGEmitter: Sendable {
             let thickX = bar.x
             let thinX  = thickX - wideSep
             emitRepeatDots(isStartSide: false, nearX: thinX, topY: topY, bottomY: bottomY, builder: &builder)
-            builder.line(x1: thinX,  y1: topY, x2: thinX,  y2: bottomY, stroke: "black", strokeWidth: thin)
-            builder.line(x1: thickX, y1: topY, x2: thickX, y2: bottomY, stroke: "black", strokeWidth: thick)
+            builder.line(x1: thinX,  y1: topY, x2: thinX,  y2: footY, stroke: "black", strokeWidth: thin)
+            builder.line(x1: thickX, y1: topY, x2: thickX, y2: footY, stroke: "black", strokeWidth: thick)
         }
     }
 

--- a/Sources/CeolKitSVGRenderer/Layout/Justifier.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/Justifier.swift
@@ -42,46 +42,81 @@ public struct Justifier: Sendable {
         justifyLastSystem: Bool,
         systemHeaderWidths: [Double] = []
     ) -> [JustifiedSystem] {
-        systems.enumerated().map { i, system in
+        justifyGroups(systems.map { SystemGroup(staves: [$0]) },
+                      usableWidth: usableWidth,
+                      justifyLastSystem: justifyLastSystem,
+                      systemHeaderWidths: systemHeaderWidths)
+            .map { $0.staves[0] }
+    }
+
+    /// Justifies `groups`, giving every staff of a group the same measure x-positions.
+    ///
+    /// A column's final width is derived once, from the widest staff's natural width for
+    /// that column, and handed to every staff in the group.  That is what makes the bar
+    /// lines line up vertically: a staff whose measure is narrower than the column simply
+    /// gets more slack distributed inside it.
+    ///
+    /// - Parameters:
+    ///   - groups: Pass 2 output.
+    ///   - usableWidth: Full available horizontal space (page width minus margins).
+    ///   - justifyLastSystem: When `true`, the last system is also stretched to fill the line.
+    ///   - systemHeaderWidths: Per-system width consumed by clef/key/time-sig headers —
+    ///     already the `max` across the group's voices, since its staves start at a common x.
+    /// Named rather than overloaded on the element type: `justify([])` would otherwise be
+    /// ambiguous, which is a trap for a call site that has nothing to justify.
+    public func justifyGroups(
+        _ groups: [SystemGroup],
+        usableWidth: Double,
+        justifyLastSystem: Bool,
+        systemHeaderWidths: [Double] = []
+    ) -> [JustifiedSystemGroup] {
+        groups.enumerated().map { i, group in
             let headerWidth = i < systemHeaderWidths.count ? systemHeaderWidths[i] : 0
             let targetWidth = usableWidth - headerWidth
-            let shouldStretch = !system.isLastSystem || justifyLastSystem
-            return justify(system, targetWidth: targetWidth, stretch: shouldStretch,
-                           capStretch: system.staveWasSplit)
+            let shouldStretch = !group.isLastSystem || justifyLastSystem
+            return justify(group, targetWidth: targetWidth, stretch: shouldStretch,
+                           capStretch: group.staveWasSplit)
         }
     }
 
     // MARK: - Private
 
-    private func justify(_ system: System, targetWidth: Double, stretch: Bool,
-                         capStretch: Bool) -> JustifiedSystem {
-        let naturalTotal = system.measures.reduce(0.0) { $0 + $1.naturalWidth }
+    private func justify(_ group: SystemGroup, targetWidth: Double, stretch: Bool,
+                         capStretch: Bool) -> JustifiedSystemGroup {
+        // A column is as wide as its widest staff needs; every staff is then drawn to that.
+        let columnWidths = (0..<group.columnCount).map { column in
+            group.staves.reduce(0.0) { max($0, $1.measures[column].naturalWidth) }
+        }
+        let naturalTotal = columnWidths.reduce(0, +)
         let finalTotal = resolvedWidth(naturalTotal: naturalTotal, targetWidth: targetWidth,
                                        stretch: stretch, capStretch: capStretch)
 
-        guard naturalTotal > 0, finalTotal != naturalTotal else {
+        let finalWidths: [Double]
+        if naturalTotal > 0 && finalTotal != naturalTotal {
+            let slack = finalTotal - naturalTotal
+            finalWidths = columnWidths.map { $0 + slack * ($0 / naturalTotal) }
+        } else {
             // Nothing to redistribute: keep natural widths (left-aligned).
-            let measures = system.measures.map { sized in
-                JustifiedMeasure(source: sized, finalWidth: sized.naturalWidth, eventOffsets: sized.eventOffsets)
-            }
-            return JustifiedSystem(measures: measures, isLastSystem: system.isLastSystem,
-                                   sourceForced: system.sourceForced, clef: system.clef,
-                                   keySignature: system.keySignature, meter: system.meter)
+            finalWidths = columnWidths
         }
 
-        let slack = finalTotal - naturalTotal
-        let measures = system.measures.map { sized -> JustifiedMeasure in
-            let share = slack * (sized.naturalWidth / naturalTotal)
-            let finalWidth = sized.naturalWidth + share
-            let offsets = stretchOffsets(sized.eventOffsets,
-                                         naturalWidth: sized.naturalWidth,
-                                         finalWidth: finalWidth,
-                                         graceIndices: sized.graceEventIndices)
-            return JustifiedMeasure(source: sized, finalWidth: finalWidth, eventOffsets: offsets)
-        }
-        return JustifiedSystem(measures: measures, isLastSystem: system.isLastSystem,
-                               sourceForced: system.sourceForced, clef: system.clef,
-                               keySignature: system.keySignature, meter: system.meter)
+        return JustifiedSystemGroup(staves: group.staves.map { staff in
+            let measures = staff.measures.enumerated().map { column, sized -> JustifiedMeasure in
+                let finalWidth = finalWidths[column]
+                guard finalWidth != sized.naturalWidth else {
+                    return JustifiedMeasure(source: sized, finalWidth: finalWidth,
+                                            eventOffsets: sized.eventOffsets)
+                }
+                let offsets = stretchOffsets(sized.eventOffsets,
+                                             naturalWidth: sized.naturalWidth,
+                                             finalWidth: finalWidth,
+                                             graceIndices: sized.graceEventIndices)
+                return JustifiedMeasure(source: sized, finalWidth: finalWidth, eventOffsets: offsets)
+            }
+            return JustifiedSystem(measures: measures, isLastSystem: staff.isLastSystem,
+                                   sourceForced: staff.sourceForced, clef: staff.clef,
+                                   keySignature: staff.keySignature, meter: staff.meter)
+        })
     }
 
     /// The width the system's music is laid out to.

--- a/Sources/CeolKitSVGRenderer/Layout/LineBreaker.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/LineBreaker.swift
@@ -47,105 +47,162 @@ public struct LineBreaker: Sendable {
         keySignature: KeySignature? = nil,
         meter: Meter? = nil
     ) -> [System] {
-        var systems: [System] = []
+        let voice = VoiceLine(measures: measures.map(\.measure), clef: clef,
+                              keySignature: keySignature, meter: meter)
+        return breakIntoGroups([voice], breaks: measures.map(\.breakAfter),
+                               usableWidth: usableWidth,
+                               firstSystemHeaderWidth: firstSystemHeaderWidth,
+                               laterSystemHeaderWidth: laterSystemHeaderWidth)
+            .map { $0.staves[0] }
+    }
 
-        for stave in staves(of: measures) {
+    /// One voice's contribution to a joint break: its measures and the header material that
+    /// travels with them.
+    public struct VoiceLine: Sendable {
+        public let measures: [SizedMeasure]
+        public let clef: ClefSpec
+        public let keySignature: KeySignature?
+        /// Stamped on the voice's first system only.
+        public let meter: Meter?
+
+        public init(measures: [SizedMeasure], clef: ClefSpec = ClefSpec(clef: .treble, octaveShift: 0),
+                    keySignature: KeySignature? = nil, meter: Meter? = nil) {
+            self.measures = measures
+            self.clef = clef
+            self.keySignature = keySignature
+            self.meter = meter
+        }
+    }
+
+    /// Breaks every voice of a tune at the same measure indices, producing one `SystemGroup`
+    /// per system.
+    ///
+    /// The voices must already agree on measure count and break positions — `VoiceAligner`
+    /// pads them into agreement, and warns when it had to.  That is why there is a single
+    /// `breaks` array rather than one per voice: a break has to fall at the same measure
+    /// index in every voice or the staves desynchronise, so there is only one decision to make.
+    ///
+    /// Column widths are the `max` across the voices, not each voice's own: a column is only
+    /// as narrow as its widest staff can be drawn.
+    ///
+    /// - Parameters:
+    ///   - voices: One entry per voice, in `V:` declaration order. Every `measures` array
+    ///     has the same count, equal to `breaks.count`.
+    ///   - breaks: The source line-break hint following each measure column.
+    ///   - firstSystemHeaderWidth: Header width on the tune's first system — already the
+    ///     `max` across voices, since the group's staves must start at a common x.
+    ///   - laterSystemHeaderWidth: Same for every later system (no time signature).
+    public func breakIntoGroups(
+        _ voices: [VoiceLine],
+        breaks: [ScoreLineBreak?],
+        usableWidth: Double,
+        firstSystemHeaderWidth: Double = 0,
+        laterSystemHeaderWidth: Double = 0
+    ) -> [SystemGroup] {
+        guard let first = voices.first, !first.measures.isEmpty else { return [] }
+
+        // A column is as wide as its widest voice needs it to be.
+        let columnWidths = (0..<first.measures.count).map { column in
+            voices.reduce(0.0) { max($0, $1.measures[column].naturalWidth) }
+        }
+
+        var groups: [SystemGroup] = []
+        for stave in staves(columnCount: columnWidths.count, breaks: breaks) {
             // Header width — and therefore the space left for music — differs between the
-            // very first system of the voice and every later one.
-            let firstSystemIndex = systems.count
+            // very first system of the tune and every later one.
+            let firstSystemIndex = groups.count
             let available: (Int) -> Double = { indexWithinStave in
                 usableWidth - (firstSystemIndex + indexWithinStave == 0
                                ? firstSystemHeaderWidth
                                : laterSystemHeaderWidth)
             }
 
-            let groups = pack(stave.measures, available: available)
-            for (i, group) in groups.enumerated() {
-                let isLastOfStave = i == groups.count - 1
-                systems.append(System(
-                    measures: group,
-                    isLastSystem: false,
-                    // Only the group that ends on the source break inherited it.
-                    sourceForced: stave.endsAtSourceBreak && isLastOfStave,
-                    staveWasSplit: groups.count > 1,
-                    clef: clef,
-                    keySignature: keySignature,
-                    meter: systems.isEmpty ? meter : nil
-                ))
+            let ranges = pack(Array(columnWidths[stave.columns]), available: available)
+                .map { $0.offset(by: stave.columns.lowerBound) }
+            for (i, range) in ranges.enumerated() {
+                let isLastOfStave = i == ranges.count - 1
+                let isFirstOfTune = groups.isEmpty
+                groups.append(SystemGroup(staves: voices.map { voice in
+                    System(
+                        measures: Array(voice.measures[range]),
+                        isLastSystem: false,
+                        // Only the system that ends on the source break inherited it.
+                        sourceForced: stave.endsAtSourceBreak && isLastOfStave,
+                        staveWasSplit: ranges.count > 1,
+                        clef: voice.clef,
+                        keySignature: voice.keySignature,
+                        meter: isFirstOfTune ? voice.meter : nil
+                    )
+                }))
             }
         }
 
         // Mark the trailing system.
-        if !systems.isEmpty {
-            let last = systems.removeLast()
-            systems.append(System(measures: last.measures, isLastSystem: true,
-                                  sourceForced: last.sourceForced,
-                                  staveWasSplit: last.staveWasSplit, clef: clef,
-                                  keySignature: keySignature, meter: last.meter))
+        if let last = groups.popLast() {
+            groups.append(SystemGroup(staves: last.staves.map { staff in
+                System(measures: staff.measures, isLastSystem: true,
+                       sourceForced: staff.sourceForced, staveWasSplit: staff.staveWasSplit,
+                       clef: staff.clef, keySignature: staff.keySignature, meter: staff.meter)
+            }))
         }
 
-        return systems
+        return groups
     }
 
     // MARK: - Staves
 
     private struct Stave {
-        let measures: [SizedMeasure]
+        /// The measure columns this stave covers.
+        let columns: Range<Int>
         /// `true` when the stave closes on a `.hard` source break rather than on the end of input.
         let endsAtSourceBreak: Bool
     }
 
-    /// Splits the input at every `.hard` break.  A trailing run with no break after it is a
-    /// stave too — it just ends at the end of the voice.
-    private func staves(
-        of measures: [(measure: SizedMeasure, breakAfter: ScoreLineBreak?)]
-    ) -> [Stave] {
+    /// Splits `0..<columnCount` at every `.hard` break.  A trailing run with no break after
+    /// it is a stave too — it just ends at the end of the tune.
+    private func staves(columnCount: Int, breaks: [ScoreLineBreak?]) -> [Stave] {
         var result: [Stave] = []
-        var current: [SizedMeasure] = []
-        for (sized, breakAfter) in measures {
-            current.append(sized)
-            if breakAfter == .hard {
-                result.append(Stave(measures: current, endsAtSourceBreak: true))
-                current = []
-            }
+        var start = 0
+        for column in 0..<columnCount where column < breaks.count && breaks[column] == .hard {
+            result.append(Stave(columns: start..<(column + 1), endsAtSourceBreak: true))
+            start = column + 1
         }
-        if !current.isEmpty {
-            result.append(Stave(measures: current, endsAtSourceBreak: false))
+        if start < columnCount {
+            result.append(Stave(columns: start..<columnCount, endsAtSourceBreak: false))
         }
         return result
     }
 
     // MARK: - Packing
 
-    /// Splits one stave into system-sized groups.
+    /// Splits one stave into system-sized runs of columns, as ranges into `widths`.
     ///
     /// `available(i)` gives the width left for music on the `i`-th system of this stave.
-    private func pack(_ measures: [SizedMeasure], available: (Int) -> Double) -> [[SizedMeasure]] {
-        guard !measures.isEmpty else { return [] }
-        let greedy = greedyPack(measures, available: available)
+    private func pack(_ widths: [Double], available: (Int) -> Double) -> [Range<Int>] {
+        guard !widths.isEmpty else { return [] }
+        let greedy = greedyPack(widths, available: available)
         // A stave that fits on one system has nothing to rebalance.
         guard greedy.count > 1 else { return greedy }
-        return balance(measures, systemCount: greedy.count, available: available) ?? greedy
+        return balance(widths, systemCount: greedy.count, available: available) ?? greedy
     }
 
     /// First-fit packing.  Establishes the minimum number of systems the stave needs; the
-    /// balancing pass keeps that number and only moves measures between the groups.
-    private func greedyPack(_ measures: [SizedMeasure], available: (Int) -> Double) -> [[SizedMeasure]] {
-        var groups: [[SizedMeasure]] = []
-        var bucket: [SizedMeasure] = []
+    /// balancing pass keeps that number and only moves columns between the systems.
+    private func greedyPack(_ widths: [Double], available: (Int) -> Double) -> [Range<Int>] {
+        var groups: [Range<Int>] = []
+        var start = 0
         var bucketWidth: Double = 0
 
-        for sized in measures {
+        for (i, width) in widths.enumerated() {
             let limit = capacity(available(groups.count))
-            if !bucket.isEmpty && bucketWidth + sized.naturalWidth > limit {
-                groups.append(bucket)
-                bucket = []
+            if i > start && bucketWidth + width > limit {
+                groups.append(start..<i)
+                start = i
                 bucketWidth = 0
             }
-            bucket.append(sized)
-            bucketWidth += sized.naturalWidth
+            bucketWidth += width
         }
-        if !bucket.isEmpty { groups.append(bucket) }
+        if start < widths.count { groups.append(start..<widths.count) }
         return groups
     }
 
@@ -154,21 +211,21 @@ public struct LineBreaker: Sendable {
         available * (1 + overflowTolerance)
     }
 
-    /// Redistributes `measures` over exactly `systemCount` systems, minimising the total
+    /// Redistributes the columns over exactly `systemCount` systems, minimising the total
     /// squared relative slack.
     ///
     /// Measure counts per stave are small (a source line is rarely more than a dozen bars),
     /// so an exact O(systemCount · n²) dynamic program is cheaper than reasoning about when a
     /// heuristic would misfire.  Returns `nil` if no assignment respects the width limits,
     /// which cannot happen for a `systemCount` that greedy first-fit already achieved.
-    private func balance(_ measures: [SizedMeasure], systemCount: Int,
-                         available: (Int) -> Double) -> [[SizedMeasure]]? {
-        let n = measures.count
+    private func balance(_ widths: [Double], systemCount: Int,
+                         available: (Int) -> Double) -> [Range<Int>]? {
+        let n = widths.count
         guard systemCount > 1, systemCount <= n else { return nil }
 
-        // prefix[i] = summed natural width of measures[0..<i]
+        // prefix[i] = summed natural width of widths[0..<i]
         var prefix = [Double](repeating: 0, count: n + 1)
-        for i in 0..<n { prefix[i + 1] = prefix[i] + measures[i].naturalWidth }
+        for i in 0..<n { prefix[i + 1] = prefix[i] + widths[i] }
 
         // cost[s][i]: best badness for packing measures[i...] into exactly `s` systems.
         // choice[s][i]: where the system starting at `i` ends in that solution.
@@ -207,11 +264,11 @@ public struct LineBreaker: Sendable {
 
         guard cost[systemCount][0] < .infinity else { return nil }
 
-        var groups: [[SizedMeasure]] = []
+        var groups: [Range<Int>] = []
         var start = 0
         for s in stride(from: systemCount, through: 1, by: -1) {
             let end = choice[s][start]
-            groups.append(Array(measures[start..<end]))
+            groups.append(start..<end)
             start = end
         }
         return groups
@@ -226,4 +283,8 @@ public struct LineBreaker: Sendable {
         let slack = (available - groupWidth) / available
         return slack * slack
     }
+}
+
+private extension Range where Bound == Int {
+    func offset(by delta: Int) -> Range<Int> { (lowerBound + delta)..<(upperBound + delta) }
 }

--- a/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
@@ -69,13 +69,40 @@ public struct System: Sendable {
     }
 }
 
+/// One system's worth of unjustified music: the staves of every voice that is active on
+/// the source line the system came from, in `V:` declaration order.
+///
+/// A single-voice tune produces groups of exactly one staff, which is the pre-grouping
+/// path unchanged — every stage below treats a one-staff group as an ordinary system.
+public struct SystemGroup: Sendable {
+    /// One entry per voice, top to bottom.  Never empty.
+    ///
+    /// Every staff holds the same number of measures and was broken at the same measure
+    /// index, because `VoiceAligner` padded the voices into agreement before the line
+    /// breaker ever saw them.
+    public let staves: [System]
+
+    public init(staves: [System]) {
+        self.staves = staves
+    }
+
+    /// The properties the line breaker assigned to the group as a whole.  They are recorded
+    /// on every staff identically, so the first one speaks for all of them.
+    public var isLastSystem: Bool { staves[0].isLastSystem }
+    public var sourceForced: Bool { staves[0].sourceForced }
+    public var staveWasSplit: Bool { staves[0].staveWasSplit }
+    /// Number of measures in each staff — the group's column count.
+    public var columnCount: Int { staves[0].measures.count }
+}
+
 /// Groups the justified systems and optional title block for a single tune.
 ///
 /// `titleRows` use `baselineY` values relative to the top of the tune's title area
 /// (i.e. `y = 0` origin). The layout engine adds the actual page y-origin when placing them,
 /// so the same `TuneBlock` can be positioned anywhere on a page.
 public struct TuneBlock: Sendable {
-    public let systems: [JustifiedSystem]
+    /// One entry per system, each holding one staff per voice.
+    public let systemGroups: [JustifiedSystemGroup]
     public let titleRows: [ResolvedTitleRow]
     public let titleBlockHeight: Double
     /// Multiplier applied to `SVGRenderConfig.staffSize` (and the inter-system/inter-tune gaps
@@ -88,18 +115,43 @@ public struct TuneBlock: Sendable {
     /// so the emitter has to draw with the same one.
     public let graceNoteSpacing: Double
 
-    public init(systems: [JustifiedSystem], titleRows: [ResolvedTitleRow] = [],
+    public init(systemGroups: [JustifiedSystemGroup], titleRows: [ResolvedTitleRow] = [],
                 titleBlockHeight: Double = 0, scale: Double = 1.0,
                 graceNoteSpacing: Double = SVGRenderConfig().graceNoteSpacing) {
-        self.systems = systems
+        self.systemGroups = systemGroups
         self.titleRows = titleRows
         self.titleBlockHeight = titleBlockHeight
         self.scale = scale
         self.graceNoteSpacing = graceNoteSpacing
     }
+
+    /// Convenience for single-voice music: each system becomes a group of one staff.
+    public init(systems: [JustifiedSystem], titleRows: [ResolvedTitleRow] = [],
+                titleBlockHeight: Double = 0, scale: Double = 1.0,
+                graceNoteSpacing: Double = SVGRenderConfig().graceNoteSpacing) {
+        self.init(systemGroups: systems.map { JustifiedSystemGroup(staves: [$0]) },
+                  titleRows: titleRows, titleBlockHeight: titleBlockHeight,
+                  scale: scale, graceNoteSpacing: graceNoteSpacing)
+    }
 }
 
 // MARK: - Pass 3 output
+
+/// A `SystemGroup` after justification.
+///
+/// Every staff carries the same per-column final widths, so a bar line at column *j* lands
+/// on the same x on all of them — which is the whole point of engraving voices in parallel.
+public struct JustifiedSystemGroup: Sendable {
+    /// One entry per voice, top to bottom.  Never empty.
+    public let staves: [JustifiedSystem]
+
+    public init(staves: [JustifiedSystem]) {
+        self.staves = staves
+    }
+
+    public var isLastSystem: Bool { staves[0].isLastSystem }
+    public var sourceForced: Bool { staves[0].sourceForced }
+}
 
 public struct JustifiedSystem: Sendable {
     public let measures: [JustifiedMeasure]
@@ -205,6 +257,37 @@ public enum TextAnchor: String, Sendable {
     case start, middle, end
 }
 
+/// Where one staff sits inside a multi-staff system, and how far the furniture that belongs
+/// to the *group* rather than to this staff has to reach.
+///
+/// Present only when the system holds more than one voice.  A single-voice tune leaves
+/// ``ResolvedSystem/staffGroup`` nil and the emitter takes exactly the path it always did.
+public struct StaffGroup: Sendable {
+    /// 0-based position of this staff within its group, top to bottom.
+    public let index: Int
+    /// Number of staves in the group.  Always > 1 — a group of one is represented by `nil`.
+    public let count: Int
+    /// Absolute y of the *next* staff's top staff line, or `nil` on the group's last staff.
+    ///
+    /// Bar lines are drawn down to this instead of stopping at their own staff, so the
+    /// group's bar lines read as one continuous stroke through the whole system.  Repeat
+    /// dots still sit within the staff that owns them.
+    public let nextStaffTopY: Double?
+    /// Absolute y of the bottom staff line of the group's last staff — the foot of the
+    /// vertical line that joins the staves at the left edge.
+    public let bottomY: Double
+
+    public init(index: Int, count: Int, nextStaffTopY: Double?, bottomY: Double) {
+        self.index = index
+        self.count = count
+        self.nextStaffTopY = nextStaffTopY
+        self.bottomY = bottomY
+    }
+
+    /// `true` on the staff that draws the furniture spanning the whole group.
+    public var isGroupLeader: Bool { index == 0 }
+}
+
 public struct ResolvedSystem: Sendable {
     public let origin: Point
     public let measures: [ResolvedMeasure]
@@ -231,7 +314,12 @@ public struct ResolvedSystem: Sendable {
     public let meter: Meter?
     /// 1-based ABC source line that first contributed content to this staff system.
     /// Used to emit scroll-sync anchor metadata (see `%%ceolkit` extension, issue #25).
+    ///
+    /// In a multi-voice system every staff reports the *group's* line — the first voice's —
+    /// rather than its own, so the anchor sequence down a page stays monotonic (issue #41).
     public let abcLine: Int
+    /// Non-nil when this staff is one of several in a system; see ``StaffGroup``.
+    public let staffGroup: StaffGroup?
 
     public init(
         origin: Point,
@@ -246,7 +334,8 @@ public struct ResolvedSystem: Sendable {
         clef: ClefSpec = ClefSpec(clef: .treble, octaveShift: 0),
         keySignature: KeySignature? = nil,
         meter: Meter? = nil,
-        abcLine: Int = 1
+        abcLine: Int = 1,
+        staffGroup: StaffGroup? = nil
     ) {
         self.origin = origin
         self.measures = measures
@@ -261,6 +350,7 @@ public struct ResolvedSystem: Sendable {
         self.keySignature = keySignature
         self.meter = meter
         self.abcLine = abcLine
+        self.staffGroup = staffGroup
     }
 }
 

--- a/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
@@ -103,6 +103,7 @@ public struct VerticalLayoutEngine: Sendable {
         var previousAbcLine: Int?
 
         for block in tuneBlocks {
+            let groups = block.systemGroups
             // %%ceolkit:scale sizes this tune's music (and the gaps derived from staffSize)
             // relative to the renderer default. Page size and margins stay absolute.
             let tuneConfig  = config.scaled(by: block.scale)
@@ -135,44 +136,29 @@ public struct VerticalLayoutEngine: Sendable {
             }
             y += block.titleBlockHeight
 
-            for (si, jsystem) in block.systems.enumerated() {
-                let (extraAbove, extraBelow) = verticalExtent(of: jsystem, staffSize: staffSize)
-                let totalHeight = extraAbove + staffHeight + extraBelow
+            for (gi, group) in groups.enumerated() {
+                let metrics = groupMetrics(of: group, staffSize: staffSize, staffGap: tuneConfig.staffGap)
 
-                if !pageSystems.isEmpty && y + totalHeight > config.pageSize.height - config.margins.bottom {
+                // A group breaks to the next page whole: splitting it would separate staves
+                // that only mean anything read together.
+                if !pageSystems.isEmpty && y + metrics.totalHeight > config.pageSize.height - config.margins.bottom {
                     pages.append(ResolvedPage(systems: pageSystems, titleRows: pageTitleRows))
                     pageSystems = []
                     pageTitleRows = []
                     y = config.margins.top
                 }
 
-                let systemOrigin = Point(x: config.margins.left, y: y)
-                let startWidth = systemStartWidth(for: jsystem, staffSize: staffSize)
-                let measures = resolveMeasures(
-                    jsystem.measures,
-                    systemOrigin: systemOrigin,
-                    extraAbove: extraAbove,
-                    systemStartWidth: startWidth
-                )
-                let abcLine = resolvedAbcLine(of: jsystem, previous: previousAbcLine)
+                // Every staff in the group reports the group's line, so the anchor sequence
+                // down the page stays monotonic (issue #41).
+                let abcLine = resolvedAbcLine(of: group.staves[0], previous: previousAbcLine)
                 previousAbcLine = abcLine
-                pageSystems.append(ResolvedSystem(
-                    origin: systemOrigin,
-                    measures: measures,
-                    staffOrigin: extraAbove,
-                    staffSize: staffSize,
-                    staffHeight: staffHeight,
-                    graceNoteSpacing: block.graceNoteSpacing,
-                    extraAbove: extraAbove,
-                    extraBelow: extraBelow,
-                    totalHeight: totalHeight,
-                    clef: jsystem.clef,
-                    keySignature: jsystem.keySignature,
-                    meter: jsystem.meter,
-                    abcLine: abcLine
-                ))
-                let isLastInBlock = si == block.systems.count - 1
-                y += totalHeight + (isLastInBlock ? tuneGap : systemGap)
+                pageSystems.append(contentsOf: resolveGroup(
+                    group, metrics: metrics, topY: y, staffSize: staffSize,
+                    staffHeight: staffHeight, staffGap: tuneConfig.staffGap,
+                    graceNoteSpacing: block.graceNoteSpacing, abcLine: abcLine))
+
+                let isLastInBlock = gi == groups.count - 1
+                y += metrics.totalHeight + (isLastInBlock ? tuneGap : systemGap)
             }
         }
 
@@ -187,19 +173,101 @@ public struct VerticalLayoutEngine: Sendable {
         )
     }
 
+    // MARK: - Staff groups
+
+    /// The vertical shape of one system: where each of its staves sits relative to the
+    /// system's top, and how tall the whole thing is.
+    private struct GroupMetrics {
+        /// Per staff, the space its ledger lines and annotations need above and below it,
+        /// and the y of its top staff line relative to the system's top edge.
+        let staves: [(extraAbove: Double, extraBelow: Double, staffTopOffset: Double)]
+        /// Full height of the group: every staff's extent plus the gaps between them.
+        let totalHeight: Double
+        /// Width of the widest clef + key + time signature run in the group.  Every staff
+        /// starts its first measure there, so their bar lines can align.
+        let startWidth: Double
+    }
+
+    private func groupMetrics(of group: JustifiedSystemGroup, staffSize: Double,
+                              staffGap: Double) -> GroupMetrics {
+        let staffHeight = 4.0 * staffSize
+        var staves: [(extraAbove: Double, extraBelow: Double, staffTopOffset: Double)] = []
+        staves.reserveCapacity(group.staves.count)
+        var offset = 0.0
+        var startWidth = 0.0
+        for (i, staff) in group.staves.enumerated() {
+            let (extraAbove, extraBelow) = verticalExtent(of: staff, staffSize: staffSize)
+            staves.append((extraAbove, extraBelow, offset + extraAbove))
+            offset += extraAbove + staffHeight + extraBelow
+            if i < group.staves.count - 1 { offset += staffGap }
+            startWidth = max(startWidth, systemStartWidth(for: staff, staffSize: staffSize))
+        }
+        return GroupMetrics(staves: staves, totalHeight: offset, startWidth: startWidth)
+    }
+
+    /// Places every staff of one system, top to bottom, starting at `topY`.
+    private func resolveGroup(_ group: JustifiedSystemGroup, metrics: GroupMetrics,
+                              topY: Double, staffSize: Double, staffHeight: Double,
+                              staffGap: Double, graceNoteSpacing: Double,
+                              abcLine: Int) -> [ResolvedSystem] {
+        // A group of one is an ordinary system: no membership, no group furniture, and the
+        // same output the renderer produced before staff groups existed.
+        let isGrouped = group.staves.count > 1
+        // The foot of the line that joins the staves at the left edge: the bottom staff line
+        // of the last staff.
+        let last = metrics.staves[metrics.staves.count - 1]
+        let groupBottomY = topY + last.staffTopOffset + staffHeight
+
+        return group.staves.enumerated().map { i, staff in
+            let (extraAbove, extraBelow, staffTopOffset) = metrics.staves[i]
+            // `origin.y` is the top of the staff's own band; `staffOrigin` walks down from
+            // there to the top staff line, exactly as in the single-staff case.
+            let systemOrigin = Point(x: config.margins.left, y: topY + staffTopOffset - extraAbove)
+            let measures = resolveMeasures(
+                staff.measures,
+                systemOrigin: systemOrigin,
+                extraAbove: extraAbove,
+                systemStartWidth: metrics.startWidth
+            )
+            let membership: StaffGroup? = isGrouped ? StaffGroup(
+                index: i,
+                count: group.staves.count,
+                nextStaffTopY: i + 1 < metrics.staves.count
+                    ? topY + metrics.staves[i + 1].staffTopOffset
+                    : nil,
+                bottomY: groupBottomY
+            ) : nil
+            return ResolvedSystem(
+                origin: systemOrigin,
+                measures: measures,
+                staffOrigin: extraAbove,
+                staffSize: staffSize,
+                staffHeight: staffHeight,
+                graceNoteSpacing: graceNoteSpacing,
+                extraAbove: extraAbove,
+                extraBelow: extraBelow,
+                totalHeight: extraAbove + staffHeight + extraBelow,
+                clef: staff.clef,
+                keySignature: staff.keySignature,
+                meter: staff.meter,
+                abcLine: abcLine,
+                staffGroup: membership
+            )
+        }
+    }
+
     // MARK: - Clef width
 
     /// Returns the total vertical space required to render `block` on a single page,
     /// including its title block, all systems, and inter-system gaps (but not the
     /// trailing gap that follows the last system).
     private func totalHeight(of block: TuneBlock) -> Double {
-        let tuneConfig  = config.scaled(by: block.scale)
-        let staffHeight = 4.0 * tuneConfig.staffSize
+        let tuneConfig = config.scaled(by: block.scale)
         var h = block.titleBlockHeight
-        for (i, jsystem) in block.systems.enumerated() {
-            let (ea, eb) = verticalExtent(of: jsystem, staffSize: tuneConfig.staffSize)
-            h += ea + staffHeight + eb
-            if i < block.systems.count - 1 { h += tuneConfig.systemGap }
+        for (i, group) in block.systemGroups.enumerated() {
+            h += groupMetrics(of: group, staffSize: tuneConfig.staffSize,
+                              staffGap: tuneConfig.staffGap).totalHeight
+            if i < block.systemGroups.count - 1 { h += tuneConfig.systemGap }
         }
         return h
     }

--- a/Sources/CeolKitSVGRenderer/Layout/VoiceAligner.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VoiceAligner.swift
@@ -1,0 +1,123 @@
+import CeolKitModel
+
+/// Pass 1½: brings a tune's voices into agreement about how much music each source line
+/// holds, so the line breaker can pick break points that are legal for all of them.
+///
+/// The semantic pass gives each voice one `Staff` per source line-break, so in a well-formed
+/// parallel source the voices already agree and this is a pure pass-through.  What it exists
+/// for is the source that does not: voices of unequal measure counts, or a `$`/`!` break in
+/// one voice that the others do not have.
+///
+/// On disagreement the short voice is **padded**, never dropped back to sequential layout —
+/// that is the confusing rendering this whole grouping exists to remove.  The padding is an
+/// invisible full-measure rest (`X`): the source did not write silence, it wrote nothing, and
+/// printing rests the author never typed would misrepresent the music.  Staff and bar lines
+/// still draw, because they are group furniture, so a padded measure reads as "this voice has
+/// nothing here" rather than as an engraving error.
+///
+/// Every divergence produces a `.voiceLengthMismatch` warning naming the voices and the
+/// measure index where they parted, at `.warning` severity: the render succeeds, and says
+/// what it had to do to succeed.
+enum VoiceAligner {
+
+    /// One source line's music, across every voice of the tune.
+    struct AlignedStave {
+        /// `measures[voiceIndex]` — one entry per voice, all of the same count.
+        let measures: [[Measure]]
+
+        var measureCount: Int { measures.first?.count ?? 0 }
+    }
+
+    /// Aligns `voices` stave by stave, padding wherever they disagree.
+    ///
+    /// Alignment is by *stave index*, not by running measure count: staves are source lines,
+    /// and parallel voices are written line for line.  A voice with fewer staves than the
+    /// tune's widest therefore gains whole padded lines at the end rather than having its
+    /// music silently slide up into someone else's line.
+    ///
+    /// - Returns: One entry per stave, in source order.  Empty when `voices` is empty.
+    static func align(_ voices: [Voice], into diagnostics: inout [Diagnostic]) -> [AlignedStave] {
+        guard !voices.isEmpty else { return [] }
+        // The single-voice case has nothing to align and nothing to warn about.
+        guard voices.count > 1 else {
+            return voices[0].staves.map { AlignedStave(measures: [$0.measures]) }
+        }
+
+        let staveCount = voices.reduce(0) { max($0, $1.staves.count) }
+        var result: [AlignedStave] = []
+        result.reserveCapacity(staveCount)
+        // Running measure index across the whole tune, so a diagnostic can name the bar the
+        // reader would count to rather than a position within some line.
+        var measureOrigin = 0
+
+        for staveIndex in 0..<staveCount {
+            let perVoice = voices.map { $0.staves.indices.contains(staveIndex) ? $0.staves[staveIndex].measures : [] }
+            let width = perVoice.reduce(0) { max($0, $1.count) }
+
+            if let diagnostic = mismatch(perVoice, voices: voices, width: width,
+                                         measureOrigin: measureOrigin) {
+                diagnostics.append(diagnostic)
+            }
+
+            result.append(AlignedStave(measures: perVoice.map { pad($0, to: width) }))
+            measureOrigin += width
+        }
+
+        return result
+    }
+
+    // MARK: - Private
+
+    /// The warning for one stave whose voices did not all supply the same number of measures,
+    /// or `nil` when they did.
+    private static func mismatch(_ perVoice: [[Measure]], voices: [Voice], width: Int,
+                                 measureOrigin: Int) -> Diagnostic? {
+        let short = perVoice.indices.filter { perVoice[$0].count < width }
+        guard !short.isEmpty,
+              let longest = perVoice.indices.max(by: { perVoice[$0].count < perVoice[$1].count })
+        else { return nil }
+
+        let names = short.map { "\(label(voices[$0].id)) has \(perVoice[$0].count)" }
+            .joined(separator: ", ")
+        // The first measure some voice does not have — the earliest bar where they part.
+        let divergesAt = measureOrigin + short.map { perVoice[$0].count }.min()! + 1
+
+        return Diagnostic(
+            severity: .warning,
+            code: .voiceLengthMismatch,
+            message: "voices disagree on the length of this line: \(label(voices[longest].id)) "
+                + "has \(width) measures, \(names). Padding the short "
+                + "\(short.count == 1 ? "voice" : "voices") with invisible rests so the staves stay aligned.",
+            source: perVoice[longest].first?.source
+                ?? voices[longest].source,
+            related: short.compactMap { perVoice[$0].last?.source },
+            hint: "measure \(divergesAt) is where they part; give every voice the same number "
+                + "of measures per line so the bar lines align."
+        )
+    }
+
+    /// How a voice is named in a diagnostic.
+    private static func label(_ id: VoiceId) -> String {
+        switch id {
+        case .named(let name): "V:\(name)"
+        case .all:             "V:*"
+        }
+    }
+
+    /// Extends `measures` to `width` with invisible full-measure rests.
+    ///
+    /// The padding borrows the source range of the measure it follows so the padded bars
+    /// still point somewhere real in the file; where there is nothing to follow — a voice
+    /// that supplied no measures for this line at all — it falls back to the empty range.
+    private static func pad(_ measures: [Measure], to width: Int) -> [Measure] {
+        guard measures.count < width else { return measures }
+        let source = measures.last?.source ?? .emptySourceRange
+        let bar = BarLine(kind: .single, source: source)
+        let rest = Rest(kind: .fullMeasureInvisible,
+                        duration: Fraction(numerator: 1, denominator: 1),
+                        decorations: [], source: source)
+        let filler = Measure(openingBar: bar, events: [.rest(rest)], closingBar: bar,
+                             endingNumber: nil, source: source)
+        return measures + Array(repeating: filler, count: width - measures.count)
+    }
+}

--- a/Sources/ckprobe/main.swift
+++ b/Sources/ckprobe/main.swift
@@ -74,9 +74,13 @@ if let factors = options.sweep {
 let abc = SourceRewriter.apply(options, to: source)
 let result = parse(abc)
 
+// The renderer can find problems the parser cannot — voices that disagree about where the
+// bar lines fall only matter once they have to share a system — so its diagnostics are
+// collected and reported alongside the parser's.
+var renderDiagnostics: [CeolKitModel.Diagnostic] = []
 let svgs: [String]
 do {
-    svgs = try SVGRenderer(config: renderConfig).render(result.score)
+    svgs = try SVGRenderer(config: renderConfig).render(result.score, diagnostics: &renderDiagnostics)
 } catch {
     fail("render failed: \(error)")
 }
@@ -96,7 +100,7 @@ if let directory = options.outputDirectory {
 do {
     let report = Report(file: options.file,
                         score: result.score,
-                        diagnostics: result.diagnostics,
+                        diagnostics: result.diagnostics + renderDiagnostics,
                         pages: try SVGGeometry.pages(from: svgs))
     if options.json {
         let encoder = JSONEncoder()

--- a/Tests/CeolKitSVGRendererTests/IntegrationTests.swift
+++ b/Tests/CeolKitSVGRendererTests/IntegrationTests.swift
@@ -33,6 +33,12 @@ private func makeMeasure(events: [Event], closing: BarLine = singleBar) -> Measu
 }
 
 private func makeVoice(id: String, measures: [Measure]) -> Voice {
+    makeVoice(id: id, staves: [Staff(measures: measures, overlays: [])])
+}
+
+/// A voice with an explicit stave list — one stave per source line, which is what the
+/// semantic pass produces and what the line breaker turns into forced system breaks.
+private func makeVoice(id: String, staves: [Staff]) -> Voice {
     Voice(
         id: .named(id),
         properties: VoiceProperties(
@@ -44,7 +50,7 @@ private func makeVoice(id: String, measures: [Measure]) -> Voice {
             stemDirection:   .auto,
             middleNote:      nil
         ),
-        staves:     [Staff(measures: measures, overlays: [])],
+        staves:     staves,
         directives: [],
         source:     dummyRange
     )
@@ -169,17 +175,22 @@ private func simpleJigScore() -> Score {
 
     // MARK: Page overflow
 
-    /// Three voices on a 100 pt-tall page forces a second page.
+    /// One voice of three source lines on a 100 pt-tall page forces a second page.
     ///
-    /// Geometry: usable height = 80 pt; staffHeight = 18; systemGap = 22.5.
-    ///   System 1 bottom: 10 + 18 = 28 pt.
-    ///   System 2 bottom: 28 + 22.5 + 18 = 68.5 pt.
-    ///   System 3 top:   68.5 + 22.5 = 91 pt + 18 = 109 pt > 90 → next page.
+    /// Three *staves* of one voice rather than three voices: since #58 a tune's voices are
+    /// engraved as the staves of one system, so three voices would be one system tall, not
+    /// three systems deep, and would test the opposite of what this is about.
+    ///
+    /// Geometry: usable height = 80 pt; staffHeight = 24; systemGap = 24.
+    ///   System 1 bottom: 10 + 24 = 34 pt.
+    ///   System 2 bottom: 34 + 24 + 24 = 82 pt.
+    ///   System 3 top:   82 + 24 = 106 pt + 24 = 130 pt > 90 → next page.
     @Test func systemsOverflowingPageProduceMultipleElements() throws {
         let quarter = Fraction(numerator: 1, denominator: 1)
         let measure = makeMeasure(events: [.note(makeNote(step: .c, octave: 4, duration: quarter))])
-        let voices  = (1...3).map { i in makeVoice(id: "\(i)", measures: [measure]) }
-        let tune    = makeTune(voices: voices, unitNoteLength: Fraction(numerator: 1, denominator: 4))
+        let staves  = (1...3).map { _ in Staff(measures: [measure], overlays: []) }
+        let tune    = makeTune(voices: [makeVoice(id: "1", staves: staves)],
+                               unitNoteLength: Fraction(numerator: 1, denominator: 4))
         let score   = makeScore(tunes: [tune])
         let config  = SVGRenderConfig(
             pageSize: PageSize(width: 400, height: 100),

--- a/Tests/CeolKitSVGRendererTests/JustifierTests.swift
+++ b/Tests/CeolKitSVGRendererTests/JustifierTests.swift
@@ -149,6 +149,50 @@ private let usableWidth: Double = 300
         #expect(result[0].measures[0].finalWidth > result[0].measures[1].finalWidth)
     }
 
+    // MARK: - Staff groups (issue #58)
+
+    // Every staff of a system gets the same measure widths, so its bar lines line up
+    // vertically down the group.
+    @Test func staffGroupSharesOneSetOfMeasureWidths() {
+        let group = SystemGroup(staves: [
+            makeSystem(widths: [80, 100, 60], isLast: false),
+            makeSystem(widths: [50, 120, 90], isLast: false),
+        ])
+        let result = justifier.justifyGroups([group], usableWidth: usableWidth,
+                                             justifyLastSystem: false)
+        #expect(result[0].staves.count == 2)
+        #expect(result[0].staves[0].measures.map(\.finalWidth)
+                == result[0].staves[1].measures.map(\.finalWidth))
+        // And the group still fills the line.
+        let total = result[0].staves[0].measures.reduce(0.0) { $0 + $1.finalWidth }
+        #expect(abs(total - usableWidth) < 1e-9)
+    }
+
+    // Column widths come from the widest staff, so a staff whose measure is narrower than
+    // the column simply gets more slack inside it rather than dragging the column in.
+    @Test func columnWidthIsDrivenByTheWidestStaff() {
+        // Naturals: columns are max(10, 140) = 140 and max(140, 10) = 140 — an even split,
+        // which neither staff would produce on its own.
+        let group = SystemGroup(staves: [
+            makeSystem(widths: [10, 140], isLast: false),
+            makeSystem(widths: [140, 10], isLast: false),
+        ])
+        let result = justifier.justifyGroups([group], usableWidth: usableWidth,
+                                             justifyLastSystem: false)
+        let widths = result[0].staves[0].measures.map(\.finalWidth)
+        #expect(abs(widths[0] - widths[1]) < 1e-9)
+    }
+
+    // A group of one staff is the pre-grouping path: same numbers, same everything.
+    @Test func groupOfOneMatchesTheSingleSystemPath() {
+        let system = makeSystem(widths: [80, 100, 60], isLast: false)
+        let viaGroups = justifier.justifyGroups([SystemGroup(staves: [system])],
+                                                usableWidth: usableWidth, justifyLastSystem: false)
+        let direct = justifier.justify([system], usableWidth: usableWidth, justifyLastSystem: false)
+        #expect(viaGroups[0].staves[0].measures.map(\.finalWidth)
+                == direct[0].measures.map(\.finalWidth))
+    }
+
     // MARK: - Grace-note spacing
 
     // When a measure contains a grace+note pair, the internal grace-to-note gap must not

--- a/Tests/CeolKitSVGRendererTests/LineBreakerTests.swift
+++ b/Tests/CeolKitSVGRendererTests/LineBreakerTests.swift
@@ -173,4 +173,65 @@ private let usableWidth: Double = 300
         let systems = breaker.breakIntoSystems([], usableWidth: usableWidth)
         #expect(systems.isEmpty)
     }
+
+    // MARK: - Joint breaking (issue #58)
+
+    private func voiceLine(widths: [Double]) -> LineBreaker.VoiceLine {
+        LineBreaker.VoiceLine(measures: widths.map(sizedMeasure(width:)))
+    }
+
+    // Every voice breaks at the same measure index, or the staves desynchronise.
+    @Test func voicesBreakAtTheSameMeasureIndex() {
+        let voices = [voiceLine(widths: [90, 90, 90, 90]), voiceLine(widths: [90, 90, 90, 90])]
+        let groups = breaker.breakIntoGroups(voices, breaks: [nil, nil, nil, nil],
+                                             usableWidth: usableWidth)
+        #expect(groups.count == 2)
+        for group in groups {
+            #expect(group.staves.count == 2)
+            #expect(group.staves.map(\.measures.count) == [2, 2])
+        }
+    }
+
+    // A column is as wide as its widest voice, so the break has to be driven by the max —
+    // not by either voice on its own, which would let a system overrun the line.
+    @Test func columnWidthIsTheMaxAcrossVoices() {
+        // Voice 1 alone would fit 3 columns of 60 on a 300 pt line alongside a 90; voice 2
+        // makes two of those columns 150 wide, so only two columns fit.
+        let voices = [voiceLine(widths: [90, 60, 60]), voiceLine(widths: [90, 150, 150])]
+        let groups = breaker.breakIntoGroups(voices, breaks: [nil, nil, nil],
+                                             usableWidth: usableWidth)
+        #expect(groups.map(\.columnCount) == [2, 1])
+    }
+
+    // A .hard break closes the system in every voice at once.
+    @Test func sourceBreakClosesTheWholeGroup() {
+        let voices = [voiceLine(widths: [50, 50, 50]), voiceLine(widths: [50, 50, 50])]
+        let groups = breaker.breakIntoGroups(voices, breaks: [nil, .hard, nil],
+                                             usableWidth: usableWidth)
+        #expect(groups.map(\.columnCount) == [2, 1])
+        #expect(groups[0].sourceForced)
+        #expect(groups[0].staves.allSatisfy { $0.sourceForced })
+        #expect(groups[1].isLastSystem)
+    }
+
+    // A one-voice tune goes through the joint path and comes out as it always did.
+    @Test func oneVoiceGivesGroupsOfOneStaff() {
+        let groups = breaker.breakIntoGroups([voiceLine(widths: [90, 90, 90, 90])],
+                                             breaks: [nil, nil, nil, nil],
+                                             usableWidth: usableWidth)
+        #expect(groups.map(\.staves.count) == [1, 1])
+        #expect(groups.map(\.columnCount) == [2, 2])
+    }
+
+    // The time signature is stamped on every staff of the first system, and no other.
+    @Test func meterGoesOnEveryStaffOfTheFirstSystemOnly() {
+        let voices = (0..<2).map { _ in
+            LineBreaker.VoiceLine(measures: [90, 90, 90, 90].map(sizedMeasure(width:)),
+                                  meter: .fraction(num: 4, den: 4))
+        }
+        let groups = breaker.breakIntoGroups(voices, breaks: [nil, nil, nil, nil],
+                                             usableWidth: usableWidth)
+        #expect(groups[0].staves.allSatisfy { $0.meter != nil })
+        #expect(groups[1].staves.allSatisfy { $0.meter == nil })
+    }
 }

--- a/Tests/CeolKitSVGRendererTests/MultiVoiceSystemTests.swift
+++ b/Tests/CeolKitSVGRendererTests/MultiVoiceSystemTests.swift
@@ -1,0 +1,143 @@
+import Testing
+import CeolKitModel
+import CeolKitParser
+import CeolKitSVGGeometry
+@testable import CeolKitSVGRenderer
+
+/// Issue #58: a tune's voices are the staves of one system, not a run of systems one after
+/// the other.  These go end to end — source in, SVG out, geometry read back — because the
+/// bug was only visible in the shape of the finished page.
+@Suite struct MultiVoiceSystemTests {
+
+    private func render(_ abc: String,
+                        config: SVGRenderConfig = SVGRenderConfig())
+    -> (pages: [PageGeometry], diagnostics: [Diagnostic]) {
+        let score = CeolKitParser().parse(abc, options: .default).score
+        var diagnostics: [Diagnostic] = []
+        let svgs = try! SVGRenderer(config: config).render(score, diagnostics: &diagnostics)
+        return (try! SVGGeometry.pages(from: svgs), diagnostics)
+    }
+
+    /// Two voices, two source lines each, four bars per line.
+    private let twoVoices = """
+        X:1
+        T:Two Voices
+        M:4/4
+        L:1/8
+        K:D
+        V:M1
+        V:M2
+        [V:M1] abcd efga | bage dcBA | abcd efga | bage dcBA |
+        [V:M2] ABcd efga | bage dcBA | ABcd efga | bage dcBA |
+        [V:M1] abcd efga | bage dcBA | abcd efga | bage dcBA |
+        [V:M2] ABcd efga | bage dcBA | ABcd efga | bage dcBA |
+        """
+
+    // Two source lines × two voices = two systems of two staves, not four systems in a row.
+    @Test func voicesAreStavesOfOneSystem() {
+        let staves = render(twoVoices).pages.flatMap(\.systems)
+        #expect(staves.count == 4)
+        // Staves 0/1 are one system and 2/3 another: each pair shares an x-range, and the
+        // pair sits closer together than the two pairs do.
+        #expect(staves[0].left == staves[1].left && staves[0].right == staves[1].right)
+        #expect(staves[2].left == staves[3].left && staves[2].right == staves[3].right)
+        let withinGroup = staves[1].topY - staves[0].topY
+        let betweenGroups = staves[2].topY - staves[1].topY
+        #expect(withinGroup < betweenGroups)
+    }
+
+    // The bar lines of a system land on the same x on every staff — the point of writing
+    // two voices in parallel is being able to read down the page.
+    @Test func barLinesAlignAcrossTheStavesOfASystem() {
+        let staves = render(twoVoices).pages.flatMap(\.systems)
+        #expect(staves[0].barlineXs == staves[1].barlineXs)
+        #expect(staves[2].barlineXs == staves[3].barlineXs)
+        #expect(!staves[0].barlineXs.isEmpty)
+    }
+
+    // The scroll-sync anchors run forward down the page instead of restarting when the
+    // second voice begins (issue #41's consumer breaks on a non-monotonic sequence).
+    @Test func anchorLinesAreMonotonic() {
+        let lines = render(twoVoices).pages.flatMap(\.systems).compactMap(\.abcLine)
+        #expect(lines.count == 4)
+        #expect(zip(lines, lines.dropFirst()).allSatisfy { $0 <= $1 })
+        // Both staves of a system report the system's line, so consumers filtering for a
+        // strictly increasing sequence keep exactly one anchor per system.
+        #expect(lines[0] == lines[1])
+        #expect(lines[2] == lines[3])
+        #expect(lines[0] < lines[2])
+    }
+
+    // MARK: - Disagreeing voices
+
+    // A voice short of a measure is padded rather than laid out on its own, and the render
+    // says so.
+    @Test func voicesOfUnequalLengthArePaddedAndWarned() {
+        let abc = """
+            X:1
+            T:Ragged
+            M:4/4
+            L:1/8
+            K:D
+            V:M1
+            V:M2
+            [V:M1] abcd efga | bage dcBA | abcd efga |
+            [V:M2] ABcd efga | bage dcBA |
+            """
+        let (pages, diagnostics) = render(abc)
+        let staves = pages.flatMap(\.systems)
+        #expect(staves.count == 2)
+        // The short voice still gets the third measure's bar line: the staff is drawn,
+        // it just has nothing in it.
+        #expect(staves[0].barlineXs == staves[1].barlineXs)
+
+        let warning = diagnostics.first { $0.code == .voiceLengthMismatch }
+        #expect(warning != nil)
+        #expect(warning?.severity == .warning)
+        #expect(warning?.message.contains("M2") == true)
+    }
+
+    // A voice that supplied no music at all for a source line still gets a staff there.
+    @Test func voiceMissingAWholeLineIsPadded() {
+        let abc = """
+            X:1
+            T:Missing Line
+            M:4/4
+            L:1/8
+            K:D
+            V:M1
+            V:M2
+            [V:M1] abcd efga | bage dcBA |
+            [V:M2] ABcd efga | bage dcBA |
+            [V:M1] abcd efga | bage dcBA |
+            """
+        let (pages, diagnostics) = render(abc)
+        let staves = pages.flatMap(\.systems)
+        #expect(staves.count == 4)
+        #expect(staves[2].barlineXs == staves[3].barlineXs)
+        #expect(diagnostics.contains { $0.code == .voiceLengthMismatch })
+    }
+
+    // Voices that agree need no warning — the common case must stay quiet.
+    @Test func agreeingVoicesProduceNoDiagnostic() {
+        #expect(render(twoVoices).diagnostics.isEmpty)
+    }
+
+    // MARK: - Single voice
+
+    // One voice is one staff per system, with no group furniture and nothing to warn about.
+    @Test func singleVoiceIsUnchanged() {
+        let abc = """
+            X:1
+            T:One Voice
+            M:4/4
+            L:1/8
+            K:D
+            abcd efga | bage dcBA |
+            abcd efga | bage dcBA |
+            """
+        let (pages, diagnostics) = render(abc)
+        #expect(pages.flatMap(\.systems).count == 2)
+        #expect(diagnostics.isEmpty)
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/VerticalLayoutTests.swift
+++ b/Tests/CeolKitSVGRendererTests/VerticalLayoutTests.swift
@@ -239,4 +239,98 @@ private let metadata      = try! BravuraMetadata.load()
         let secondToLast = allSystems[allSystems.count - 2]
         #expect(last.abcLine == secondToLast.abcLine + 1)
     }
+
+    // MARK: - Staff groups (issue #58)
+
+    private func group(_ staves: [JustifiedSystem]) -> JustifiedSystemGroup {
+        JustifiedSystemGroup(staves: staves)
+    }
+
+    // The staves of a system stack downward, separated by staffGap, and are all placed
+    // before the next system starts.
+    @Test func groupStavesStackWithStaffGap() {
+        let block = TuneBlock(systemGroups: [group([
+            justifiedSystem(measures: [emptyMeasure(line: 3)]),
+            justifiedSystem(measures: [emptyMeasure(line: 4)], isLast: true),
+        ])])
+        let systems = engine.layout([block]).pages[0].systems
+        #expect(systems.count == 2)
+        let staffHeight = 4.0 * defaultConfig.staffSize
+        #expect(abs(systems[1].origin.y - (systems[0].origin.y + staffHeight + defaultConfig.staffGap)) < 1e-9)
+        // Closer together than two systems would be: that is what makes the group read as one.
+        #expect(defaultConfig.staffGap < defaultConfig.systemGap)
+    }
+
+    // The next system clears the whole group, not just its last staff.
+    @Test func nextSystemClearsTheWholeGroup() {
+        let block = TuneBlock(systemGroups: [
+            group([justifiedSystem(measures: [emptyMeasure(line: 3)]),
+                   justifiedSystem(measures: [emptyMeasure(line: 4)])]),
+            group([justifiedSystem(measures: [emptyMeasure(line: 5)]),
+                   justifiedSystem(measures: [emptyMeasure(line: 6)], isLast: true)]),
+        ])
+        let systems = engine.layout([block]).pages[0].systems
+        #expect(systems.count == 4)
+        let staffHeight = 4.0 * defaultConfig.staffSize
+        let groupHeight = 2 * staffHeight + defaultConfig.staffGap
+        #expect(abs(systems[2].origin.y - (systems[0].origin.y + groupHeight + defaultConfig.systemGap)) < 1e-9)
+    }
+
+    // Membership records where each staff sits and how far the group's furniture reaches.
+    @Test func groupMembershipDescribesTheGroup() {
+        let block = TuneBlock(systemGroups: [group([
+            justifiedSystem(measures: [emptyMeasure(line: 3)]),
+            justifiedSystem(measures: [emptyMeasure(line: 4)], isLast: true),
+        ])])
+        let systems = engine.layout([block]).pages[0].systems
+        let staffHeight = 4.0 * defaultConfig.staffSize
+        let top = try! #require(systems[0].staffGroup)
+        let bottom = try! #require(systems[1].staffGroup)
+        #expect(top.index == 0 && top.count == 2 && top.isGroupLeader)
+        #expect(bottom.index == 1 && !bottom.isGroupLeader)
+        // The top staff's bar lines reach the bottom staff's top line; the bottom staff's stop.
+        #expect(top.nextStaffTopY == systems[1].origin.y + systems[1].staffOrigin)
+        #expect(bottom.nextStaffTopY == nil)
+        // Both agree on where the joining rule ends.
+        #expect(top.bottomY == bottom.bottomY)
+        #expect(abs(top.bottomY - (systems[1].origin.y + systems[1].staffOrigin + staffHeight)) < 1e-9)
+    }
+
+    // A one-voice tune carries no membership, so the emitter takes its original path.
+    @Test func singleStaffSystemHasNoGroupMembership() {
+        let block = TuneBlock(systems: [justifiedSystem(measures: [emptyMeasure(line: 3)], isLast: true)])
+        let systems = engine.layout([block]).pages[0].systems
+        #expect(systems[0].staffGroup == nil)
+    }
+
+    // Every staff reports the group's line, so the anchor sequence stays monotonic (#41).
+    @Test func everyStaffOfAGroupReportsTheGroupsLine() {
+        let block = TuneBlock(systemGroups: [
+            group([justifiedSystem(measures: [emptyMeasure(line: 8)]),
+                   justifiedSystem(measures: [emptyMeasure(line: 9)])]),
+            group([justifiedSystem(measures: [emptyMeasure(line: 10)]),
+                   justifiedSystem(measures: [emptyMeasure(line: 11)], isLast: true)]),
+        ])
+        let systems = engine.layout([block]).pages[0].systems
+        #expect(systems.map(\.abcLine) == [8, 8, 10, 10])
+    }
+
+    // A group breaks to the next page whole rather than being split across the fold.
+    @Test func groupIsNotSplitAcrossAPageBreak() {
+        // A page just tall enough for one two-staff group plus a little.
+        let staffHeight = 4.0 * defaultConfig.staffSize
+        let groupHeight = 2 * staffHeight + defaultConfig.staffGap
+        let config = SVGRenderConfig(
+            pageSize: PageSize(width: 400, height: 20 + groupHeight + defaultConfig.systemGap + staffHeight),
+            margins: EdgeInsets(top: 10, bottom: 10, left: 10, right: 10))
+        let tightEngine = VerticalLayoutEngine(config: config, metadata: metadata)
+        let block = TuneBlock(systemGroups: (0..<2).map { i in
+            group([justifiedSystem(measures: [emptyMeasure(line: 8 + 2 * i)]),
+                   justifiedSystem(measures: [emptyMeasure(line: 9 + 2 * i)], isLast: i == 1)])
+        })
+        let pages = tightEngine.layout([block]).pages
+        #expect(pages.count == 2)
+        // Two staves per page — never one staff orphaned from its partner.
+        #expect(pages.map(\.systems.count) == [2, 2])
+    }
 }

--- a/Tests/CeolKitSVGRendererTests/VoiceAlignerTests.swift
+++ b/Tests/CeolKitSVGRendererTests/VoiceAlignerTests.swift
@@ -1,0 +1,135 @@
+import Testing
+import CeolKitModel
+@testable import CeolKitSVGRenderer
+
+// MARK: - Helpers
+
+private let dummyRange = SourceRange(file: nil, byteOffset: 0, length: 0, line: 1, column: 0)
+private let dummyBar   = BarLine(kind: .single, source: dummyRange)
+
+private func measure(line: Int) -> Measure {
+    Measure(openingBar: nil, events: [], closingBar: dummyBar, endingNumber: nil,
+            source: SourceRange(file: nil, byteOffset: 0, length: 0, line: line, column: 0))
+}
+
+/// A voice whose staves are given as measure counts — one stave per source line.
+private func voice(_ id: String, staves: [Int]) -> Voice {
+    Voice(
+        id: .named(id),
+        properties: VoiceProperties(
+            clef:            ClefSpec(clef: .treble, octaveShift: 0),
+            transposition:   .none,
+            staffProperties: StaffProperties(staffLines: 5),
+            name:            nil,
+            subname:         nil,
+            stemDirection:   .auto,
+            middleNote:      nil
+        ),
+        staves: staves.enumerated().map { index, count in
+            Staff(measures: (0..<count).map { _ in measure(line: index + 1) }, overlays: [])
+        },
+        directives: [],
+        source: dummyRange
+    )
+}
+
+private func isInvisibleFullMeasureRest(_ m: Measure) -> Bool {
+    guard m.events.count == 1, case .rest(let rest) = m.events[0] else { return false }
+    return rest.kind == .fullMeasureInvisible
+}
+
+// MARK: - Tests
+
+@Suite struct VoiceAlignerTests {
+
+    // Voices that already agree pass through untouched and silently.
+    @Test func agreeingVoicesPassThrough() {
+        var diagnostics: [Diagnostic] = []
+        let staves = VoiceAligner.align([voice("1", staves: [4, 4]), voice("2", staves: [4, 4])],
+                                        into: &diagnostics)
+        #expect(staves.map(\.measureCount) == [4, 4])
+        #expect(staves.allSatisfy { $0.measures.count == 2 })
+        #expect(diagnostics.isEmpty)
+    }
+
+    // A single voice is never warned about, however ragged its staves are.
+    @Test func singleVoiceIsNeverWarnedAbout() {
+        var diagnostics: [Diagnostic] = []
+        let staves = VoiceAligner.align([voice("1", staves: [4, 2, 7])], into: &diagnostics)
+        #expect(staves.map(\.measureCount) == [4, 2, 7])
+        #expect(diagnostics.isEmpty)
+    }
+
+    // The short voice is padded up to the long one, with invisible full-measure rests.
+    @Test func shortVoiceIsPaddedWithInvisibleRests() {
+        var diagnostics: [Diagnostic] = []
+        let staves = VoiceAligner.align([voice("1", staves: [4]), voice("2", staves: [2])],
+                                        into: &diagnostics)
+        #expect(staves[0].measureCount == 4)
+        #expect(staves[0].measures[1].count == 4)
+        // The two real measures are kept; only the tail is filler.
+        #expect(!isInvisibleFullMeasureRest(staves[0].measures[1][1]))
+        #expect(isInvisibleFullMeasureRest(staves[0].measures[1][2]))
+        #expect(isInvisibleFullMeasureRest(staves[0].measures[1][3]))
+    }
+
+    // Padding is per source line, so a short line does not pull the next line's music up
+    // into it — the voices stay line for line, which is how they were written.
+    @Test func paddingIsPerSourceLine() {
+        var diagnostics: [Diagnostic] = []
+        let staves = VoiceAligner.align([voice("1", staves: [4, 4]), voice("2", staves: [2, 4])],
+                                        into: &diagnostics)
+        #expect(staves.map(\.measureCount) == [4, 4])
+        // Line 2 of the short voice is its own music, not line 1's overflow.
+        #expect(staves[1].measures[1].allSatisfy { !isInvisibleFullMeasureRest($0) })
+    }
+
+    // A voice with fewer source lines gains whole padded lines rather than being dropped.
+    @Test func voiceWithFewerStavesGainsWholeLines() {
+        var diagnostics: [Diagnostic] = []
+        let staves = VoiceAligner.align([voice("1", staves: [4, 4]), voice("2", staves: [4])],
+                                        into: &diagnostics)
+        #expect(staves.count == 2)
+        #expect(staves[1].measures[1].count == 4)
+        #expect(staves[1].measures[1].allSatisfy(isInvisibleFullMeasureRest))
+    }
+
+    // The warning names both voices and points at the bar where they part.
+    @Test func mismatchWarningNamesTheVoicesAndTheBar() {
+        var diagnostics: [Diagnostic] = []
+        _ = VoiceAligner.align([voice("Melody", staves: [4]), voice("Alternate", staves: [2])],
+                               into: &diagnostics)
+        #expect(diagnostics.count == 1)
+        let warning = diagnostics[0]
+        #expect(warning.code == .voiceLengthMismatch)
+        #expect(warning.severity == .warning)
+        #expect(warning.message.contains("Melody"))
+        #expect(warning.message.contains("Alternate"))
+        // Measures 1 and 2 are shared; measure 3 is the first the short voice lacks.
+        #expect(warning.hint?.contains("measure 3") == true)
+    }
+
+    // Bar numbers in the hint run across the whole tune, not within a line.
+    @Test func mismatchBarNumberIsCountedFromTheStartOfTheTune() {
+        var diagnostics: [Diagnostic] = []
+        _ = VoiceAligner.align([voice("1", staves: [4, 4]), voice("2", staves: [4, 1])],
+                               into: &diagnostics)
+        #expect(diagnostics.count == 1)
+        // Four bars in line 1, then one in line 2 — bar 6 is where they part.
+        #expect(diagnostics[0].hint?.contains("measure 6") == true)
+    }
+
+    // One warning per line that disagrees, not one per padded measure.
+    @Test func oneWarningPerDisagreeingLine() {
+        var diagnostics: [Diagnostic] = []
+        _ = VoiceAligner.align([voice("1", staves: [4, 4, 4]), voice("2", staves: [1, 4, 1])],
+                               into: &diagnostics)
+        #expect(diagnostics.count == 2)
+    }
+
+    @Test func noVoicesProducesNoStaves() {
+        var diagnostics: [Diagnostic] = []
+        #expect(VoiceAligner.align([], into: &diagnostics).isEmpty)
+        #expect(diagnostics.isEmpty)
+    }
+}


### PR DESCRIPTION
Closes #58.

A tune with two or more `V:` voices engraved each voice's music one after the other, top to bottom, as an unbroken run of single-staff systems. It was unreadable, and it broke consumers silently: the `abcLine` anchor sequence restarted when the second voice began, so a scroll-sync interpolator that keeps only strictly increasing anchors (#41) dropped everything after voice 0 and stopped tracking partway down the preview.

Voices are now the staves of one system — one system per source line, measures and bar lines aligned across them.

## What changed

- **`VoiceAligner`** (new) brings the voices into agreement about how much music each source line holds. In a well-formed parallel source they already agree, so it is a pass-through. Where they do not, the short voice is padded with `RestKind.fullMeasureInvisible` and a new `DiagnosticCode.voiceLengthMismatch` warning names the voices and the bar where they part. Per the issue, falling back to sequential layout is not an option.
- **`LineBreaker.breakIntoGroups`** picks break points legal for every voice at once. Column width is the `max` across voices, not each voice's own. The packing internals now work on widths and return index ranges, so one decision drives every staff.
- **`Justifier.justifyGroups`** derives one set of column widths per system and applies them to every staff. That is what puts a bar line at column *j* on the same x on all of them.
- **`VerticalLayoutEngine`** stacks a system's staves with a new `SVGRenderConfig.staffGap` (defaults to `staffSize * 3`, deliberately tighter than `systemGap`), breaks to the next page as a whole group, and reports the group's source line on every staff so the anchor sequence is monotonic again.
- **`SVGEmitter`** carries each staff's bar lines down to the next staff's top line so a system's bar lines read as one stroke, and draws the rule that joins the staves at the left edge.
- **`SVGRenderer.render(_:diagnostics:)`** (new) surfaces what the renderer found — `Score.diagnostics` is sealed before rendering starts. `ckprobe` now reports both.
- **`CeolKitSVGGeometry`** recognises a bar line that runs past its own staff.

## Deliberately not done

No brace or bracket at the left edge, only the joining rule. Which staves a bracket spans is a property of `%%score`/`%%staves`, which the parser does not handle and which the issue puts out of scope. Adding one now would mean inventing the grouping it is supposed to express.

## Verification

`ckprobe` on a two-voice, two-line tune — before, voice 1 restarted at line 9 after voice 0 had reached 10:

```
  page[0] systems: 4
      #  abcLine  x-span        width  barlines
      0        8  36..576         540  4
      1        8  36..576         540  4
      2       10  36..387.19   351.19  4
      3       10  36..387.19   351.19  4
```

Two systems of two staves, identical x-spans and bar line positions within each, `abcLine` monotonic.

- **Single-voice output is byte-identical.** Rendered `Tests/CeolKitSVGRendererTests/tunebook.abc` (16 pages) before and after: the only difference is the `$D` footer timestamp's minute, which moved between the two runs. A group of one staff carries no membership and takes exactly the path it always did.
- 691 tests pass (was 661). New: `VoiceAlignerTests` (9), `MultiVoiceSystemTests` (7, end to end through the geometry reader), plus joint-breaking, group-justification and group-stacking cases in the existing suites.
- One existing test changed: `systemsOverflowingPageProduceMultipleElements` used three voices to force three systems, which is now one system three staves tall. Rewritten with three staves of one voice, which is what it was actually testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xirTKgxQqbSBUQfrk5BXK