### PR TITLE
Fix #62 — parse %%score / %%staves into a StaffPlan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ Six `%%ceolkit:*` directives are first-class model members:
 - `%%ceolkit:scale F` (F > 0; tune-wide, never per-voice)
 - `%%ceolkit:gracenotespacing F` (F >= 1, in grace notehead widths; tune-wide, never per-voice)
 
-All are represented in `CeolKitDirective` (an enum, not a string map) with an `.unknown(name:payload:)` case for forward compatibility. They attach to a `Scope` (`.fileGlobal`, `.tuneGlobal`, `.voiceLocal(VoiceId)`).
+All are represented in `CeolKitDirective` (an enum, not a string map). An unrecognised directive is not represented at all: it produces an `unknownDirective` diagnostic and is dropped. They attach to a `Scope` (`.fileGlobal`, `.tuneGlobal`, `.voiceLocal(VoiceId)`).
 
 ### Dialect
 ```swift

--- a/Sources/CeolKitModel/CeolKitDirective.swift
+++ b/Sources/CeolKitModel/CeolKitDirective.swift
@@ -20,6 +20,7 @@ public enum CeolKitDirective: Hashable, Sendable {
     case dateFormat(String)            // %%dateformat <strftime-string>  (abcm2ps/abc2svg)
     case straightFlags(Bool)           // %%straightflags bool  (abcm2ps/abc2svg)
     case graceSlurs(Bool)              // %%graceslurs bool      (abcm2ps/abc2svg)
+    case staffPlan(StaffPlan)          // %%score / %%staves     (ABC v2.2 §11.1)
 }
 
 public struct CeolKitDirectiveScope: Sendable {

--- a/Sources/CeolKitModel/Diagnostic.swift
+++ b/Sources/CeolKitModel/Diagnostic.swift
@@ -54,6 +54,9 @@ public enum DiagnosticCode: String, Codable, Sendable {
     // Directives
     case unknownDirective
     case redundantDirective
+    /// A `%%score` / `%%staves` payload did not parse (ABC v2.2 §11.1).  The whole
+    /// directive is dropped rather than stored as a partial tree.
+    case invalidStaffPlan
     // Field keys
     case unknownKey
     // Include directive

--- a/Sources/CeolKitModel/StaffPlan.swift
+++ b/Sources/CeolKitModel/StaffPlan.swift
@@ -1,0 +1,101 @@
+//
+//  StaffPlan.swift
+//  CeolKit
+//
+//  Created by Stephen Beitzel on 8/18/26.
+//
+
+import Foundation
+
+/// Resolved staff layout from `%%score` / `%%staves` (ABC v2.2 §11.1).
+///
+/// The two spellings differ only in the sense of `|`, and both normalise to this tree,
+/// so nothing downstream can tell which one was written.
+///
+/// Equality covers the layout only, not where it was written: `%%staves [S|A|T|B]` and
+/// `%%score [S A T B]` describe the same plan and compare equal, even though the two
+/// payloads are different lengths and so can never carry matching source ranges.  The
+/// ranges are provenance for diagnostics, not part of what the plan *is*.  `StaffPlanVoice`
+/// does the same for the same reason; every other type in the tree gets there through them.
+public struct StaffPlan: Hashable, Sendable {
+    /// The outermost siblings.  The top level has no delimiter of its own, so it is a
+    /// bare branch rather than a node.
+    public let root: StaffPlanBranch
+    public let source: SourceRange
+
+    public init(root: StaffPlanBranch, source: SourceRange) {
+        self.root = root
+        self.source = source
+    }
+
+    public static func == (lhs: StaffPlan, rhs: StaffPlan) -> Bool {
+        lhs.root == rhs.root
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(root)
+    }
+}
+
+public indirect enum StaffPlanNode: Hashable, Sendable {
+    case voice(StaffPlanVoice)
+    case shared(StaffPlanBranch)   // `( … )` — these voices share one staff
+    case brace(StaffPlanBranch)    // `{ … }`
+    case bracket(StaffPlanBranch)  // `[ … ]`
+}
+
+/// One or more sibling nodes and the joints between them.  `head` guarantees non-emptiness;
+/// each `tail` element carries the joint that *precedes* it, so there are always exactly
+/// `count - 1` joints and no index arithmetic.
+public struct StaffPlanBranch: Hashable, Sendable {
+    public let head: StaffPlanNode
+    public let tail: [Sibling]
+
+    public struct Sibling: Hashable, Sendable {
+        public let joint: StaffPlanJoint
+        public let node: StaffPlanNode
+
+        public init(joint: StaffPlanJoint, node: StaffPlanNode) {
+            self.joint = joint
+            self.node = node
+        }
+    }
+
+    public init(head: StaffPlanNode, tail: [Sibling] = []) {
+        self.head = head
+        self.tail = tail
+    }
+
+    /// The siblings in written order, joints discarded.
+    public var nodes: [StaffPlanNode] {
+        [head] + tail.map(\.node)
+    }
+}
+
+public enum StaffPlanJoint: Hashable, Sendable {
+    case separate
+    case continuedBarline
+}
+
+/// Equality ignores `source`, so that plans written differently but meaning the same
+/// thing compare equal — see `StaffPlan`.
+public struct StaffPlanVoice: Hashable, Sendable {
+    public let id: VoiceId
+    public let isFloating: Bool    // `*V`
+    public let source: SourceRange
+
+    public init(id: VoiceId, isFloating: Bool, source: SourceRange) {
+        self.id = id
+        self.isFloating = isFloating
+        self.source = source
+    }
+
+    public static func == (lhs: StaffPlanVoice, rhs: StaffPlanVoice) -> Bool {
+        lhs.id == rhs.id && lhs.isFloating == rhs.isFloating
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(isFloating)
+    }
+}

--- a/Sources/CeolKitParser/Fields/StaffPlanParser.swift
+++ b/Sources/CeolKitParser/Fields/StaffPlanParser.swift
@@ -1,0 +1,255 @@
+import CeolKitModel
+
+/// Parses the payload of `%%score` / `%%staves` (ABC v2.2 §11.1) into a `StaffPlan`.
+///
+/// The line classifier splits `%%name payload` on the first space only, with no bracket
+/// or quote awareness (`LineClassifier.swift:79-87`), so every delimiter in the payload
+/// is this parser's business.
+///
+/// The two spellings share a grammar and differ only in the sense of `|`: in `%%score` a
+/// `|` means the bar lines continue across that boundary, in `%%staves` it means they do
+/// not.  The inversion is applied while the tree is built, so `%%staves [S|A|T|B]` and
+/// `%%score [S A T B]` yield the same structure.
+///
+/// On any syntax error the whole directive is dropped rather than stored as a partial
+/// tree, matching how the other directives recover.
+enum StaffPlanParser {
+
+    /// - Parameters:
+    ///   - name: the directive name as written, `"score"` or `"staves"`.
+    ///   - payload: everything after the first space of the directive line.
+    ///   - source: the range of the whole directive line.
+    static func parse(
+        name: String,
+        payload: String,
+        source: SourceRange
+    ) -> (StaffPlan?, [Diagnostic]) {
+        // The payload begins after "%%", the name, and the single separating space.
+        let origin = source.byteOffset + 2 + name.utf8.count + 1
+        var parser = Parser(
+            payload: payload,
+            origin: origin,
+            line: source,
+            directiveName: name,
+            invertJoints: name == "staves"
+        )
+        do {
+            let root = try parser.parsePlan()
+            return (StaffPlan(root: root, source: source), [])
+        } catch let error as PlanError {
+            return (nil, [error.diagnostic])
+        } catch {
+            return (nil, [])
+        }
+    }
+
+    // MARK: - Recursive descent
+
+    private struct PlanError: Error {
+        let diagnostic: Diagnostic
+    }
+
+    private struct Parser {
+        /// Each character of the payload with its absolute UTF-8 offset.  Columns are
+        /// byte-based here, as they are in `MusicLexer.makeRange`.
+        private let items: [(ch: Character, offset: Int)]
+        private let endOffset: Int
+        private let line: SourceRange
+        private let directiveName: String
+        private let invertJoints: Bool
+        private var index = 0
+
+        init(payload: String, origin: Int, line: SourceRange, directiveName: String, invertJoints: Bool) {
+            var items: [(ch: Character, offset: Int)] = []
+            var offset = origin
+            for ch in payload {
+                items.append((ch, offset))
+                offset += ch.utf8.count
+            }
+            self.items = items
+            self.endOffset = offset
+            self.line = line
+            self.directiveName = directiveName
+            self.invertJoints = invertJoints
+        }
+
+        mutating func parsePlan() throws -> StaffPlanBranch {
+            let root = try parseBranch(opener: nil, openIndex: 0)
+            skipSpace()
+            if let ch = current {
+                throw error("'\(ch)' is left over after the end of the staff plan", at: index)
+            }
+            return root
+        }
+
+        /// - Parameters:
+        ///   - opener: the delimiter this branch was opened with, or `nil` at the top level.
+        ///   - openIndex: where that delimiter was, so an unclosed group points at it.
+        private mutating func parseBranch(opener: Character?, openIndex: Int) throws -> StaffPlanBranch {
+            let closer = opener.map(Self.closer(for:))
+            skipSpace()
+            if current == "|" {
+                throw error("A '|' cannot open \(subject(opener))", at: index)
+            }
+            guard let head = try parseNode() else {
+                throw error(
+                    opener == nil
+                        ? "%%\(directiveName) needs at least one voice"
+                        : "Empty staff group '\(opener!)\(closer!)'",
+                    at: index
+                )
+            }
+
+            var tail: [StaffPlanBranch.Sibling] = []
+            while true {
+                skipSpace()
+                guard let ch = current else {
+                    if let opener {
+                        throw error("Unclosed '\(opener)' in the staff plan", at: openIndex)
+                    }
+                    break
+                }
+                if ch == closer {
+                    index += 1
+                    break
+                }
+                if Self.isCloser(ch) {
+                    throw error(
+                        opener == nil
+                            ? "'\(ch)' closes a staff group that was never opened"
+                            : "'\(ch)' does not close the '\(opener!)' it was reached from",
+                        at: index
+                    )
+                }
+
+                var barLine = false
+                if ch == "|" {
+                    barLine = true
+                    index += 1
+                    skipSpace()
+                }
+                guard let node = try parseNode() else {
+                    throw error(
+                        barLine
+                            ? "A '|' must be followed by a voice or a staff group"
+                            : "'\(ch)' is not valid in a staff plan",
+                        at: index
+                    )
+                }
+                tail.append(StaffPlanBranch.Sibling(joint: joint(barLine: barLine), node: node))
+            }
+
+            return StaffPlanBranch(head: head, tail: tail)
+        }
+
+        /// Returns `nil` where a node cannot start — end of input, a closing delimiter,
+        /// or a `|` — leaving the caller to decide whether that is an error.
+        private mutating func parseNode() throws -> StaffPlanNode? {
+            skipSpace()
+            guard let ch = current else { return nil }
+            if ch == "|" || Self.isCloser(ch) { return nil }
+
+            switch ch {
+            case "(", "{", "[":
+                let openIndex = index
+                index += 1
+                let branch = try parseBranch(opener: ch, openIndex: openIndex)
+                switch ch {
+                case "(": return .shared(branch)
+                case "{": return .brace(branch)
+                default:  return .bracket(branch)
+                }
+            case "*":
+                let start = index
+                index += 1
+                guard let id = scanVoiceId() else {
+                    throw error("'*' marks a floating voice and must be followed by a voice id", at: start)
+                }
+                return .voice(StaffPlanVoice(
+                    id: .named(id),
+                    isFloating: true,
+                    source: range(from: start, to: index)
+                ))
+            default:
+                let start = index
+                guard let id = scanVoiceId() else {
+                    throw error("'\(ch)' is not valid in a staff plan", at: index)
+                }
+                return .voice(StaffPlanVoice(
+                    id: .named(id),
+                    isFloating: false,
+                    source: range(from: start, to: index)
+                ))
+            }
+        }
+
+        // MARK: Scanning
+
+        private var current: Character? {
+            index < items.count ? items[index].ch : nil
+        }
+
+        private mutating func skipSpace() {
+            while let ch = current, ch == " " || ch == "\t" {
+                index += 1
+            }
+        }
+
+        private mutating func scanVoiceId() -> String? {
+            let start = index
+            while let ch = current, Self.isVoiceIdCharacter(ch) {
+                index += 1
+            }
+            guard index > start else { return nil }
+            return String(items[start..<index].map(\.ch))
+        }
+
+        private static func isVoiceIdCharacter(_ ch: Character) -> Bool {
+            ch.isLetter || ch.isNumber || ch == "_" || ch == "-" || ch == "."
+        }
+
+        private static func isCloser(_ ch: Character) -> Bool {
+            ch == ")" || ch == "}" || ch == "]"
+        }
+
+        private static func closer(for opener: Character) -> Character {
+            switch opener {
+            case "(": return ")"
+            case "{": return "}"
+            default:  return "]"
+            }
+        }
+
+        private func subject(_ opener: Character?) -> String {
+            opener == nil ? "a staff plan" : "a staff group"
+        }
+
+        private func joint(barLine: Bool) -> StaffPlanJoint {
+            barLine != invertJoints ? .continuedBarline : .separate
+        }
+
+        // MARK: Source ranges
+
+        /// The range of `items[start..<end]`, or a zero-width range at end of input.
+        private func range(from start: Int, to end: Int) -> SourceRange {
+            let byteOffset = start < items.count ? items[start].offset : endOffset
+            let endByte = end < items.count ? items[end].offset : endOffset
+            return SourceRange(
+                file: line.file,
+                byteOffset: byteOffset,
+                length: max(0, endByte - byteOffset),
+                line: line.line,
+                column: line.column + (byteOffset - line.byteOffset)
+            )
+        }
+
+        private func error(_ message: String, at index: Int) -> PlanError {
+            PlanError(diagnostic: Diagnostic(
+                severity: .warning,
+                code: .invalidStaffPlan,
+                message: message,
+                source: range(from: index, to: index + 1)
+            ))
+        }
+    }
+}

--- a/Sources/CeolKitParser/Semantic/SemanticPass.swift
+++ b/Sources/CeolKitParser/Semantic/SemanticPass.swift
@@ -135,6 +135,7 @@ struct SemanticPass {
         name == "landscape" || name == "flatbeams" || name == "writefields"
             || name == "dateformat" || name == "footer"
             || name == "straightflags" || name == "graceslurs"
+            || name == "score" || name == "staves"
     }
 
     // MARK: - Tune builder
@@ -611,7 +612,8 @@ struct SemanticPass {
             }
         case "landscape", "flatbeams", "ceolkit:justifylast", "ceolkit:scale",
              "ceolkit:gracenotespacing", "writefields",
-             "dateformat", "footer", "straightflags", "graceslurs":
+             "dateformat", "footer", "straightflags", "graceslurs",
+             "score", "staves":
             var tempDiags: [Diagnostic] = []
             if let d = parseCeolKitDirective(name: name, payload: payload, source: source, diagnostics: &tempDiags) {
                 ctx.bodyTuneDirectives.append(CeolKitDirectiveScope(directive: d, scope: .tuneGlobal, source: source))
@@ -944,6 +946,12 @@ struct SemanticPass {
             diagnostics.append(Diagnostic(severity: .warning, code: .unknownDirective,
                 message: "%%graceslurs expects '0'/'false' or '1'/'true'", source: source))
             return nil
+        case "score", "staves":
+            // Both spellings normalise to one StaffPlan; a malformed payload drops the
+            // whole directive rather than storing a partial tree (ABC v2.2 §11.1).
+            let (plan, planDiags) = StaffPlanParser.parse(name: name, payload: payload, source: source)
+            diagnostics += planDiags
+            return plan.map { .staffPlan($0) }
         case "footer":
             // %%footer is file-scoped and extracted directly in build(); silently accept here.
             return nil

--- a/Tests/CeolKitParserTests/Extensions/StaffPlanDirectiveTests.swift
+++ b/Tests/CeolKitParserTests/Extensions/StaffPlanDirectiveTests.swift
@@ -1,0 +1,305 @@
+// %%score / %%staves conformance tests (ABC v2.2 §11.1).
+// Parser and model only — nothing here asserts about rendering.
+import Testing
+import CeolKitModel
+import CeolKitParser
+
+@Suite("Staff Plan Directives")
+struct StaffPlanDirectiveTests {
+
+    // MARK: - Helpers
+
+    /// The staff plan attached to the first tune, or `nil` if the directive was dropped.
+    private func staffPlan(_ abc: String) -> StaffPlan? {
+        guard let tune = parse(abc).score.firstTune else { return nil }
+        for scoped in tune.directives {
+            if case .staffPlan(let plan) = scoped.directive { return plan }
+        }
+        return nil
+    }
+
+    private func staffPlanDiagnostics(_ abc: String) -> [Diagnostic] {
+        parse(abc).score.diagnostics.filter { $0.code == .invalidStaffPlan }
+    }
+
+    /// Wraps a directive in the smallest tune that parses.
+    private func tune(_ directive: String) -> String {
+        """
+        X:1
+        T:Test
+        M:4/4
+        L:1/4
+        \(directive)
+        K:C
+        CDEF|
+        """
+    }
+
+    private func voice(_ node: StaffPlanNode?) -> StaffPlanVoice? {
+        if case .voice(let v) = node { return v }
+        return nil
+    }
+
+    private func branch(_ node: StaffPlanNode?) -> StaffPlanBranch? {
+        switch node {
+        case .shared(let b), .brace(let b), .bracket(let b): return b
+        default: return nil
+        }
+    }
+
+    // MARK: - Accepted plans
+
+    @Test("%%score [1 2 3] is a bracket of three separately barred voices")
+    func canzonetta() {
+        let plan = staffPlan(tune("%%score [1 2 3]"))
+        let root = try! #require(plan?.root)
+        #expect(root.tail.isEmpty)
+
+        guard case .bracket(let inner) = root.head else {
+            Issue.record("root node is not a bracket: \(root.head)")
+            return
+        }
+        #expect(inner.nodes.count == 3)
+        #expect(inner.nodes.compactMap(voice).map(\.id) == [.named("1"), .named("2"), .named("3")])
+        #expect(inner.tail.map(\.joint) == [.separate, .separate])
+        #expect(inner.nodes.compactMap(voice).allSatisfy { !$0.isFloating })
+    }
+
+    @Test("%%score (T1 T2) (B1 B2) is two shared-staff groups at the root")
+    func zochartiLoch() {
+        let plan = staffPlan(tune("%%score (T1 T2) (B1 B2)"))
+        let root = try! #require(plan?.root)
+        #expect(root.tail.count == 1)
+        #expect(root.tail.map(\.joint) == [.separate])
+
+        guard case .shared(let tenors) = root.head,
+              case .shared(let basses) = root.tail[0].node else {
+            Issue.record("root is not two shared groups: \(root)")
+            return
+        }
+        #expect(tenors.nodes.compactMap(voice).map(\.id) == [.named("T1"), .named("T2")])
+        #expect(basses.nodes.compactMap(voice).map(\.id) == [.named("B1"), .named("B2")])
+        #expect(tenors.tail.map(\.joint) == [.separate])
+        #expect(basses.tail.map(\.joint) == [.separate])
+    }
+
+    @Test("%%score [{Vln1 | Vln2} | Vla | Vc | DB] nests a brace inside a bracket")
+    func stringQuintet() {
+        let plan = staffPlan(tune("%%score [{Vln1 | Vln2} | Vla | Vc | DB]"))
+        let root = try! #require(plan?.root)
+
+        guard case .bracket(let outer) = root.head else {
+            Issue.record("root node is not a bracket: \(root.head)")
+            return
+        }
+        #expect(outer.nodes.count == 4)
+        #expect(outer.tail.map(\.joint) == [.continuedBarline, .continuedBarline, .continuedBarline])
+        #expect(outer.nodes.dropFirst().compactMap(voice).map(\.id)
+                == [.named("Vla"), .named("Vc"), .named("DB")])
+
+        guard case .brace(let violins) = outer.head else {
+            Issue.record("first node is not a brace: \(outer.head)")
+            return
+        }
+        #expect(violins.nodes.compactMap(voice).map(\.id) == [.named("Vln1"), .named("Vln2")])
+        #expect(violins.tail.map(\.joint) == [.continuedBarline])
+    }
+
+    @Test("%%score {RH *M| LH} marks only M as floating")
+    func floatingVoice() {
+        let plan = staffPlan(tune("%%score {RH *M| LH}"))
+        let root = try! #require(plan?.root)
+
+        guard case .brace(let inner) = root.head else {
+            Issue.record("root node is not a brace: \(root.head)")
+            return
+        }
+        let voices = inner.nodes.compactMap(voice)
+        #expect(voices.map(\.id) == [.named("RH"), .named("M"), .named("LH")])
+        #expect(voices.map(\.isFloating) == [false, true, false])
+        #expect(inner.tail.map(\.joint) == [.separate, .continuedBarline])
+    }
+
+    @Test("A floating voice's source range covers the '*' and the id")
+    func floatingVoiceSourceRange() {
+        let abc = tune("%%score {RH *M| LH}")
+        let plan = staffPlan(abc)
+        let root = try! #require(plan?.root)
+        guard case .brace(let inner) = root.head, let floater = voice(inner.nodes[1]) else {
+            Issue.record("expected a floating voice at index 1")
+            return
+        }
+        // "%%score {RH *M| LH}" — '*' is the 13th character, i.e. column 13 (1-based).
+        #expect(floater.source.column == 13)
+        #expect(floater.source.length == 2)
+    }
+
+    // MARK: - %%staves inverts the sense of '|'
+
+    @Test("%%staves [S|A|T|B] and %%score [S A T B] describe the same plan")
+    func stavesInvertsJoints() {
+        let fromStaves = staffPlan(tune("%%staves [S|A|T|B]"))
+        let fromScore = staffPlan(tune("%%score [S A T B]"))
+        let staves = try! #require(fromStaves)
+        let score = try! #require(fromScore)
+        #expect(staves == score)
+        #expect(staves.hashValue == score.hashValue)
+    }
+
+    @Test("%%staves without '|' continues the bar lines")
+    func stavesAdjacencyContinuesBarlines() {
+        let fromStaves = staffPlan(tune("%%staves [S A]"))
+        let fromScore = staffPlan(tune("%%score [S|A]"))
+        let staves = try! #require(fromStaves)
+        let score = try! #require(fromScore)
+        #expect(staves == score)
+
+        guard case .bracket(let inner) = staves.root.head else {
+            Issue.record("root node is not a bracket: \(staves.root.head)")
+            return
+        }
+        #expect(inner.tail.map(\.joint) == [.continuedBarline])
+    }
+
+    @Test("Plans that differ in joints are not equal")
+    func differingJointsAreUnequal() {
+        let separate = try! #require(staffPlan(tune("%%score [S A]")))
+        let joined = try! #require(staffPlan(tune("%%score [S|A]")))
+        #expect(separate != joined)
+    }
+
+    @Test("Plans that differ in nesting are not equal")
+    func differingNestingAreUnequal() {
+        let bracket = try! #require(staffPlan(tune("%%score [S A]")))
+        let brace = try! #require(staffPlan(tune("%%score {S A}")))
+        #expect(bracket != brace)
+    }
+
+    // MARK: - Placement
+
+    @Test("%%score in the file preamble attaches to the tune")
+    func preamble() {
+        let abc = """
+        %%score [1 2]
+        X:1
+        T:Test
+        M:4/4
+        L:1/4
+        K:C
+        CDEF|
+        """
+        #expect(staffPlan(abc) != nil)
+        #expect(staffPlanDiagnostics(abc).isEmpty)
+    }
+
+    @Test("%%score in the tune body attaches and is not reported as unknown")
+    func body() {
+        let abc = """
+        X:1
+        T:Test
+        M:4/4
+        L:1/4
+        K:C
+        %%score [1 2]
+        CDEF|
+        """
+        #expect(staffPlan(abc) != nil)
+        let unknown = parse(abc).score.diagnostics.filter { $0.code == .unknownDirective }
+        #expect(unknown.isEmpty)
+    }
+
+    // MARK: - Rejected plans
+
+    @Test("An unclosed delimiter drops the directive", arguments: [
+        "%%score [1 2",
+        "%%score {1 2",
+        "%%score (1 2",
+    ])
+    func unclosed(_ directive: String) {
+        let abc = tune(directive)
+        #expect(staffPlan(abc) == nil)
+        #expect(staffPlanDiagnostics(abc).count == 1)
+    }
+
+    @Test("A mismatched delimiter drops the directive")
+    func mismatchedDelimiter() {
+        let abc = tune("%%score [1 2}")
+        #expect(staffPlan(abc) == nil)
+        #expect(staffPlanDiagnostics(abc).count == 1)
+    }
+
+    @Test("A closing delimiter with nothing open drops the directive")
+    func strayCloser() {
+        let abc = tune("%%score 1 2]")
+        #expect(staffPlan(abc) == nil)
+        #expect(staffPlanDiagnostics(abc).count == 1)
+    }
+
+    @Test("An empty group drops the directive", arguments: [
+        "%%score ()",
+        "%%score []",
+        "%%score {}",
+        "%%score [1 ()]",
+    ])
+    func emptyGroup(_ directive: String) {
+        let abc = tune(directive)
+        #expect(staffPlan(abc) == nil)
+        #expect(staffPlanDiagnostics(abc).count == 1)
+    }
+
+    @Test("An empty payload drops the directive")
+    func emptyPayload() {
+        let abc = tune("%%score")
+        #expect(staffPlan(abc) == nil)
+        #expect(staffPlanDiagnostics(abc).count == 1)
+    }
+
+    @Test("A stray '|' drops the directive", arguments: [
+        "%%score [|1 2]",
+        "%%score [1 2|]",
+        "%%score [1 || 2]",
+        "%%score |1 2",
+        "%%score 1 2|",
+    ])
+    func strayBar(_ directive: String) {
+        let abc = tune(directive)
+        #expect(staffPlan(abc) == nil)
+        #expect(staffPlanDiagnostics(abc).count == 1)
+    }
+
+    @Test("'*' on something that is not a bare voice drops the directive", arguments: [
+        "%%score *(1 2)",
+        "%%score *[1 2]",
+        "%%score {1 *}",
+        "%%score 1 *",
+    ])
+    func floatingNonVoice(_ directive: String) {
+        let abc = tune(directive)
+        #expect(staffPlan(abc) == nil)
+        #expect(staffPlanDiagnostics(abc).count == 1)
+    }
+
+    @Test("An illegal character in a voice id drops the directive")
+    func illegalVoiceIdCharacter() {
+        let abc = tune("%%score [1 + 2]")
+        #expect(staffPlan(abc) == nil)
+        #expect(staffPlanDiagnostics(abc).count == 1)
+    }
+
+    @Test("A rejected plan still yields a tune with music")
+    func recovery() {
+        let abc = tune("%%score [1 2")
+        let result = parse(abc)
+        let measures = result.score.firstTune?.singleVoiceMeasures ?? []
+        #expect(!measures.isEmpty)
+    }
+
+    @Test("The diagnostic points at the offending character")
+    func diagnosticPosition() {
+        // "%%score [1 + 2]" — '+' is the 12th character, i.e. column 12 (1-based).
+        let diagnostics = staffPlanDiagnostics(tune("%%score [1 + 2]"))
+        let first = try! #require(diagnostics.first)
+        #expect(first.source.column == 12)
+        #expect(first.severity == .warning)
+    }
+}


### PR DESCRIPTION
Closes #62. Parser and model only — no renderer consumes the plan yet (#63, #64), so
`SVGEmitter.swift:250`'s note about braces and brackets stays accurate.

## What it does

Both spellings normalise to one `StaffPlan`, so nothing downstream can tell which was
written: `%%staves` inverts the sense of `|`, and that inversion is a single flag applied
where each joint is built. Joints are paired with the node they precede, so a branch
cannot be empty and the joint count is structurally correct without index arithmetic.

The line classifier splits `%%name payload` on the first space only, with no bracket
awareness (`LineClassifier.swift:79-87`), so `StaffPlanParser` owns every delimiter. It
tracks UTF-8 offsets while scanning to give each voice id its own `SourceRange`, which is
what lets a diagnostic point at the offending id rather than at the whole line. On any
syntax error the whole directive is dropped rather than stored as a partial tree, matching
how the other directives recover.

## Custom `==` / `hash(into:)`

`StaffPlan` and `StaffPlanVoice` ignore `SourceRange` in their `Hashable` conformance —
the first types in `CeolKitModel` to do so, so the divergence is documented at the type.
Two spellings of the same plan have different payload lengths and therefore can never
carry matching ranges; the ranges are provenance for diagnostics, not part of what the
plan *is*. Every other type in the tree keeps its synthesized conformance and inherits the
semantics through these two.

The tests assert offsets directly (`floatingVoiceSourceRange`, `diagnosticPosition`) so
ignoring `source` in `==` cannot mask a regression in computing it, and pin the
conformance from the other side too: `[S A]` != `[S|A]` (joints) and `[S A]` != `{S A}`
(nesting).

## Wiring

Directive names live in three hand-synced lists — `isStandardDirective`, the
`parseCeolKitDirective` switch, and the `applyBodyDirective` allowlist. All three learn
`score` and `staves`; the third is what keeps a body `%%score` from reporting
`unknownDirective`.

Also corrects `CLAUDE.md`, which documented a `CeolKitDirective.unknown(name:payload:)`
case that does not exist.

## Verification

734 tests in 51 suites pass from a clean checkout (713 before, 21 new). All four
acceptance tunes parse to the expected tree, and `ckprobe` confirms it end to end on
`%%score [{Vln1 | Vln2} | Vla | Vc | DB]` — bracket/brace nesting, `continuedBarline`
joints, and `Vln1` located at line 3 column 11.

Independent of #92; either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ti4qg7EGCvA5Pa7o9TL8fF