### PR TITLE
Move actions/cache to v5, off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           swift --version
 
       - name: Cache SwiftPM dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/Library/Caches/org.swift.swiftpm
           key: swiftpm-macos-${{ hashFiles('Package.resolved') }}
@@ -59,7 +59,7 @@ jobs:
         run: swift --version
 
       - name: Cache SwiftPM dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/org.swift.swiftpm
           key: swiftpm-linux-${{ hashFiles('Package.resolved') }}


### PR DESCRIPTION
Every CI run annotates both legs with:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/cache@v4`.

`actions/cache@v4` declares `using: 'node20'`. GitHub [deprecated Node 20 on its runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) and now runs those actions on Node 24 anyway — so the warning describes a substitution that is already happening on every run.

Bumping to `v5` makes it explicit: v5's `action.yml` declares `using: 'node24'`, which is exactly what that release was for. Inputs are unchanged, so the `path` / `key` / `restore-keys` blocks are untouched. `actions/checkout` was already on v5, which is why it never warned.

## Why v5 and not v6

`v6` exists and is also Node 24, but it is an ESM migration on top of the same runtime — it clears nothing extra here. The v5 line is still maintained: v5.1.0 and v6.1.0 shipped the same day, so this is not a dead branch.

## Caveat

`actions/cache@v5` requires runner `2.327.1` or newer. Every GitHub-hosted runner satisfies this, and this repo uses only hosted runners (`macos-26`, `ubuntu-latest`). It would be the thing to check first if self-hosted runners are ever added.

## Verification

The change is two identical one-line bumps, one per job. This PR's own CI run is the test: it should go green with no Node annotation.

Not bundled into #89 — issue #61 asks to land alone, and a CI change does not belong in a parser PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nwj54Htj6wS6wNNqPGGBmY