### PR TITLE
Update test dependencies to their current releases

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "6c9cd2d44d5ffd786465b339df3ee24d445d01485963c01ab2cd1e2e1bb4a593",
+  "originHash" : "21af4b05f8803f6886e8b94408f9cfeaa7ea9f47c9807d39a5aee6bca8019abf",
   "pins" : [
     {
       "identity" : "swift-custom-dump",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
-        "version" : "1.5.0"
+        "revision" : "e9c34fd54ece006b491a0e6d23fe9a6024b9a828",
+        "version" : "1.7.0"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
-        "version" : "1.19.2"
+        "revision" : "59a99c458de4d2dee580529b61b4f78dca7b7fa6",
+        "version" : "1.19.4"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "9de99a78f099e59caf2b2beec65a4c45d54b2081",
-        "version" : "603.0.1"
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
-        "version" : "1.9.0"
+        "revision" : "8f6abcf4c8950e2679d5b2fee4ca284fd7c34886",
+        "version" : "1.11.0"
       }
     }
   ],


### PR DESCRIPTION
Routine bump of the four test-only dependencies:

| Package | From | To |
|---|---|---|
| swift-custom-dump | 1.5.0 | 1.7.0 |
| swift-snapshot-testing | 1.19.2 | 1.19.4 |
| swift-syntax | 603.0.1 | 603.0.2 |
| xctest-dynamic-overlay | 1.9.0 | 1.11.0 |

`swift package update` reported a `FoundationNetworking` trait mismatch between
swift-snapshot-testing and swift-custom-dump while it was searching. That turned out to
come from a stale `.build`, not from the pins — from a clean checkout, both the old and
the new sets resolve, build, and pass the full suite (713 tests, 50 suites).

Independent of #62; either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ti4qg7EGCvA5Pa7o9TL8fF