### PR TITLE
Fix #61 — keep V: declaration order, and stop dropping unused voices

### DIFF
--- a/Sources/CeolKitModel/Voice.swift
+++ b/Sources/CeolKitModel/Voice.swift
@@ -27,4 +27,12 @@ public struct Voice: Sendable {
         self.directives = directives
         self.source = source
     }
+
+    /// True when no stave of this voice holds a measure — a voice a `V:` field declared and
+    /// the tune body never wrote to.
+    ///
+    /// Such a voice is part of the model so that a `%%score` plan can name it, but it is not
+    /// printed: ABC §11.1 prints "all voices that appear in the tune body", and this one does
+    /// not appear there.  Renderers filter on this before laying staves out.
+    public var isEmpty: Bool { staves.allSatisfy(\.measures.isEmpty) }
 }

--- a/Sources/CeolKitParser/Semantic/BodyContext.swift
+++ b/Sources/CeolKitParser/Semantic/BodyContext.swift
@@ -343,10 +343,22 @@ struct BodyContext {
     private(set) var keySignatureAlterations: [DiatonicStep: Alteration]
     var userSymbols: [Character: Decoration]
 
-    // Voice table — created on first musical content, never eagerly, so `buildVoices` still
-    // drops a voice that was declared and never written to (see issue #61).
+    // Voice table — created on first musical content, never eagerly, so a voice that was
+    // declared and never written to has no entry here.  `declaredVoices` is what keeps it
+    // from being lost: a `V:` field is a declaration whether or not any note follows it.
     private(set) var voices: [String: VoiceState] = [:]
-    private(set) var voiceOrder: [String] = ["1"]
+
+    /// Every voice this tune knows about, in print order: the header's `V:` declarations
+    /// first, then any the body introduced, in the order each was first seen.
+    ///
+    /// Seeded `["1"]` only when the header declared nothing — that entry is the implicit
+    /// default voice, a placeholder rather than a declaration, which is why it is absent
+    /// from `declaredVoices` and never printed unless music actually lands in it.
+    private(set) var voiceOrder: [String]
+
+    /// The ids an actual `V:` field named, header or inline.  These exist as voices even
+    /// with no music: `%%score` may place a voice the body never switches into (issue #61).
+    private(set) var declaredVoices: Set<String>
     var voiceProperties: [String: VoiceProperties] = [:]
     var voiceDirectives: [String: [CeolKitDirectiveScope]] = [:]
     var bodyTuneDirectives: [CeolKitDirectiveScope] = []
@@ -362,9 +374,12 @@ struct BodyContext {
         key: KeySignature,
         userSymbols: [Character: Decoration],
         headerVoices: [String: VoiceProperties] = [:],
+        headerVoiceOrder: [String] = [],
         linebreakChars: Set<Character> = ["$"],
         linebreakOnEOL: Bool = true
     ) {
+        self.voiceOrder = headerVoiceOrder.isEmpty ? ["1"] : headerVoiceOrder
+        self.declaredVoices = Set(headerVoiceOrder)
         self.unitNoteLength = unitNoteLength
         self.meter = meter
         self.key = key
@@ -385,25 +400,45 @@ struct BodyContext {
     ) -> R {
         let unitLen = unitNoteLength
         let alterations = keySignatureAlterations
+        // Creating state for an id nothing has named yet also gives it a place in the print
+        // order.  Belt and braces — the walker's cursor only ever holds an id that is already
+        // in `voiceOrder` — but it makes "has music" imply "is printed" true by construction
+        // rather than by inspection of every path that can move the cursor.
+        if voices[id] == nil, !voiceOrder.contains(id) { voiceOrder.append(id) }
         return body(&voices[id, default: VoiceState(
             accumulator: VoiceAccumulator(source: source(), unitNoteLength: unitLen),
             accidentals: AccidentalScope(keyAlterations: alterations)
         )])
     }
 
+    /// The voice the walker starts in: the first the header declared, or the implicit `"1"`
+    /// when it declared none.  Music written before the tune's first inline `[V:]` belongs to
+    /// the first voice on the page, not to a voice the header never mentioned.
+    var initialVoice: String { voiceOrder.first ?? "1" }
+
     /// Read-only access.  Never allocates, so a voice that writes nothing costs nothing.
     func voice(_ id: String) -> VoiceState? { voices[id] }
 
-    /// Voices in the order they were first encountered, skipping any that were declared but
-    /// never written to.
-    func orderedVoices() -> [(String, VoiceState)] {
-        voiceOrder.compactMap { id in voices[id].map { (id, $0) } }
+    /// Every voice of the tune in print order, paired with its state.
+    ///
+    /// A `nil` state is a voice a `V:` field declared and no music ever reached — it is still
+    /// a voice, and the caller emits it with empty staves.  The one id that can be dropped
+    /// here is the implicit `"1"` of a tune whose header named its voices: a placeholder no
+    /// one declared and nothing wrote to.
+    func orderedVoices() -> [(String, VoiceState?)] {
+        voiceOrder.compactMap { id in
+            guard let state = voices[id] else {
+                return declaredVoices.contains(id) ? (id, nil) : nil
+            }
+            return (id, state)
+        }
     }
 
     /// Records a `V:` switch.  Does *not* move any cursor — the walker owns that, and assigns
     /// the returned id to the voice it is threading.
     mutating func registerVoice(id: String, properties: VoiceProperties) {
         if !voiceOrder.contains(id) { voiceOrder.append(id) }
+        declaredVoices.insert(id)
         hasExplicitVoice = true
 
         let defaultClef = ClefSpec(clef: .treble, octaveShift: 0)

--- a/Sources/CeolKitParser/Semantic/SemanticPass.swift
+++ b/Sources/CeolKitParser/Semantic/SemanticPass.swift
@@ -190,6 +190,7 @@ struct SemanticPass {
             key: key,
             userSymbols: ctx.userSymbols,
             headerVoices: ctx.headerVoices,
+            headerVoiceOrder: ctx.headerVoiceOrder,
             linebreakChars: ctx.linebreakChars,
             linebreakOnEOL: ctx.linebreakOnEOL
         )
@@ -234,7 +235,10 @@ struct SemanticPass {
         case .unitNoteLength(let f, _): ctx.unitNoteLength = f
         case .tempo(let t, _):          ctx.tempo = t
         case .parts(let p):             ctx.parts = p
-        case .voice(let id, let props, _): ctx.headerVoices[id] = props
+        case .voice(let id, let props, _):
+            if ctx.headerVoices.updateValue(props, forKey: id) == nil {
+                ctx.headerVoiceOrder.append(id)
+            }
         case .userSymbol(let ch, let d, _): ctx.userSymbols[ch] = d
         case .macro(let pat, let exp, let src):
             ctx.macros.append(MacroDefinition(pattern: pat, expansion: exp, source: src))
@@ -286,7 +290,7 @@ struct SemanticPass {
     ) {
         // The one cursor in the pass, threaded from here down.  It is a parameter rather than
         // a field on BodyContext so nothing can read "the current voice" implicitly.
-        var voice = "1"
+        var voice = ctx.initialVoice
         for line in body {
             // Check if this is a single-field lyric line
             if line.count == 1, case .inlineField(let f, _) = line[0], case .lyric(let tokens, _) = f {
@@ -970,22 +974,28 @@ struct SemanticPass {
         var diagnostics: [Diagnostic] = []
 
         for (voiceId, state) in bodyCtx.orderedVoices() {
-            let accumulator = state.accumulator
-            let (measures, voiceDiags) = finaliseAccumulator(accumulator, meter: bodyCtx.meter)
-            diagnostics += voiceDiags
-
+            // A voice a `V:` declared and no music reached: it exists, with one empty stave,
+            // so a later `%%score` can place it.  Renderers skip it — see `Voice.isEmpty`.
             var staves: [Staff] = []
-            var start = 0
-            for breakIdx in accumulator.staveBreakIndices where breakIdx <= measures.count {
-                let slice = Array(measures[start..<breakIdx])
-                if !slice.isEmpty {
-                    staves.append(Staff(measures: slice, overlays: []))
+            if let state {
+                let accumulator = state.accumulator
+                let (measures, voiceDiags) = finaliseAccumulator(accumulator, meter: bodyCtx.meter)
+                diagnostics += voiceDiags
+
+                var start = 0
+                for breakIdx in accumulator.staveBreakIndices where breakIdx <= measures.count {
+                    let slice = Array(measures[start..<breakIdx])
+                    if !slice.isEmpty {
+                        staves.append(Staff(measures: slice, overlays: []))
+                    }
+                    start = breakIdx
                 }
-                start = breakIdx
-            }
-            let tail = Array(measures[start...])
-            if !tail.isEmpty || staves.isEmpty {
-                staves.append(Staff(measures: tail, overlays: []))
+                let tail = Array(measures[start...])
+                if !tail.isEmpty || staves.isEmpty {
+                    staves.append(Staff(measures: tail, overlays: []))
+                }
+            } else {
+                staves = [Staff(measures: [], overlays: [])]
             }
 
             let props = bodyCtx.voiceProperties[voiceId] ?? defaultVoiceProperties()
@@ -1141,6 +1151,10 @@ private struct TuneContext {
     var tempo: Tempo? = nil
     var parts: PartPlan? = nil
     var headerVoices: [String: VoiceProperties] = [:]
+    /// The ids of `headerVoices` in the order the header declared them.  The dictionary
+    /// answers "what are this voice's properties?"; this answers "in what order do the
+    /// voices print?", which a dictionary cannot (issue #61).
+    var headerVoiceOrder: [String] = []
     var userSymbols: [Character: Decoration] = [:]
     var macros: [MacroDefinition] = []
     // metadata fields

--- a/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
+++ b/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
@@ -79,21 +79,28 @@ public struct SVGRenderer: CeolKitRenderer {
             tuneConfig.graceNoteSpacing = graceNoteSpacing
             let sizer = MeasureSizer(config: tuneConfig, metadata: metadata)
 
+            // A voice a `V:` declared and the body never wrote to is in the model so a
+            // `%%score` plan can name it, but it has no music to engrave. Dropping it here
+            // rather than downstream matters: the aligner would pad it with invisible rests
+            // on every line and warn that the voices disagree, drawing a staff of silence
+            // the source never asked for.
+            let printedVoices = tune.voices.filter { !$0.isEmpty }
+
             // Bring the voices into agreement about how much music each source line holds,
             // so the break points chosen below are legal for every one of them. Voices that
             // disagree are padded and warned about rather than laid out sequentially.
-            let alignedStaves = VoiceAligner.align(tune.voices, into: &diagnostics)
+            let alignedStaves = VoiceAligner.align(printedVoices, into: &diagnostics)
 
             // Flatten the aligned staves into one measure column per bar, carrying the
             // stave boundaries as .hard breaks: the semantic pass makes one Staff per source
             // line-break, so the last column of every non-final stave forces a system break.
             var breaks: [ScoreLineBreak?] = []
-            var columnsPerVoice = [[SizedMeasure]](repeating: [], count: tune.voices.count)
+            var columnsPerVoice = [[SizedMeasure]](repeating: [], count: printedVoices.count)
             for (si, stave) in alignedStaves.enumerated() {
                 let isLastStave = si == alignedStaves.count - 1
                 for column in 0..<stave.measureCount {
                     breaks.append(!isLastStave && column == stave.measureCount - 1 ? .hard : nil)
-                    for voiceIndex in tune.voices.indices {
+                    for voiceIndex in printedVoices.indices {
                         columnsPerVoice[voiceIndex].append(
                             sizer.size(stave.measures[voiceIndex][column],
                                        unitNoteLength: tune.unitNoteLength))
@@ -103,7 +110,7 @@ public struct SVGRenderer: CeolKitRenderer {
 
             var tuneGroups: [JustifiedSystemGroup] = []
             if !breaks.isEmpty {
-                let voiceLines = tune.voices.enumerated().map { index, voice in
+                let voiceLines = printedVoices.enumerated().map { index, voice in
                     LineBreaker.VoiceLine(measures: columnsPerVoice[index],
                                           clef: voice.properties.clef,
                                           keySignature: tune.key,
@@ -112,12 +119,12 @@ public struct SVGRenderer: CeolKitRenderer {
                 // Header widths differ between the first system (has time sig) and later
                 // ones, and are the max across the group: the staves of a system have to
                 // start at the same x even when one voice's clef or key signature is wider.
-                let firstHeaderW = tune.voices.reduce(0.0) { widest, voice in
+                let firstHeaderW = printedVoices.reduce(0.0) { widest, voice in
                     max(widest, systemHeaderWidth(clef: voice.properties.clef, keySignature: tune.key,
                                                   meter: tune.meter, metadata: metadata,
                                                   staffSize: tuneConfig.staffSize))
                 }
-                let laterHeaderW = tune.voices.reduce(0.0) { widest, voice in
+                let laterHeaderW = printedVoices.reduce(0.0) { widest, voice in
                     max(widest, systemHeaderWidth(clef: voice.properties.clef, keySignature: tune.key,
                                                   meter: nil, metadata: metadata,
                                                   staffSize: tuneConfig.staffSize))

--- a/Tests/CeolKitParserTests/Conformance/VoiceOrderTests.swift
+++ b/Tests/CeolKitParserTests/Conformance/VoiceOrderTests.swift
@@ -1,0 +1,147 @@
+// Voice collection — issue #61.
+//
+// Two questions this file pins down: in what order do a tune's voices come out, and which
+// voices come out at all.  Both used to be answered by the music body alone, which meant a
+// header that declared V:1/V:2/V:3 could yield them in any other order, and a voice the body
+// never switched into vanished with no diagnostic.
+//
+// Declaration order is what `%%score` (issue #62) places voices by, and a plan may name a
+// voice the body never writes to — so both have to survive the semantic pass.
+import Testing
+import CeolKitModel
+import CeolKitParser
+
+@Suite("Voice order and declaration")
+struct VoiceOrderTests {
+
+    /// The voice ids of the first tune, in the order the model presents them.
+    private func voiceIds(_ result: ParseResult) -> [String] {
+        (result.score.firstTune?.voices ?? []).map { voice in
+            switch voice.id {
+            case .named(let name): name
+            case .all:             "*"
+            }
+        }
+    }
+
+    private func voice(_ result: ParseResult, _ id: String) -> Voice? {
+        result.score.firstTune?.voices.first { $0.id == .named(id) }
+    }
+
+    // MARK: Declaration order
+
+    @Test("Voices come out in V: declaration order, not body order")
+    func declarationOrderWinsOverBodyOrder() {
+        // The body writes A before S; the header declared S first.  The header wins — the
+        // order voices print in is the order the author declared them.
+        let result = parse("""
+            X:1
+            T:T
+            M:4/4
+            L:1/4
+            V:S name="Soprano"
+            V:A name="Alto"
+            V:B name="Bass"
+            K:C
+            [V:A] CDEF|
+            [V:S] GABc|
+            [V:B] C,D,E,F,|
+            """)
+        #expect(voiceIds(result) == ["S", "A", "B"])
+    }
+
+    @Test("A body-only voice appends after every declared one")
+    func bodyOnlyVoiceAppendsLast() {
+        // X is never declared in the header, so it takes its place at the end — after the
+        // voices the author did declare, in the order the body introduced it.
+        let result = parse("""
+            X:1
+            T:T
+            M:4/4
+            L:1/4
+            V:S
+            V:A
+            K:C
+            [V:X] CDEF|
+            [V:A] GABc|
+            [V:S] cdef|
+            """)
+        #expect(voiceIds(result) == ["S", "A", "X"])
+    }
+
+    @Test("A tune with no V: at all still has exactly one voice, \"1\"")
+    func implicitSingleVoiceUnchanged() {
+        let result = parse("X:1\nT:T\nM:4/4\nL:1/4\nK:C\nCDEF|GABc|\n")
+        #expect(voiceIds(result) == ["1"])
+        let measures = voice(result, "1")?.allMeasures ?? []
+        #expect(measures.count == 2)
+    }
+
+    // MARK: Declared but never written to
+
+    @Test("A header-declared voice the body never uses is still a voice, with empty staves")
+    func unusedDeclaredVoiceSurvives() {
+        let result = parse("""
+            X:1
+            T:T
+            M:4/4
+            L:1/4
+            V:S
+            V:A
+            V:B name="Bass"
+            K:C
+            [V:S] CDEF|
+            [V:A] GABc|
+            """)
+        #expect(voiceIds(result) == ["S", "A", "B"])
+        guard let bass = voice(result, "B") else {
+            Issue.record("V:B was dropped")
+            return
+        }
+        // It exists, it kept the properties it was declared with, and it holds no music.
+        #expect(bass.properties.name == "Bass")
+        #expect(bass.allMeasures.isEmpty)
+        #expect(bass.isEmpty)
+        // The voices that do have music are not marked empty.
+        let soprano = voice(result, "S")
+        #expect(soprano?.isEmpty == false)
+    }
+
+    @Test("A voice declared inline and never written to is a voice too")
+    func unusedInlineVoiceSurvives() {
+        let result = parse("X:1\nT:T\nM:4/4\nL:1/4\nK:C\n[V:1] CDEF|\n[V:2]\n")
+        #expect(voiceIds(result) == ["1", "2"])
+        #expect(voice(result, "2")?.isEmpty == true)
+    }
+
+    @Test("Declaring voices does not conjure an empty implicit voice 1")
+    func noPhantomDefaultVoice() {
+        // "1" is the id the walker starts in when nothing else is declared.  A header that
+        // names its own voices must not leave that placeholder behind as a silent staff.
+        let result = parse("X:1\nT:T\nM:4/4\nL:1/4\nV:S\nV:A\nK:C\n[V:S] CDEF|\n[V:A] GABc|\n")
+        #expect(voiceIds(result) == ["S", "A"])
+    }
+
+    // MARK: Where unlabelled music goes
+
+    @Test("Music before the first inline [V:] belongs to the first declared voice")
+    func leadingMusicLandsInFirstDeclaredVoice() {
+        // No [V:] has been seen when CDEF is walked.  It belongs to the voice at the top of
+        // the score, not to a voice id the header never mentioned.
+        let result = parse("""
+            X:1
+            T:T
+            M:4/4
+            L:1/4
+            V:S
+            V:A
+            K:C
+            CDEF|
+            [V:A] GABc|
+            """)
+        #expect(voiceIds(result) == ["S", "A"])
+        let soprano = voice(result, "S")?.allMeasures ?? []
+        #expect(soprano.count == 1)
+        #expect(soprano.first?.noteEvents.count == 4)
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/MultiVoiceSystemTests.swift
+++ b/Tests/CeolKitSVGRendererTests/MultiVoiceSystemTests.swift
@@ -123,6 +123,37 @@ import CeolKitSVGGeometry
         #expect(render(twoVoices).diagnostics.isEmpty)
     }
 
+    // MARK: - Declared but unused voices — issue #61
+
+    // A voice a `V:` declared and the body never wrote to is in the model so a `%%score`
+    // plan can name it, but it has no music, so it is not engraved.  If it reached the
+    // aligner it would be padded with invisible rests on every line and draw a whole staff
+    // of silence — plus a mismatch warning for music the author never wrote.
+    @Test func declaredButUnusedVoiceIsNotDrawn() {
+        let abc = """
+            X:1
+            T:Two Voices
+            M:4/4
+            L:1/8
+            K:D
+            V:M1
+            V:M2
+            V:M3
+            [V:M1] abcd efga | bage dcBA | abcd efga | bage dcBA |
+            [V:M2] ABcd efga | bage dcBA | ABcd efga | bage dcBA |
+            [V:M1] abcd efga | bage dcBA | abcd efga | bage dcBA |
+            [V:M2] ABcd efga | bage dcBA | ABcd efga | bage dcBA |
+            """
+        let (pages, diagnostics) = render(abc)
+        let staves = pages.flatMap(\.systems)
+        // The same page `twoVoices` produces: two systems of two staves, not three, and
+        // laid out identically — the unused voice costs no vertical space either.
+        let expected = render(twoVoices).pages.flatMap(\.systems)
+        #expect(staves.count == 4)
+        #expect(staves.map(\.topY) == expected.map(\.topY))
+        #expect(diagnostics.isEmpty)
+    }
+
     // MARK: - Single voice
 
     // One voice is one staff per system, with no group furniture and nothing to warn about.


### PR DESCRIPTION
Closes #61.

## The bug

Voice order came from the music body. `BodyContext.voiceOrder` was seeded `["1"]` and appended to only by an inline `V:`, so the header's declaration order never reached it — a header declaring `V:S`/`V:A`/`V:B` printed its voices in whatever order the body happened to switch into them. Separately, `orderedVoices()` walked the lazily-created state table, so a voice the header declared and the body never wrote to produced nothing at all, silently.

`ckprobe` on a tune declaring `V:S`/`V:A`/`V:B` whose body writes `[V:A]` then `[V:S]`, before this change:

```
tune[0] voice[0] ... stave[0] measure source lines: [9]    <- V:A
tune[0] voice[1] ... stave[0] measure source lines: [10]   <- V:S
```

Two voices, body order, `V:B` gone. After: three voices as `S`, `A`, `B`, with `B` holding no measures — and the page still drawing two staves.

Both defects matter for `%%score` (#62): a plan places voices by declaration order, and may name a voice the body never switches into.

> The issue's line references were stale — #87 moved this code from `SemanticPass.swift` into `BodyContext.swift`. The defects were unchanged.

## What changed

| File | Change |
|---|---|
| `SemanticPass.swift` | `TuneContext.headerVoiceOrder` carries declaration order out of the header; the walker's cursor starts at `ctx.initialVoice`; `buildVoices` emits an empty `Staff` for a stateless voice |
| `BodyContext.swift` | `voiceOrder` seeded from the header; new `declaredVoices` set; `orderedVoices()` returns `VoiceState?` |
| `Voice.swift` | `isEmpty`, documenting that such a voice exists in the model but is not printed |
| `CeolKitSVGRenderer.swift` | Binds `printedVoices` once, filtered on `isEmpty`, for all five former `tune.voices` uses |

Three decisions worth review:

- **The implicit `"1"` is not a declaration.** It is excluded from `declaredVoices`, so a header naming its own voices does not sprout a phantom empty staff. Without this, seeding `voiceOrder` from the header would have turned the placeholder into a printed voice.
- **The cursor had to move.** With `voiceOrder` seeded from the header, a bar written before the first inline `[V:]` would have landed in an id absent from `voiceOrder` and been dropped entirely. It now starts at the first declared voice, and `withVoice` appends unknown ids as a structural backstop — after this, "has music" implies "is printed" by construction.
- **The renderer filter is not cosmetic.** Left unfiltered, the empty voice reaches `VoiceAligner`, which pads it with invisible rests on every line and draws a staff of silence, plus a spurious `.voiceLengthMismatch` for music the author never wrote.

## Acceptance

- [x] Voices come out in `V:` declaration order regardless of body order
- [x] A header-declared, body-unused voice appears in `tune.voices` with empty staves
- [x] Rendering a tune with such a voice produces no extra staff
- [x] `CanzonettaTests` still passes (3 voices, declared and used in order)

## Tests

New `Tests/CeolKitParserTests/Conformance/VoiceOrderTests.swift` — 7 cases: declaration order beats body order, body-only voice appends last, unused header voice survives, unused inline voice survives, no phantom default voice, leading unlabelled music lands in the first declared voice, single-voice tunes unchanged.

`declaredButUnusedVoiceIsNotDrawn` in `MultiVoiceSystemTests` renders the existing two-voice fixture with an extra unused `V:M3` and asserts identical stave count *and* `topY` layout, with no diagnostics.

713 tests in 50 suites pass (705 before). `VoiceScopeTests`, `VoiceAlignerTests` and `TunebookTests` are unchanged.

## Deliberately not here

- **No diagnostic for a declared-but-unused voice.** Acceptance does not ask for one, and `%%score` may legitimately name such a voice.
- **Header `V:` duplicate merging.** A repeated `V:1` in the header still overwrites rather than merging the way `registerVoice` merges inline ones. Pre-existing, separate.
- **`hasExplicitVoice`** is still set only by an inline `V:`, so `%%ceolkit:stemalignment` scoping does not move.

As the issue asks, this lands alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nwj54Htj6wS6wNNqPGGBmY