### PR TITLE
Fix #64 — record where a body %%score takes effect

### DIFF
--- a/Sources/CeolKitModel/Diagnostic.swift
+++ b/Sources/CeolKitModel/Diagnostic.swift
@@ -57,6 +57,10 @@ public enum DiagnosticCode: String, Codable, Sendable {
     /// A `%%score` / `%%staves` payload did not parse (ABC v2.2 §11.1).  The whole
     /// directive is dropped rather than stored as a partial tree.
     case invalidStaffPlan
+    /// A `%%score` / `%%staves` was written part-way through a stave, where the plan cannot
+    /// change without splitting the system.  It takes effect from the start of the stave
+    /// enclosing it instead — see `StaffPlanChange`.
+    case staffPlanSnappedToStave
     // Field keys
     case unknownKey
     // Include directive

--- a/Sources/CeolKitModel/StaffPlanChange.swift
+++ b/Sources/CeolKitModel/StaffPlanChange.swift
@@ -1,0 +1,39 @@
+//
+//  StaffPlanChange.swift
+//  CeolKit
+//
+//  Created by Stephen Beitzel on 8/19/26.
+//
+
+import Foundation
+
+/// A `%%score` / `%%staves` plan and the point in the tune it governs from (ABC v2.2 §11.1).
+///
+/// A plan written in the tune body "resets the music generator, so that voices may appear and
+/// disappear for some period of time", which makes it the first directive in CeolKit with
+/// *from here on* semantics: every other one flattens to a last-wins scalar for the whole
+/// tune.  ``Tune/staffPlans`` is the source-ordered list of those resets.
+///
+/// The unit is the **stave** — one source line of music, the same unit ``Voice/staves`` is
+/// indexed in — because the staves of a system are laid out together, so the plan cannot
+/// change part-way through one without splitting it.  A plan written inside a stave is
+/// therefore snapped back to the start of the stave enclosing it, with a
+/// ``DiagnosticCode/staffPlanSnappedToStave`` diagnostic saying so: snapping is more
+/// predictable than an implicit system break the source never asked for.
+public struct StaffPlanChange: Hashable, Sendable {
+    public let plan: StaffPlan
+
+    /// Index of the stave this plan governs from, inclusive, counted from zero at the start
+    /// of the tune body.  A plan written before any music — file preamble or tune header —
+    /// is 0.
+    public let effectiveFromStave: Int
+
+    /// Where the directive was written, which is not where it takes effect once it snaps.
+    public let source: SourceRange
+
+    public init(plan: StaffPlan, effectiveFromStave: Int, source: SourceRange) {
+        self.plan = plan
+        self.effectiveFromStave = effectiveFromStave
+        self.source = source
+    }
+}

--- a/Sources/CeolKitModel/Tune.swift
+++ b/Sources/CeolKitModel/Tune.swift
@@ -20,6 +20,15 @@ public struct Tune: Sendable {
     public let userSymbols: [Character: Decoration]
     public let macros: [MacroDefinition]
     public let directives: [CeolKitDirectiveScope] // see §7
+    /// Every `%%score` / `%%staves` that reaches this tune, in source order, each paired
+    /// with the stave it governs from — see ``StaffPlanChange``.  Empty when the tune has
+    /// no plan at all.
+    ///
+    /// The plans are also in ``directives``; this is the positional view of them.  Two
+    /// changes can share an `effectiveFromStave` — a file-preamble plan and a tune-header
+    /// plan both govern from stave 0 — and the later one wins, as it does for every other
+    /// directive.
+    public let staffPlans: [StaffPlanChange]
     public let source: SourceRange
 
     public init(
@@ -35,6 +44,7 @@ public struct Tune: Sendable {
         userSymbols: [Character: Decoration],
         macros: [MacroDefinition],
         directives: [CeolKitDirectiveScope],
+        staffPlans: [StaffPlanChange] = [],
         source: SourceRange
     ) {
         self.reference = reference
@@ -49,6 +59,7 @@ public struct Tune: Sendable {
         self.userSymbols = userSymbols
         self.macros = macros
         self.directives = directives
+        self.staffPlans = staffPlans
         self.source = source
     }
 }

--- a/Sources/CeolKitParser/Semantic/BodyContext.swift
+++ b/Sources/CeolKitParser/Semantic/BodyContext.swift
@@ -19,9 +19,25 @@ struct VoiceAccumulator {
         self.unitNoteLength = unitNoteLength
     }
 
+    /// How many staves of this voice are finished — the index of the stave now being
+    /// written.  Boundaries that close no measures are dropped when the staves are sliced
+    /// (a lone `V:` line before any music makes one), so they are not counted here either.
+    var completedStaveCount = 0
+
+    /// True when measures or events have accumulated since the last boundary, so the stave
+    /// now being written already holds music.
+    var hasStaveInProgress: Bool {
+        if closedMeasures.count > staveBreakIndices.last ?? 0 { return true }
+        return currentEvents.contains {
+            if case .spacer = $0 { return false }
+            return true
+        }
+    }
+
     mutating func markStaveBoundary() {
         let idx = closedMeasures.count
         guard idx != staveBreakIndices.last else { return }  // no new measures since last split
+        if idx > staveBreakIndices.last ?? 0 { completedStaveCount += 1 }
         staveBreakIndices.append(idx)
     }
 
@@ -362,6 +378,9 @@ struct BodyContext {
     var voiceProperties: [String: VoiceProperties] = [:]
     var voiceDirectives: [String: [CeolKitDirectiveScope]] = [:]
     var bodyTuneDirectives: [CeolKitDirectiveScope] = []
+    /// `%%score` / `%%staves` met in the body, in source order, each already carrying the
+    /// stave it governs from.
+    var bodyStaffPlans: [StaffPlanChange] = []
     var hasExplicitVoice: Bool = false
 
     // I:linebreak settings — ABC 2.2 §9.2 — default is I:linebreak <EOL> $
@@ -544,6 +563,21 @@ struct BodyContext {
 
     mutating func splitStave(in voice: String) {
         voices[voice]?.accumulator.markStaveBoundary()
+    }
+
+    /// The index of the stave now being written, for the tune as a whole.
+    ///
+    /// Every voice finishes a stave at the same system boundary, so the voices are expected
+    /// to agree; taking the maximum reads correctly when they do and tolerates a voice the
+    /// body has not written to yet, which has finished none.
+    var currentStaveIndex: Int {
+        voices.values.map(\.accumulator.completedStaveCount).max() ?? 0
+    }
+
+    /// True when some voice has already written into the stave now being written, so
+    /// anything landing here lands part-way through a system.
+    var hasStaveInProgress: Bool {
+        voices.values.contains(where: \.accumulator.hasStaveInProgress)
     }
 
     func isInGrace(_ voice: String) -> Bool { voices[voice]?.isInGrace ?? false }

--- a/Sources/CeolKitParser/Semantic/SemanticPass.swift
+++ b/Sources/CeolKitParser/Semantic/SemanticPass.swift
@@ -71,6 +71,7 @@ struct SemanticPass {
                     userSymbols: tune.userSymbols,
                     macros: tune.macros,
                     directives: preambleCeolKitDirectives + tune.directives,
+                    staffPlans: initialStaffPlans(from: preambleCeolKitDirectives) + tune.staffPlans,
                     source: tune.source
                 ))
             } else {
@@ -216,6 +217,7 @@ struct SemanticPass {
             userSymbols: ctx.userSymbols,
             macros: ctx.macros,
             directives: tuneDirectives + bodyCtx.bodyTuneDirectives,
+            staffPlans: initialStaffPlans(from: tuneDirectives) + bodyCtx.bodyStaffPlans,
             source: abcTune.source
         )
         return (tune, diagnostics)
@@ -610,10 +612,34 @@ struct SemanticPass {
                     source: source
                 ))
             }
+        case "score", "staves":
+            // §11.1: a plan in the body resets the music generator from here on, so unlike
+            // every other directive its position is part of what it means.
+            var tempDiags: [Diagnostic] = []
+            if let d = parseCeolKitDirective(name: name, payload: payload, source: source, diagnostics: &tempDiags) {
+                ctx.bodyTuneDirectives.append(CeolKitDirectiveScope(directive: d, scope: .tuneGlobal, source: source))
+                if case .staffPlan(let plan) = d {
+                    // The plan can only change where the staves of a system do, so one
+                    // written inside a stave governs the whole of the stave enclosing it
+                    // rather than breaking the system where it happens to fall.
+                    if ctx.hasStaveInProgress {
+                        tempDiags.append(Diagnostic(
+                            severity: .warning, code: .staffPlanSnappedToStave,
+                            message: "%%\(name) inside a stave takes effect from the start of that stave",
+                            source: source
+                        ))
+                    }
+                    ctx.bodyStaffPlans.append(StaffPlanChange(
+                        plan: plan,
+                        effectiveFromStave: ctx.currentStaveIndex,
+                        source: source
+                    ))
+                }
+            }
+            diagnostics += tempDiags
         case "landscape", "flatbeams", "ceolkit:justifylast", "ceolkit:scale",
              "ceolkit:gracenotespacing", "writefields",
-             "dateformat", "footer", "straightflags", "graceslurs",
-             "score", "staves":
+             "dateformat", "footer", "straightflags", "graceslurs":
             var tempDiags: [Diagnostic] = []
             if let d = parseCeolKitDirective(name: name, payload: payload, source: source, diagnostics: &tempDiags) {
                 ctx.bodyTuneDirectives.append(CeolKitDirectiveScope(directive: d, scope: .tuneGlobal, source: source))
@@ -844,6 +870,15 @@ struct SemanticPass {
             }
         }
         return result
+    }
+
+    /// The staff plans among `scopes`, each governing from the first stave — the position
+    /// of a plan written before any music, in the file preamble or the tune header.
+    private func initialStaffPlans(from scopes: [CeolKitDirectiveScope]) -> [StaffPlanChange] {
+        scopes.compactMap { scoped in
+            guard case .staffPlan(let plan) = scoped.directive else { return nil }
+            return StaffPlanChange(plan: plan, effectiveFromStave: 0, source: scoped.source)
+        }
     }
 
     private func parseCeolKitDirective(

--- a/Sources/ckprobe/Report.swift
+++ b/Sources/ckprobe/Report.swift
@@ -30,8 +30,18 @@ struct Report: Codable {
         let staves: [Stave]
     }
 
+    /// One `%%score` / `%%staves` and the stave it governs from, so that a body plan's
+    /// position can be read off without re-deriving it from the source.
+    struct StaffPlanChange: Codable {
+        let effectiveFromStave: Int
+        let line: Int
+        /// The voices of each staff, top to bottom.
+        let staves: [[String]]
+    }
+
     struct Tune: Codable {
         let directives: [String]
+        let staffPlans: [StaffPlanChange]
         let voices: [Voice]
     }
 
@@ -53,6 +63,13 @@ extension Report {
         self.tunes = score.tunes.map { tune in
             Tune(
                 directives: tune.directives.map { "\($0.directive) @\($0.scope)" },
+                staffPlans: tune.staffPlans.map { change in
+                    StaffPlanChange(
+                        effectiveFromStave: change.effectiveFromStave,
+                        line: change.source.line,
+                        staves: change.plan.layout.staves.map { $0.map(name) }
+                    )
+                },
                 voices: tune.voices.map { voice in
                     Voice(staves: voice.staves.map { stave in
                         Stave(measureCount: stave.measures.count,
@@ -84,6 +101,11 @@ extension Report {
         for (tuneIndex, tune) in tunes.enumerated() {
             for directive in tune.directives {
                 out.append("  tune[\(tuneIndex)] \(directive)")
+            }
+            for plan in tune.staffPlans {
+                let staves = plan.staves.map { $0.joined(separator: "+") }.joined(separator: " / ")
+                out.append("  tune[\(tuneIndex)] staffPlan from stave \(plan.effectiveFromStave)"
+                           + " (line \(plan.line)): \(staves)")
             }
             for (voiceIndex, voice) in tune.voices.enumerated() {
                 let counts = voice.staves.map(\.measureCount)
@@ -131,5 +153,14 @@ extension Report {
 
     private func fmt(_ value: Double) -> String {
         value == value.rounded() ? String(Int(value)) : String(format: "%.2f", value)
+    }
+}
+
+
+/// `VoiceId` printed the way the source wrote it.
+private func name(_ id: VoiceId) -> String {
+    switch id {
+    case .named(let n): return n
+    case .all:          return "*"
     }
 }

--- a/Tests/CeolKitParserTests/Extensions/StaffPlanPositionTests.swift
+++ b/Tests/CeolKitParserTests/Extensions/StaffPlanPositionTests.swift
@@ -1,0 +1,252 @@
+// Where a %%score / %%staves takes effect (ABC v2.2 §11.1).
+// Parser and model only — nothing here asserts about rendering.
+import Testing
+import CeolKitModel
+import CeolKitParser
+
+@Suite("Staff Plan Position")
+struct StaffPlanPositionTests {
+
+    // MARK: - Helpers
+
+    private func staffPlans(_ abc: String) -> [StaffPlanChange] {
+        parse(abc).score.firstTune?.staffPlans ?? []
+    }
+
+    private func snapDiagnostics(_ abc: String) -> [Diagnostic] {
+        parse(abc).score.diagnostics.filter { $0.code == .staffPlanSnappedToStave }
+    }
+
+    /// The staves a plan resolves to, so a test can name a plan without rebuilding the tree.
+    private func staves(_ change: StaffPlanChange) -> [[VoiceId]] {
+        change.plan.layout.staves
+    }
+
+    // MARK: - Plans written before any music
+
+    @Test("A tune with no plan has no changes")
+    func noPlan() {
+        #expect(staffPlans("""
+        X:1
+        L:1/4
+        K:C
+        CDEF|
+        """).isEmpty)
+    }
+
+    @Test("A header %%score governs from the first stave")
+    func headerPlan() throws {
+        let changes = staffPlans("""
+        X:1
+        L:1/4
+        %%score [1 2]
+        K:C
+        CDEF|
+        """)
+        let change = try #require(changes.first)
+        #expect(changes.count == 1)
+        #expect(change.effectiveFromStave == 0)
+        #expect(staves(change) == [[.named("1")], [.named("2")]])
+    }
+
+    @Test("A file-preamble %%score governs from the first stave, ahead of the header's")
+    func preambleAndHeaderPlans() throws {
+        let changes = staffPlans("""
+        %%score [1 2]
+        X:1
+        L:1/4
+        %%score (1 2)
+        K:C
+        CDEF|
+        """)
+        try #require(changes.count == 2)
+        #expect(changes.map(\.effectiveFromStave) == [0, 0])
+        // Source order: the preamble plan first, the header plan — which wins — second.
+        #expect(staves(changes[0]) == [[.named("1")], [.named("2")]])
+        #expect(staves(changes[1]) == [[.named("1"), .named("2")]])
+    }
+
+    // MARK: - Plans written in the body
+
+    @Test("A body %%score after the third source line governs from stave 3")
+    func bodyPlanAfterThreeStaves() throws {
+        let changes = staffPlans("""
+        X:1
+        L:1/4
+        K:C
+        CDEF|
+        GABc|
+        defg|
+        %%score [1 2]
+        cBAG|
+        """)
+        #expect(changes.count == 1)
+        #expect(try #require(changes.first).effectiveFromStave == 3)
+    }
+
+    @Test("Two body %%score directives yield two changes in source order")
+    func twoBodyPlans() throws {
+        let changes = staffPlans("""
+        X:1
+        L:1/4
+        K:C
+        CDEF|
+        %%score [1 2 3]
+        GABc|
+        defg|
+        %%score [1 2]
+        cBAG|
+        """)
+        try #require(changes.count == 2)
+        #expect(changes.map(\.effectiveFromStave) == [1, 3])
+        #expect(staves(changes[0]).count == 3)
+        #expect(staves(changes[1]).count == 2)
+    }
+
+    @Test("A header plan and a body plan are both recorded, in source order")
+    func headerThenBody() {
+        let changes = staffPlans("""
+        X:1
+        L:1/4
+        %%score [1 2 3]
+        K:C
+        CDEF|
+        GABc|
+        %%score [1 2]
+        defg|
+        """)
+        #expect(changes.map(\.effectiveFromStave) == [0, 2])
+    }
+
+    @Test("%%staves is positioned the same way %%score is")
+    func stavesSpelling() {
+        let changes = staffPlans("""
+        X:1
+        L:1/4
+        K:C
+        CDEF|
+        %%staves [1|2]
+        GABc|
+        """)
+        #expect(changes.map(\.effectiveFromStave) == [1])
+    }
+
+    @Test("A stave index counts systems, not source lines, in a multi-voice tune")
+    func multiVoiceCountsSystems() {
+        let abc = """
+        X:1
+        L:1/4
+        V:1
+        V:2
+        K:C
+        V:1
+        CDEF|
+        V:2
+        C2E2|
+        %%score (1 2)
+        V:1
+        GABc|
+        V:2
+        G2B2|
+        """
+        // Two source lines of music above the directive, but only one finished system.
+        #expect(staffPlans(abc).map(\.effectiveFromStave) == [1])
+        #expect(snapDiagnostics(abc).isEmpty)
+    }
+
+    @Test("A malformed body payload records no change")
+    func malformedBodyPlan() {
+        let changes = staffPlans("""
+        X:1
+        L:1/4
+        K:C
+        CDEF|
+        %%score [1 2
+        GABc|
+        """)
+        #expect(changes.isEmpty)
+    }
+
+    // MARK: - Snapping
+
+    @Test("A %%score inside a stave snaps to the enclosing stave and warns")
+    func snapsToEnclosingStave() throws {
+        let abc = """
+        X:1
+        L:1/4
+        I:linebreak $
+        K:C
+        CDEF|$GABc|
+        %%score [1 2]
+        defg|
+        """
+        let changes = staffPlans(abc)
+        // The `$` ended stave 0; the stave holding GABc| runs on past the end of the source
+        // line, so the plan lands inside stave 1 and governs the whole of it.
+        #expect(changes.map(\.effectiveFromStave) == [1])
+
+        let diags = snapDiagnostics(abc)
+        #expect(diags.count == 1)
+        #expect(try #require(diags.first).severity == .warning)
+    }
+
+    @Test("With line breaks off, a body %%score snaps back to the tune's one stave")
+    func snapsWithLineBreaksOff() {
+        let abc = """
+        X:1
+        L:1/4
+        I:linebreak <none>
+        K:C
+        CDEF|
+        %%score [1 2]
+        GABc|
+        """
+        #expect(staffPlans(abc).map(\.effectiveFromStave) == [0])
+        #expect(snapDiagnostics(abc).count == 1)
+    }
+
+    @Test("A %%score at a stave boundary does not warn")
+    func boundaryDoesNotWarn() {
+        #expect(snapDiagnostics("""
+        X:1
+        L:1/4
+        K:C
+        CDEF|
+        %%score [1 2]
+        GABc|
+        """).isEmpty)
+    }
+
+    @Test("A plan before any music does not warn")
+    func headerDoesNotWarn() {
+        #expect(snapDiagnostics("""
+        X:1
+        L:1/4
+        %%score [1 2]
+        K:C
+        CDEF|
+        """).isEmpty)
+    }
+
+    // MARK: - The directive list is unchanged
+
+    @Test("Positioned plans are still in tune.directives, where the renderer reads them")
+    func directivesStillCarryThePlans() throws {
+        let tune = parse("""
+        X:1
+        L:1/4
+        %%score [1 2 3]
+        K:C
+        CDEF|
+        %%score [1 2]
+        GABc|
+        """).score.firstTune
+        let plans = (tune?.directives ?? []).compactMap { scoped -> StaffPlan? in
+            if case .staffPlan(let plan) = scoped.directive { return plan }
+            return nil
+        }
+        try #require(plans.count == 2)
+        #expect(plans[0].layout.staves.count == 3)
+        #expect(plans[1].layout.staves.count == 2)
+    }
+}


### PR DESCRIPTION
Closes #64.

`Tune.staffPlans` is the source-ordered list of `%%score` / `%%staves` plans, each paired with the stave it governs from. §11.1 says a plan written in the body "resets the music generator", which makes it the first directive in CeolKit with from-here-on semantics — every other one flattens to a last-wins scalar for the whole tune.

The plans stay in `tune.directives` as well, so the renderer is untouched; `staffPlans` is the positional view of them.

## The snapping rule

The issue asked for this to be settled before anything consumes it. A plan snaps **back** to the stave enclosing it, not forward to the next boundary, and warns with a new `staffPlanSnappedToStave` diagnostic.

That collapses to a single formula: `effectiveFromStave` is the number of staves any voice has finished. At a clean boundary that is the index of the next stave; inside a stave it is the index of that stave. Only the warning distinguishes the two cases, and no system gets broken somewhere the source never asked for.

## Two things that are easy to get wrong

**Counting boundaries over-counts.** A lone `V:1` line records a stave boundary at measure 0, and `buildVoices` then drops the empty slice it delimits. `VoiceAccumulator.completedStaveCount` increments only when a boundary actually closes measures, so it tracks the staves that survive the slicing rather than the breaks that were marked.

**The index is per tune, not per voice.** `BodyContext.currentStaveIndex` takes the maximum across voices, since every voice finishes a stave at the same system boundary and a voice the body has not reached yet has finished none. A two-voice tune with four music lines above the directive has two staves per voice and reads as stave 1 — not stave 2, which counting source lines would give.

## ckprobe

Prints one line per change and carries it in `--json`:

```
tune[0] staffPlan from stave 1 (line 10): 1+2
```

The new model member is otherwise invisible, and #69 has to read it.

## Acceptance

- [x] A header `%%score` yields one change at stave 0.
- [x] A body `%%score` after the third source line yields a change at stave 3.
- [x] Two body `%%score` directives yield two changes in source order.
- [x] A mid-line `%%score` snaps to the enclosing stave and warns.
- [x] The renderer is unchanged — it still reads only the first plan.

## Tests

14 new tests in `Tests/CeolKitParserTests/Extensions/StaffPlanPositionTests.swift`, covering the acceptance criteria plus preamble-and-header ordering, the `%%staves` spelling, a malformed body payload recording nothing, and the multi-voice systems-not-lines case.

The mid-stave test uses `I:linebreak $` so the plan lands inside stave 1 rather than stave 0 — it checks the snap *target*, not just that a warning fires.

Full suite: 769 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D18xaxjNXgpEsAVF1mhYFV
