### PR TITLE
Fix #63 — flatten StaffPlan to the staff table the layout engine consumes

### DIFF
--- a/Sources/CeolKitModel/StaffPlanLayout.swift
+++ b/Sources/CeolKitModel/StaffPlanLayout.swift
@@ -1,0 +1,219 @@
+//
+//  StaffPlanLayout.swift
+//  CeolKit
+//
+//  Created by Stephen Beitzel on 8/19/26.
+//
+
+import Foundation
+
+/// A `StaffPlan` tree resolved to the ordered staff table the layout engine consumes.
+///
+/// Voice selection, span threading, bar-line continuation and brace/bracket drawing each
+/// need a different flat view of the same tree.  Deriving all four here, once, keeps every
+/// downstream step from re-implementing the traversal and getting the nesting subtly
+/// different.
+///
+/// Staff indices are positions in ``staves``, counted from zero at the top of the plan, and
+/// every other member of this type is expressed in them.
+public struct StaffPlanLayout: Hashable, Sendable {
+    /// Top to bottom.  Each staff lists the voices printed on it, in plan order.
+    ///
+    /// Floating voices are not here — they have no staff of their own; see ``floating``.
+    public let staves: [[VoiceId]]
+
+    /// Brace and bracket spans over staff indices, outermost first.
+    public let spans: [Span]
+
+    /// Staff index `i` is joined to `i + 1` by a continued bar line.
+    public let barlineJoins: Set<Int>
+
+    /// Voices whose staff is chosen per note, with the staff indices they may land on.
+    public let floating: [FloatingVoice]
+
+    public init(
+        staves: [[VoiceId]],
+        spans: [Span],
+        barlineJoins: Set<Int>,
+        floating: [FloatingVoice]
+    ) {
+        self.staves = staves
+        self.spans = spans
+        self.barlineJoins = barlineJoins
+        self.floating = floating
+    }
+
+    public struct Span: Hashable, Sendable {
+        public let bracket: StaffPlanBracket
+        public let staves: ClosedRange<Int>
+        /// 0 = outermost; drives sub-bracket thickness.
+        public let depth: Int
+
+        public init(bracket: StaffPlanBracket, staves: ClosedRange<Int>, depth: Int) {
+            self.bracket = bracket
+            self.staves = staves
+            self.depth = depth
+        }
+    }
+
+    /// A `*V` voice and the two staves it sits between.  Either neighbour is `nil` where
+    /// the plan has none — the assigner diagnoses that and prints the voice on the staff
+    /// it does have.
+    public struct FloatingVoice: Hashable, Sendable {
+        public let id: VoiceId
+        /// Staff index, `nil` at the top of the plan.
+        public let above: Int?
+        /// Staff index, `nil` at the bottom of the plan.
+        public let below: Int?
+
+        public init(id: VoiceId, above: Int?, below: Int?) {
+            self.id = id
+            self.above = above
+            self.below = below
+        }
+    }
+}
+
+/// Which of the two grouping delimiters a ``StaffPlanLayout/Span`` was drawn from.
+public enum StaffPlanBracket: Hashable, Sendable {
+    case brace     // `{ … }`
+    case bracket   // `[ … ]`
+}
+
+public extension StaffPlan {
+
+    /// The plan flattened to the staff table the layout engine consumes.
+    ///
+    /// Three readings the tree leaves open are settled here, none of them dictated by
+    /// §11.1:
+    ///
+    /// - A floating voice occupies no staff, so the joint written *before* it joins
+    ///   nothing and is discarded; the joint written *after* it governs the boundary
+    ///   between the staves on either side.  That is the sense the standard's own
+    ///   `%%score {RH *M| LH}` is spelled in, and it inverts correctly for `%%staves`.
+    /// - A `( … )` group is one staff, so grouping delimiters nested inside one draw no
+    ///   span, and a `*` inside one marks nothing: the voice is simply printed on the
+    ///   shared staff.
+    /// - A grouping delimiter that ends up covering no staff at all — `{*A}`, say —
+    ///   draws no span, there being no staff to draw it over.
+    var layout: StaffPlanLayout {
+        var walk = Walk()
+        walk.branch(root)
+        return StaffPlanLayout(
+            staves: walk.staves,
+            spans: walk.spans.map {
+                StaffPlanLayout.Span(bracket: $0.bracket, staves: $0.first...$0.last, depth: $0.depth)
+            },
+            barlineJoins: walk.barlineJoins,
+            floating: walk.floating
+        )
+    }
+}
+
+/// The single in-order traversal every member of `StaffPlanLayout` falls out of.
+private struct Walk {
+    var staves: [[VoiceId]] = []
+    var spans: [OpenSpan] = []
+    var barlineJoins: Set<Int> = []
+    var floating: [StaffPlanLayout.FloatingVoice] = []
+
+    /// A span whose last staff is not known until its branch has been walked.  Spans that
+    /// never cover a staff are dropped rather than closed.
+    struct OpenSpan {
+        let bracket: StaffPlanBracket
+        let depth: Int
+        let first: Int
+        var last: Int
+    }
+
+    /// The staff most recently emitted, and so the one a continued bar line would reach
+    /// down from.
+    private var lastStaff: Int?
+    /// The joint waiting to be settled by the next staff.  A joint that meets a floating
+    /// voice instead of a staff is overwritten by the next one rather than consumed.
+    private var pendingJoint: StaffPlanJoint = .separate
+    /// Floating voices still waiting to learn which staff is below them.
+    private var floatingAwaitingBelow: [Int] = []
+    /// How many grouping delimiters enclose the node being walked.
+    private var depth = 0
+
+    mutating func branch(_ branch: StaffPlanBranch) {
+        node(branch.head)
+        for sibling in branch.tail {
+            pendingJoint = sibling.joint
+            node(sibling.node)
+        }
+    }
+
+    private mutating func node(_ node: StaffPlanNode) {
+        switch node {
+        case .voice(let voice):
+            if voice.isFloating {
+                floatingAwaitingBelow.append(floating.count)
+                floating.append(StaffPlanLayout.FloatingVoice(id: voice.id, above: lastStaff, below: nil))
+            } else {
+                emitStaff([voice.id])
+            }
+
+        case .shared(let branch):
+            // One staff, and every voice written anywhere inside it lands on that staff —
+            // including one marked `*`, which has no adjacent staff to float between.
+            emitStaff(Self.voices(in: branch))
+
+        case .brace(let branch):
+            group(branch, bracket: .brace)
+
+        case .bracket(let branch):
+            group(branch, bracket: .bracket)
+        }
+    }
+
+    private mutating func group(_ inner: StaffPlanBranch, bracket: StaffPlanBracket) {
+        // Reserved before the branch is walked so that spans come out outermost first.
+        let slot = spans.count
+        spans.append(OpenSpan(bracket: bracket, depth: depth, first: staves.count, last: -1))
+
+        depth += 1
+        branch(inner)
+        depth -= 1
+
+        if staves.count > spans[slot].first {
+            spans[slot].last = staves.count - 1
+        } else {
+            spans.remove(at: slot)
+        }
+    }
+
+    private mutating func emitStaff(_ voices: [VoiceId]) {
+        let index = staves.count
+        staves.append(voices)
+
+        if pendingJoint == .continuedBarline, let above = lastStaff {
+            barlineJoins.insert(above)
+        }
+        pendingJoint = .separate
+
+        for pending in floatingAwaitingBelow {
+            floating[pending] = StaffPlanLayout.FloatingVoice(
+                id: floating[pending].id,
+                above: floating[pending].above,
+                below: index
+            )
+        }
+        floatingAwaitingBelow.removeAll()
+
+        lastStaff = index
+    }
+
+    /// Every voice under `branch`, in written order, whatever delimiters it is nested in.
+    private static func voices(in branch: StaffPlanBranch) -> [VoiceId] {
+        branch.nodes.flatMap { node -> [VoiceId] in
+            switch node {
+            case .voice(let voice):
+                return [voice.id]
+            case .shared(let inner), .brace(let inner), .bracket(let inner):
+                return voices(in: inner)
+            }
+        }
+    }
+}

