### PR TITLE
Fix #60 — scope accidental bar memory to the voice that wrote it

### DIFF
--- a/Sources/CeolKitParser/Semantic/AccidentalScope.swift
+++ b/Sources/CeolKitParser/Semantic/AccidentalScope.swift
@@ -1,6 +1,9 @@
 import CeolKitModel
 
-/// Tracks accidental state within a single bar.
+/// Tracks accidental state within a single bar of a single voice.
+///
+/// One instance per voice — §4.2 scopes an accidental to the bar *and* to the voice that
+/// wrote it, so `BodyContext` keys these by voice id rather than holding one for the tune.
 ///
 /// The key signature provides the baseline alteration for each step (octave-independent).
 /// Within a bar, explicit written accidentals override the key signature for subsequent

--- a/Sources/CeolKitParser/Semantic/AccidentalScope.swift
+++ b/Sources/CeolKitParser/Semantic/AccidentalScope.swift
@@ -7,7 +7,7 @@ import CeolKitModel
 ///
 /// The key signature provides the baseline alteration for each step (octave-independent).
 /// Within a bar, explicit written accidentals override the key signature for subsequent
-/// notes at the same pitch level (step + octave), per ABC spec §4.3.
+/// notes at the same pitch level (step + octave), because that's how music works..
 struct AccidentalScope {
     let keyAlterations: [DiatonicStep: Alteration]
     private var barMemory: [(step: DiatonicStep, octave: Int, alteration: Alteration)] = []

--- a/Sources/CeolKitParser/Semantic/SemanticPass.swift
+++ b/Sources/CeolKitParser/Semantic/SemanticPass.swift
@@ -345,7 +345,7 @@ struct SemanticPass {
 
         case .barLine(let kind, let src):
             ctx.closeCurrentMeasure(barLine: BarLine(kind: kind, source: src))
-            ctx.accidentalScope.resetBar()
+            ctx.resetBarAccidentals()
 
         case .inlineField(let field, let src):
             applyInlineField(field, source: src, ctx: &ctx, diagnostics: &diagnostics)
@@ -424,7 +424,7 @@ struct SemanticPass {
         let baseOctave = tok.pitchLetter.isUppercase ? 4 : 5
         let octave = baseOctave + tok.octaveMarks
 
-        let currentResolved = ctx.accidentalScope.resolve(step: step, octave: octave)
+        let currentResolved = ctx.resolveAccidental(step: step, octave: octave)
         let writtenAlt = tok.accidental.map { alterationFromToken($0) }
         let playedAlt: Alteration
         let displayedAlt: Alteration?
@@ -432,7 +432,7 @@ struct SemanticPass {
             playedAlt = written
             // displayedAccidental is nil when the accidental is redundant (bar memory already implies it)
             displayedAlt = (written == currentResolved) ? nil : written
-            ctx.accidentalScope.record(step: step, octave: octave, alteration: written)
+            ctx.recordAccidental(step: step, octave: octave, alteration: written)
         } else {
             playedAlt = currentResolved
             displayedAlt = nil
@@ -474,14 +474,14 @@ struct SemanticPass {
             let baseOctave = tok.pitchLetter.isUppercase ? 4 : 5
             let octave = baseOctave + tok.octaveMarks
 
-            let currentResolved = ctx.accidentalScope.resolve(step: step, octave: octave)
+            let currentResolved = ctx.resolveAccidental(step: step, octave: octave)
             let writtenAlt = tok.accidental.map { alterationFromToken($0) }
             let playedAlt: Alteration
             let displayedAlt: Alteration?
             if let written = writtenAlt {
                 playedAlt = written
                 displayedAlt = (written == currentResolved) ? nil : written
-                ctx.accidentalScope.record(step: step, octave: octave, alteration: written)
+                ctx.recordAccidental(step: step, octave: octave, alteration: written)
             } else {
                 playedAlt = currentResolved
                 displayedAlt = nil
@@ -536,7 +536,7 @@ struct SemanticPass {
         switch field {
         case .key(let k):
             ctx.key = k
-            ctx.accidentalScope = AccidentalScope(keyAlterations: keyAlterations(for: k))
+            ctx.rekeyAccidentalScopes(k)
         case .meter(let m, _):
             ctx.meter = m
             ctx.meterChangedSinceLastBar = true
@@ -1224,7 +1224,17 @@ private struct BodyContext {
     var key: KeySignature
     var userSymbols: [Character: Decoration]
     var macros: [MacroDefinition]
-    var accidentalScope: AccidentalScope
+
+    /// Bar-scoped accidental memory, one table per voice.
+    ///
+    /// ABC §4.2 scopes a written accidental to the rest of the bar *in the voice that wrote
+    /// it*: a `^F` in the melody must not make the harmony's `F` sound or print as F♯.  A
+    /// voice's table is created on first use, so a voice that never writes an accidental
+    /// costs nothing.
+    private var accidentalScopes: [String: AccidentalScope] = [:]
+    /// Baseline alterations a newly created scope starts from.  Tune-wide today; issue #66
+    /// makes the key per voice, at which point this is looked up from the voice instead.
+    private var scopeKeyAlterations: [DiatonicStep: Alteration]
 
     // Voice tracking
     var currentVoiceId: String = "1"
@@ -1282,7 +1292,7 @@ private struct BodyContext {
         self.key = key
         self.userSymbols = userSymbols
         self.macros = macros
-        self.accidentalScope = AccidentalScope(keyAlterations: keyAlterations(for: key))
+        self.scopeKeyAlterations = keyAlterations(for: key)
         self.voiceProperties = headerVoices
         self.linebreakChars = linebreakChars
         self.linebreakOnEOL = linebreakOnEOL
@@ -1290,6 +1300,40 @@ private struct BodyContext {
 
     mutating func splitCurrentStave() {
         voiceData[currentVoiceId]?.markStaveBoundary()
+    }
+
+    // MARK: Accidental scope (per voice)
+
+    /// The effective alteration for a pitch in the *current* voice: that voice's bar memory
+    /// first, then the key signature.  A voice with no table yet has empty bar memory, so an
+    /// unrecorded voice resolves straight to the key — no need to materialise the table here.
+    func resolveAccidental(step: DiatonicStep, octave: Int) -> Alteration {
+        accidentalScopes[currentVoiceId]?.resolve(step: step, octave: octave)
+            ?? scopeKeyAlterations[step]
+            ?? .natural
+    }
+
+    /// Records a written accidental into the current voice's bar memory.
+    mutating func recordAccidental(step: DiatonicStep, octave: Int, alteration: Alteration) {
+        accidentalScopes[
+            currentVoiceId,
+            default: AccidentalScope(keyAlterations: scopeKeyAlterations)
+        ].record(step: step, octave: octave, alteration: alteration)
+    }
+
+    /// Clears the current voice's bar memory at a bar line.  Other voices keep theirs: they
+    /// reach their own bar lines on their own lines, and in a shared bar the two voices do
+    /// not necessarily cross the bar at the same point in the source.
+    mutating func resetBarAccidentals() {
+        accidentalScopes[currentVoiceId]?.resetBar()
+    }
+
+    /// Re-seeds every voice's scope after a key change, dropping all bar memory — what the
+    /// single shared scope did before, generalised to N voices.  `[K:]` is tune-wide today;
+    /// issue #66 makes it voice-local.
+    mutating func rekeyAccidentalScopes(_ key: KeySignature) {
+        scopeKeyAlterations = keyAlterations(for: key)
+        accidentalScopes.removeAll()
     }
 
     // Returns voices in the order they were first encountered.

--- a/Tests/CeolKitParserTests/Conformance/AccidentalScopeTests.swift
+++ b/Tests/CeolKitParserTests/Conformance/AccidentalScopeTests.swift
@@ -132,4 +132,84 @@ struct AccidentalScopeTests {
         // (the key signature already shows it).
         #expect(note?.displayedAccidental == nil)
     }
+
+    // MARK: Per-voice scope — issue #60
+
+    /// §4.2 scopes a written accidental to the rest of the bar *in the voice that wrote it*.
+    ///
+    /// Every tune below switches voice **mid-bar**, which is the shape that exposes a shared
+    /// scope. A voice line that ends on a bar line hides the bug: the bar reset fires before
+    /// the next voice is walked, so the leaked memory is cleared on the way past.
+    private func voiceMeasures(_ result: ParseResult, _ id: String) -> [Measure] {
+        result.score.firstTune?.voices.first { $0.id == .named(id) }?.allMeasures ?? []
+    }
+
+    private static let twoVoiceHeader = "X:1\nT:T\nM:4/4\nL:1/4\nK:C\nV:1\nV:2\n"
+
+    @Test("^F in voice 1 does not sharpen voice 2's F in the same bar")
+    func accidentalDoesNotLeakForward() {
+        let result = parse(Self.twoVoiceHeader + "[V:1] ^F F [V:2] F F|\n")
+        let one = voiceMeasures(result, "1").first?.noteEvents ?? []
+        let two = voiceMeasures(result, "2").first?.noteEvents ?? []
+        guard one.count >= 2, two.count >= 2 else { Issue.record("Parser prerequisite not met"); return }
+        // Voice 1 keeps its own bar memory: the second F is still sharp, and undrawn.
+        #expect(one[0].pitch.alteration == Alteration(numerator: 1, denominator: 1))
+        #expect(one[1].pitch.alteration == Alteration(numerator: 1, denominator: 1))
+        #expect(one[1].displayedAccidental == nil)
+        // Voice 2 wrote no accidental, so both its Fs are natural and neither draws one.
+        #expect(two[0].pitch.alteration == Alteration(numerator: 0, denominator: 1))
+        #expect(two[0].displayedAccidental == nil)
+        #expect(two[1].pitch.alteration == Alteration(numerator: 0, denominator: 1))
+        #expect(two[1].displayedAccidental == nil)
+    }
+
+    @Test("The reverse ordering behaves the same — ^F in voice 2 leaves voice 1 alone")
+    func accidentalDoesNotLeakBackward() {
+        let result = parse(Self.twoVoiceHeader + "[V:2] ^F F [V:1] F F|\n")
+        let one = voiceMeasures(result, "1").first?.noteEvents ?? []
+        let two = voiceMeasures(result, "2").first?.noteEvents ?? []
+        guard one.count >= 2, two.count >= 2 else { Issue.record("Parser prerequisite not met"); return }
+        #expect(two[0].pitch.alteration == Alteration(numerator: 1, denominator: 1))
+        #expect(two[1].pitch.alteration == Alteration(numerator: 1, denominator: 1))
+        #expect(one[0].pitch.alteration == Alteration(numerator: 0, denominator: 1))
+        #expect(one[0].displayedAccidental == nil)
+        #expect(one[1].pitch.alteration == Alteration(numerator: 0, denominator: 1))
+    }
+
+    @Test("Bar reset is independent per voice")
+    func barResetIsPerVoice() {
+        // Voice 1 leaves its bar open across the voice switch; voice 2 then closes a bar of
+        // its own. That bar line is voice 2's, so voice 1's ^F must survive it — all four of
+        // voice 1's notes are one bar and all four sound F#.
+        let result = parse(Self.twoVoiceHeader + "[V:1] ^F F\n[V:2] F F|\n[V:1] F F|\n")
+        let one = voiceMeasures(result, "1").first?.noteEvents ?? []
+        let two = voiceMeasures(result, "2").first?.noteEvents ?? []
+        guard one.count >= 4, two.count >= 2 else { Issue.record("Parser prerequisite not met"); return }
+        let sharp = Alteration(numerator: 1, denominator: 1)
+        #expect(one.prefix(4).allSatisfy { $0.pitch.alteration == sharp })
+        // …and voice 2, which never wrote one, stays natural throughout.
+        #expect(two.allSatisfy { $0.pitch.alteration == Alteration(numerator: 0, denominator: 1) })
+    }
+
+    @Test("A voice line that ends mid-bar keeps its accidental to itself")
+    func accidentalDoesNotLeakAcrossAVoiceLineBreak() {
+        // Whole V: lines rather than inline [V:…], neither ending on a bar line.
+        let result = parse("X:1\nT:T\nM:4/4\nL:1/4\nK:C\nV:1\nV:2\nV:1\n^F F\nV:2\nF F\n")
+        let two = voiceMeasures(result, "2").first?.noteEvents ?? []
+        guard two.count >= 2 else { Issue.record("Parser prerequisite not met"); return }
+        #expect(two[0].pitch.alteration == Alteration(numerator: 0, denominator: 1))
+        #expect(two[0].displayedAccidental == nil)
+        #expect(two[1].pitch.alteration == Alteration(numerator: 0, denominator: 1))
+    }
+
+    @Test("An inline [K:] still re-seeds every voice")
+    func keyChangeRekeysAllVoices() {
+        // [K:] is tune-wide until issue #66 makes it per voice; a voice that has not been
+        // walked since the change must still pick the new key up.
+        let result = parse(Self.twoVoiceHeader + "[V:1] F [K:G] F [V:2] F F|\n")
+        let two = voiceMeasures(result, "2").first?.noteEvents ?? []
+        guard two.count >= 2 else { Issue.record("Parser prerequisite not met"); return }
+        #expect(two[0].pitch.alteration == Alteration(numerator: 1, denominator: 1))
+        #expect(two[0].displayedAccidental == nil)
+    }
 }


### PR DESCRIPTION
Fixes #60.

`BodyContext` held a single `AccidentalScope` for the whole tune, so a written accidental
leaked between voices in both directions: a `^F` in one voice sharpened another voice's `F`
for the rest of the bar, and one voice's bar line cleared every other voice's memory. §4.2
scopes an accidental to the bar *and* to the voice that wrote it.

## The change

`accidentalScopes: [String: AccidentalScope]` keyed by voice id, created on first use and
seeded from the tune's key alterations. Three accessors on `BodyContext` replace the direct
field access, so `resetBar()` at a bar line touches only the current voice.

An inline `[K:]` goes through `rekeyAccidentalScopes`, which re-seeds every voice and drops
all bar memory — exactly what the single shared scope did, generalised to N voices. The key
stays tune-wide until #66 makes it per voice; the seeding site is commented to say so.

## On the tests

The obvious test shape — two voices, each on a bar-terminated line — passes *without* the
fix. A voice line ending on `|` fires the bar reset before the next voice is walked, so the
leaked memory is cleared on the way past. The bug only bites when a voice switch happens
mid-bar. Probing five shapes against the unfixed parser:

| shape | leaks? |
|---|---|
| `[V:1] ^F F2\|` / `[V:2] F F2\|` (bar-terminated) | no |
| `[V:1] ^F F [V:2] F F\|` (inline switch mid-bar) | **yes** |
| whole `V:` lines ending mid-bar | **yes** |
| voice 2's bar line crossing voice 1's open bar | **yes, both directions** |

The last one is the interesting case: voice 2's bar line cleared voice 1's still-open bar
memory, so voice 1's own notes reverted to natural mid-bar.

The four new tests use those shapes and all four fail on the previous code. A fifth pins the
`[K:]` re-seed — it passes either way, but it guards the one behaviour this change could
plausibly have broken.

Because the bug needs a mid-bar voice switch it was unreachable for single-voice tunes and
mostly unreachable for well-formed multi-voice ones. It becomes reachable constantly under
the shared-staff merge (#76), which is why #60 is sequenced first in the milestone.

## Scope — this fix is deliberately narrow

Accidentals are not the only field with this bug, just the one #60 reported. `BodyContext`
carries an implicit `currentVoiceId` cursor, and whether a field is per-voice or tune-wide is
decided field by field. Six more are still tune-wide when they should not be: the slur
counters, the open grace group, `tupletState`, the four `pending*` attachment buffers,
`lastElementWasSpace`, and `meterChangedSinceLastBar`. `switchVoice` resets none of them, and
each leaks across a mid-bar voice switch exactly as accidentals did here.

They are **not** fixed in this PR. #87 tracks the general fix — giving voice-scoped state one
home in a `VoiceState` struct and dropping the cursor — which supersedes the
`accidentalScopes` dictionary this PR introduces while keeping its behaviour and its tests.
Reviewing this one on its own merits is fine; it is the narrow fix for the reported bug.

## Verification

- 696 tests pass.
- The four leak tests fail on `develop` and pass here.
- No renderer or golden changes: single-voice output is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUFhtrUzxSLqg2f4XJpbZ3