--- a/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
+++ b/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
@@ -46,7 +46,8 @@ public struct SVGRenderer: CeolKitRenderer {
         // so each tune can start from that baseline and layer its own on top.
         let fileWriteFields: WriteFieldsConfig = {
             var wf = WriteFieldsConfig.default
-            for scope in score.tunes.first?.directives ?? [] where { if case .fileGlobal = scope.scope { true } else { false } }() {
+            for scope in score.tunes.first?.directives ?? [] {
+                guard case .fileGlobal = scope.scope else { continue }
                 wf.apply(scope.directive)
             }
             return wf

--- a/Tests/CeolKitParserTests/Extensions/StaffPlanLayoutTests.swift
+++ b/Tests/CeolKitParserTests/Extensions/StaffPlanLayoutTests.swift
@@ -1,0 +1,258 @@
+// StaffPlanLayout — the %%score / %%staves tree flattened to the staff table the layout
+// engine consumes (ABC v2.2 §11.1).  Model only: nothing here asserts about rendering.
+//
+// The plans are built by parsing, because that is the only way a StaffPlan is ever made
+// and it keeps each case readable as the directive an author would actually write.
+import Testing
+import CeolKitModel
+import CeolKitParser
+
+@Suite("Staff Plan Layout")
+struct StaffPlanLayoutTests {
+
+    // MARK: - Helpers
+
+    /// The layout of the staff plan attached to the first tune of the smallest tune that
+    /// parses, or `nil` if the directive was dropped.
+    private func flatten(_ directive: String) -> StaffPlanLayout? {
+        let abc = """
+        X:1
+        T:Test
+        M:4/4
+        L:1/4
+        \(directive)
+        K:C
+        CDEF|
+        """
+        guard let tune = parse(abc).score.firstTune else { return nil }
+        for scoped in tune.directives {
+            if case .staffPlan(let plan) = scoped.directive { return plan.layout }
+        }
+        return nil
+    }
+
+    private func named(_ ids: String...) -> [VoiceId] {
+        ids.map { .named($0) }
+    }
+
+    // MARK: - Staves
+
+    @Test("%%score [1 2 3] is three staves under one bracket")
+    func canzonetta() throws {
+        let layout = try #require(flatten("%%score [1 2 3]"))
+        #expect(layout.staves == [named("1"), named("2"), named("3")])
+        #expect(layout.spans == [
+            StaffPlanLayout.Span(bracket: .bracket, staves: 0...2, depth: 0),
+        ])
+        #expect(layout.barlineJoins.isEmpty)
+        #expect(layout.floating.isEmpty)
+    }
+
+    @Test("%%score (T1 T2) (B1 B2) is two shared staves and no spans")
+    func zochartiLoch() throws {
+        let layout = try #require(flatten("%%score (T1 T2) (B1 B2)"))
+        #expect(layout.staves == [named("T1", "T2"), named("B1", "B2")])
+        #expect(layout.spans.isEmpty)
+        #expect(layout.barlineJoins.isEmpty)
+        #expect(layout.floating.isEmpty)
+    }
+
+    @Test("A bare voice list is one staff each")
+    func bareVoices() throws {
+        let layout = try #require(flatten("%%score S A T B"))
+        #expect(layout.staves == [named("S"), named("A"), named("T"), named("B")])
+        #expect(layout.spans.isEmpty)
+        #expect(layout.barlineJoins.isEmpty)
+    }
+
+    // MARK: - Spans
+
+    @Test("%%score [{Vln1 | Vln2} | Vla | Vc | DB] nests a brace inside a bracket")
+    func stringQuintet() throws {
+        let layout = try #require(flatten("%%score [{Vln1 | Vln2} | Vla | Vc | DB]"))
+        #expect(layout.staves == [
+            named("Vln1"), named("Vln2"), named("Vla"), named("Vc"), named("DB"),
+        ])
+        // Outermost first.
+        #expect(layout.spans == [
+            StaffPlanLayout.Span(bracket: .bracket, staves: 0...4, depth: 0),
+            StaffPlanLayout.Span(bracket: .brace, staves: 0...1, depth: 1),
+        ])
+        // Every sibling boundary in the plan is written with '|', so bar lines run
+        // unbroken from the first violin staff to the double bass.
+        #expect(layout.barlineJoins == [0, 1, 2, 3])
+        #expect(layout.floating.isEmpty)
+    }
+
+    @Test("%%score Solo [(S A) (T B)] {RH | (LH1 LH2)} — the standard's own example")
+    func specExample() throws {
+        let layout = try #require(flatten("%%score Solo  [(S A) (T B)]  {RH | (LH1 LH2)}"))
+        #expect(layout.staves == [
+            named("Solo"), named("S", "A"), named("T", "B"), named("RH"), named("LH1", "LH2"),
+        ])
+        #expect(layout.spans == [
+            StaffPlanLayout.Span(bracket: .bracket, staves: 1...2, depth: 0),
+            StaffPlanLayout.Span(bracket: .brace, staves: 3...4, depth: 0),
+        ])
+        #expect(layout.barlineJoins == [3])
+        #expect(layout.floating.isEmpty)
+    }
+
+    @Test("Sibling groups at the same nesting are both depth 0")
+    func siblingGroupsShareDepth() throws {
+        let layout = try #require(flatten("%%score [1 2] [3 4]"))
+        #expect(layout.spans.map(\.depth) == [0, 0])
+        #expect(layout.spans.map(\.staves) == [0...1, 2...3])
+    }
+
+    @Test("Depth counts grouping delimiters, however deeply they nest")
+    func nestedDepth() throws {
+        let layout = try #require(flatten("%%score [{[1 2] 3} 4]"))
+        #expect(layout.staves.count == 4)
+        #expect(layout.spans == [
+            StaffPlanLayout.Span(bracket: .bracket, staves: 0...3, depth: 0),
+            StaffPlanLayout.Span(bracket: .brace, staves: 0...2, depth: 1),
+            StaffPlanLayout.Span(bracket: .bracket, staves: 0...1, depth: 2),
+        ])
+    }
+
+    @Test("A group that covers no staff draws no span")
+    func spanOverNothing() throws {
+        let layout = try #require(flatten("%%score RH {*M} LH"))
+        #expect(layout.staves == [named("RH"), named("LH")])
+        #expect(layout.spans.isEmpty)
+        #expect(layout.floating == [
+            StaffPlanLayout.FloatingVoice(id: .named("M"), above: 0, below: 1),
+        ])
+    }
+
+    @Test("Delimiters nested inside a shared group draw no span")
+    func sharedGroupSwallowsDelimiters() throws {
+        let layout = try #require(flatten("%%score ([A B] C)"))
+        #expect(layout.staves == [named("A", "B", "C")])
+        #expect(layout.spans.isEmpty)
+    }
+
+    // MARK: - Bar-line joins
+
+    @Test("'|' joins the staff above the boundary to the one below it")
+    func joinsAreIndexedByTheStaffAbove() throws {
+        let layout = try #require(flatten("%%score [1 2|3 4|5]"))
+        #expect(layout.barlineJoins == [1, 3])
+    }
+
+    @Test("A '|' across a group boundary joins the last staff of one to the first of the next")
+    func joinsCrossGroupBoundaries() throws {
+        let layout = try #require(flatten("%%score [{1 2} | {3 4}]"))
+        #expect(layout.staves.count == 4)
+        #expect(layout.barlineJoins == [1])
+    }
+
+    @Test("%%staves inverts '|', and the two spellings flatten identically")
+    func stavesInvertsJoints() throws {
+        let fromStaves = try #require(flatten("%%staves [S|A|T|B]"))
+        let fromScore = try #require(flatten("%%score [S A T B]"))
+        #expect(fromStaves == fromScore)
+        #expect(fromStaves.barlineJoins.isEmpty)
+
+        let joined = try #require(flatten("%%staves [S A T B]"))
+        #expect(joined.barlineJoins == [0, 1, 2])
+    }
+
+    // MARK: - Floating voices
+
+    @Test("%%score {RH *M| LH} floats M between the two staves it is written between")
+    func floatingVoice() throws {
+        let layout = try #require(flatten("%%score {RH *M| LH}"))
+        #expect(layout.staves == [named("RH"), named("LH")])
+        #expect(layout.spans == [
+            StaffPlanLayout.Span(bracket: .brace, staves: 0...1, depth: 0),
+        ])
+        #expect(layout.barlineJoins == [0])
+        #expect(layout.floating == [
+            StaffPlanLayout.FloatingVoice(id: .named("M"), above: 0, below: 1),
+        ])
+    }
+
+    @Test("%%score {(RH1 RH2) *M| (LH1 LH2)} floats between two shared staves")
+    func floatingBetweenSharedStaves() throws {
+        let layout = try #require(flatten("%%score {(RH1 RH2) *M| (LH1 LH2)}"))
+        #expect(layout.staves == [named("RH1", "RH2"), named("LH1", "LH2")])
+        #expect(layout.barlineJoins == [0])
+        #expect(layout.floating == [
+            StaffPlanLayout.FloatingVoice(id: .named("M"), above: 0, below: 1),
+        ])
+    }
+
+    @Test("A floating voice at the top of the plan has no staff above it")
+    func floatingAtTop() throws {
+        let layout = try #require(flatten("%%score {*M RH LH}"))
+        #expect(layout.staves == [named("RH"), named("LH")])
+        #expect(layout.floating == [
+            StaffPlanLayout.FloatingVoice(id: .named("M"), above: nil, below: 0),
+        ])
+    }
+
+    @Test("A floating voice at the bottom of the plan has no staff below it")
+    func floatingAtBottom() throws {
+        let layout = try #require(flatten("%%score {RH LH *M}"))
+        #expect(layout.staves == [named("RH"), named("LH")])
+        #expect(layout.floating == [
+            StaffPlanLayout.FloatingVoice(id: .named("M"), above: 1, below: nil),
+        ])
+    }
+
+    @Test("The joint written after a floating voice governs the boundary it straddles")
+    func jointAfterFloatingWins() throws {
+        // The joint before '*M' would join RH to a staff M does not have, so it is
+        // discarded; the one after it settles the RH/LH boundary.
+        let joined = try #require(flatten("%%score {RH *M| LH}"))
+        #expect(joined.barlineJoins == [0])
+
+        let separate = try #require(flatten("%%score {RH| *M LH}"))
+        #expect(separate.barlineJoins.isEmpty)
+
+        // Which means %%staves, where '|' has the opposite sense, inverts cleanly.
+        let inverted = try #require(flatten("%%staves {RH *M| LH}"))
+        #expect(inverted.barlineJoins.isEmpty)
+        #expect(inverted.floating == joined.floating)
+    }
+
+    @Test("Two floating voices in a row both name the same neighbours")
+    func consecutiveFloatingVoices() throws {
+        let layout = try #require(flatten("%%score {RH *M *N| LH}"))
+        #expect(layout.staves == [named("RH"), named("LH")])
+        #expect(layout.floating == [
+            StaffPlanLayout.FloatingVoice(id: .named("M"), above: 0, below: 1),
+            StaffPlanLayout.FloatingVoice(id: .named("N"), above: 0, below: 1),
+        ])
+    }
+
+    @Test("A '*' inside a shared group marks nothing — the voice shares the staff")
+    func floatingInsideSharedGroup() throws {
+        let layout = try #require(flatten("%%score (A *B) C"))
+        #expect(layout.staves == [named("A", "B"), named("C")])
+        #expect(layout.floating.isEmpty)
+    }
+
+    // MARK: - Degenerate plans
+
+    @Test("A plan of one voice is one staff and nothing else")
+    func singleVoice() throws {
+        let layout = try #require(flatten("%%score 1"))
+        #expect(layout.staves == [named("1")])
+        #expect(layout.spans.isEmpty)
+        #expect(layout.barlineJoins.isEmpty)
+        #expect(layout.floating.isEmpty)
+    }
+
+    @Test("A plan of nothing but a floating voice has no staves at all")
+    func onlyAFloatingVoice() throws {
+        let layout = try #require(flatten("%%score *M"))
+        #expect(layout.staves.isEmpty)
+        #expect(layout.spans.isEmpty)
+        #expect(layout.floating == [
+            StaffPlanLayout.FloatingVoice(id: .named("M"), above: nil, below: nil),
+        ])
+    }
+}


### PR DESCRIPTION
Closes #63.

`StaffPlan.layout` walks the tree once and derives the four flat views the layout
engine wants out of it: the ordered staff table, the brace/bracket spans over staff
indices, the set of continued bar-line joins, and the floating voices with the staves
they may land on. Voice selection (#65), span threading, bar-line continuation (#80)
and brace drawing each need a different one of those; deriving them together here keeps
those issues from re-implementing the traversal and disagreeing about the nesting.

`StaffPlanBracket`, which the issue's shape refers to, did not exist — it is added here
alongside `Span`, the only thing that uses it.

## Three readings §11.1 leaves open

Settled here and documented on `layout`:

- **A floating voice's joints.** It occupies no staff, so the joint written *before* it
  joins nothing and is discarded; the one written *after* it governs the boundary
  between the staves on either side. That is how the standard spells its own
  `%%score {RH *M| LH}`, and it inverts correctly for `%%staves`.
- **`( … )` is one staff**, so grouping delimiters nested inside one draw no span, and a
  `*` inside one marks nothing — the voice is simply printed on the shared staff.
- **A delimiter covering no staff at all** — `{*A}` — draws no span, there being no
  staff to draw it over.

## One acceptance criterion is not implemented as written

The issue expects `barlineJoins == [0, 1]` for `[{Vln1 | Vln2} | Vla | Vc | DB]`. That
plan has four sibling boundaries and every one of them is written with `|`, so the joins
are `[0, 1, 2, 3]` — bar lines unbroken from the first violin staff to the double bass,
which is also what a string section wants. The test asserts `[0, 1, 2, 3]`.

## Tests

21 cases in `Tests/CeolKitParserTests/Extensions/StaffPlanLayoutTests.swift`, covering
every acceptance case plus the standard's own `%%score Solo [(S A) (T B)] {RH | (LH1 LH2)}`,
nesting depth, `%%staves` inversion, and the degenerate plans. They live in the parser
test target because parsing is the only way a `StaffPlan` is ever made, and it keeps each
case readable as a directive an author would actually write.

## Also — an unrelated crash on develop

The first commit is not part of #63 and can be cherry-picked out if you would rather it
did not ride in on a model-only PR.

`swift test` on `develop` dies with **signal 11**, and `ckprobe` on the test tunebook
exits 139 with no output at all. Bisected to be6d47c, the #62 merge; `main` and 73f6e69
are clean.

`%%score` gave `CeolKitDirective` its first case with a refcounted payload, and that was
enough to make the file-preamble scan in `SVGRenderer.render` segfault: the `where`
clause there was an immediately-invoked closure over the loop variable, and the copy of
`Scope` it forced retained a garbage pointer (`objc_retain` on `0x0083200000000000`).
Rewritten as the `guard case … else { continue }` it was imitating. That one line alone
takes the suite from crashing to 755 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D18xaxjNXgpEsAVF1mhYFV