### PR TITLE
Fix #65 — apply the staff plan's voice selection and ordering

### DIFF
--- a/Sources/CeolKitModel/Diagnostic.swift
+++ b/Sources/CeolKitModel/Diagnostic.swift
@@ -61,6 +61,22 @@ public enum DiagnosticCode: String, Codable, Sendable {
     /// change without splitting the system.  It takes effect from the start of the stave
     /// enclosing it instead — see `StaffPlanChange`.
     case staffPlanSnappedToStave
+    /// A `%%score` / `%%staves` names a voice the tune does not declare anywhere.  The rest
+    /// of the plan is honoured.
+    case staffPlanVoiceNotFound
+    /// A `%%score` / `%%staves` names the same voice more than once.  It is printed once, at
+    /// the first position it was named in.
+    case staffPlanVoiceRepeated
+    /// A voice the tune body writes to is not named in the staff plan, so §11.1 does not
+    /// print it.  Spec-mandated, but dropping music the author wrote is worth saying aloud.
+    case voiceNotInStaffPlan
+    /// A staff plan names no voice the tune can print.  The plan is abandoned and the tune
+    /// laid out as though it had none, rather than rendered empty.
+    case staffPlanEmpty
+    /// The plan parsed and was applied as far as the renderer goes today: voice selection
+    /// and ordering.  Shared staves, floating voices and mid-tune plan changes are each
+    /// approximated, and the message says which one this is.
+    case staffPlanNotFullyApplied
     // Field keys
     case unknownKey
     // Include directive

--- a/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
+++ b/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
@@ -80,12 +80,20 @@ public struct SVGRenderer: CeolKitRenderer {
             tuneConfig.graceNoteSpacing = graceNoteSpacing
             let sizer = MeasureSizer(config: tuneConfig, metadata: metadata)
 
-            // A voice a `V:` declared and the body never wrote to is in the model so a
-            // `%%score` plan can name it, but it has no music to engrave. Dropping it here
-            // rather than downstream matters: the aligner would pad it with invisible rests
-            // on every line and warn that the voices disagree, drawing a staff of silence
-            // the source never asked for.
-            let printedVoices = tune.voices.filter { !$0.isEmpty }
+            // §11.1: a `%%score` / `%%staves` plan decides which voices are printed and in
+            // what order. Only the plan governing the first stave applies — a plan written
+            // in the body changes the staff count part-way through the tune, and the driver
+            // below sizes its column store once for the whole tune.
+            let initialPlan = tune.staffPlans.last { $0.effectiveFromStave == 0 }?.plan
+            for change in tune.staffPlans where change.effectiveFromStave > 0 {
+                diagnostics.append(Diagnostic(
+                    severity: .info, code: .staffPlanNotFullyApplied,
+                    message: "a staff plan inside the tune body cannot change the staff count "
+                           + "yet; the plan in effect at the start of the tune governs throughout",
+                    source: change.source))
+            }
+            let printedVoices = VoiceSelector.select(from: tune.voices, plan: initialPlan,
+                                                     into: &diagnostics)
 
             // Bring the voices into agreement about how much music each source line holds,
             // so the break points chosen below are legal for every one of them. Voices that

--- a/Sources/CeolKitSVGRenderer/Layout/VoiceSelector.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VoiceSelector.swift
@@ -1,0 +1,154 @@
+import CeolKitModel
+
+/// Pass 1¼: decides which of a tune's voices are printed, and in what order, from the plan
+/// a `%%score` / `%%staves` gave (ABC v2.2 §11.1).
+///
+/// §11.1: "Any voices appearing in the tune body will only be printed if it is mentioned in
+/// the score directive."  A plan therefore both *filters* and *orders*, and its order wins
+/// over the order the voices were declared in.
+///
+/// **One staff per voice, always.**  This pass runs ahead of the shared-staff work, so the
+/// voices of a `( … )` group each get a staff of their own and a floating `*V` gets one at
+/// the position it was written; both say so in a `staffPlanNotFullyApplied` diagnostic.
+/// That is strictly better than ignoring the directive — the right voices print in the right
+/// order, and only the vertical grouping is missing — and it keeps every voice the plan
+/// names on the page, which silently dropping the ones this pass cannot group would not.
+enum VoiceSelector {
+
+    /// - Parameters:
+    ///   - voices: every voice of the tune, including ones the body never wrote to.  Those
+    ///     are in the model precisely so a plan can name them, so naming one is not an error.
+    ///   - plan: the staff plan in effect, or `nil` when the tune has none.
+    /// - Returns: the voices to print, top to bottom.  Never contains a voice with no music:
+    ///   the aligner would pad it with invisible rests on every line and warn that the voices
+    ///   disagree, drawing a staff of silence the source never asked for.
+    static func select(
+        from voices: [Voice],
+        plan: StaffPlan?,
+        into diagnostics: inout [Diagnostic]
+    ) -> [Voice] {
+        let printable = voices.filter { !$0.isEmpty }
+        guard let plan else { return printable }
+
+        let layout = plan.layout
+        let byId = Dictionary(voices.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+
+        var printed: [Voice] = []
+        var seen: Set<VoiceId> = []
+        for id in order(of: layout) {
+            guard seen.insert(id).inserted else {
+                diagnostics.append(Diagnostic(
+                    severity: .warning, code: .staffPlanVoiceRepeated,
+                    message: "staff plan names voice \(label(id)) more than once; "
+                           + "it is printed once, where it is first named",
+                    source: plan.source))
+                continue
+            }
+            guard let voice = byId[id] else {
+                diagnostics.append(Diagnostic(
+                    severity: .warning, code: .staffPlanVoiceNotFound,
+                    message: "staff plan names voice \(label(id)), which this tune does not have",
+                    source: plan.source))
+                continue
+            }
+            // Named, declared, and never written to: §11.1 prints the voices that appear in
+            // the tune body, and this one does not appear there.  Not worth a diagnostic —
+            // the plan is right and the body simply has nothing to say.
+            guard !voice.isEmpty else { continue }
+            printed.append(voice)
+        }
+
+        guard !printed.isEmpty else {
+            // Reporting each voice as unprinted would be a lie: the fallback prints them all.
+            diagnostics.append(Diagnostic(
+                severity: .warning, code: .staffPlanEmpty,
+                message: "staff plan selects none of this tune's voices; "
+                       + "laying the tune out as though it had no plan",
+                source: plan.source))
+            return printable
+        }
+
+        diagnostics += omissions(from: printable, namedBy: layout, plan: plan)
+        diagnostics += approximations(of: layout, printedBy: printed, plan: plan)
+        return printed
+    }
+
+    // MARK: - Order
+
+    /// The plan's voices, top to bottom, one entry per staff this pass will draw.
+    ///
+    /// A floating voice has no staff in the layout, so it is placed after the staff it floats
+    /// below — or first, where the plan gives it nothing above.  That is where the author
+    /// wrote it, and it is the position `#80` will start from when it assigns such a voice
+    /// per note.
+    private static func order(of layout: StaffPlanLayout) -> [VoiceId] {
+        let floatingByStaffAbove = Dictionary(grouping: layout.floating, by: \.above)
+        var ordered = (floatingByStaffAbove[nil] ?? []).map(\.id)
+        for (index, staff) in layout.staves.enumerated() {
+            ordered += staff
+            ordered += (floatingByStaffAbove[index] ?? []).map(\.id)
+        }
+        return ordered
+    }
+
+    // MARK: - Diagnostics
+
+    /// Voices the body wrote to that the plan leaves out, and so §11.1 does not print.
+    private static func omissions(
+        from printable: [Voice],
+        namedBy layout: StaffPlanLayout,
+        plan: StaffPlan
+    ) -> [Diagnostic] {
+        let named = Set(layout.staves.flatMap { $0 } + layout.floating.map(\.id))
+        return printable.filter { !named.contains($0.id) }.map { voice in
+            Diagnostic(
+                severity: .info, code: .voiceNotInStaffPlan,
+                message: "voice \(label(voice.id)) has music in the tune body but is not in "
+                       + "the staff plan, so it is not printed",
+                source: plan.source)
+        }
+    }
+
+    /// The parts of the plan this pass draws differently from what it asks for.
+    private static func approximations(
+        of layout: StaffPlanLayout,
+        printedBy printed: [Voice],
+        plan: StaffPlan
+    ) -> [Diagnostic] {
+        let ids = Set(printed.map(\.id))
+        var result: [Diagnostic] = []
+
+        for staff in layout.staves {
+            let sharing = staff.filter { ids.contains($0) }
+            guard sharing.count > 1 else { continue }
+            result.append(Diagnostic(
+                severity: .info, code: .staffPlanNotFullyApplied,
+                message: "voices \(list(sharing)) share one staff in the plan; "
+                       + "each is drawn on a staff of its own for now",
+                source: plan.source))
+        }
+
+        for floating in layout.floating where ids.contains(floating.id) {
+            result.append(Diagnostic(
+                severity: .info, code: .staffPlanNotFullyApplied,
+                message: "voice \(label(floating.id)) floats between staves in the plan; "
+                       + "it is drawn on a staff of its own for now",
+                source: plan.source))
+        }
+
+        return result
+    }
+
+    // MARK: - Naming
+
+    private static func label(_ id: VoiceId) -> String {
+        switch id {
+        case .named(let name): return "'\(name)'"
+        case .all:             return "'*'"
+        }
+    }
+
+    private static func list(_ ids: [VoiceId]) -> String {
+        ids.map(label).joined(separator: ", ")
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/StaffPlanSelectionTests.swift
+++ b/Tests/CeolKitSVGRendererTests/StaffPlanSelectionTests.swift
@@ -1,0 +1,254 @@
+import Testing
+import CeolKitModel
+import CeolKitParser
+import CeolKitSVGGeometry
+@testable import CeolKitSVGRenderer
+
+/// Issue #65: `%%score` / `%%staves` decides which voices are printed and in what order
+/// (ABC v2.2 §11.1).
+///
+/// Selection is asserted through `VoiceSelector` rather than the finished page, because the
+/// geometry says how many staves were drawn but not which voice is on which; the end-to-end
+/// tests at the bottom cover the staff counts.
+@Suite("Staff Plan Selection")
+struct StaffPlanSelectionTests {
+
+    // MARK: - Helpers
+
+    /// Runs the selection the renderer runs, on a real parse.
+    private func select(_ abc: String) -> (voices: [VoiceId], diagnostics: [Diagnostic]) {
+        let tune = CeolKitParser().parse(abc, options: .default).score.tunes[0]
+        var diagnostics: [Diagnostic] = []
+        let plan = tune.staffPlans.last { $0.effectiveFromStave == 0 }?.plan
+        let chosen = VoiceSelector.select(from: tune.voices, plan: plan, into: &diagnostics)
+        return (chosen.map(\.id), diagnostics)
+    }
+
+    private func codes(_ diagnostics: [Diagnostic], _ code: DiagnosticCode) -> [Diagnostic] {
+        diagnostics.filter { $0.code == code }
+    }
+
+    /// Three voices, one bar each, with `directive` above the `K:`.
+    ///
+    /// Built by line so that the no-directive case does not leave a blank line behind — a
+    /// blank line ends the tune, and the tune this returns would be two.
+    private func threeVoices(_ directive: String = "") -> String {
+        ([
+            "X:1",
+            "L:1/4",
+            directive,
+            "V:1", "V:2", "V:3",
+            "K:C",
+            "V:1", "CDEF|",
+            "V:2", "GABc|",
+            "V:3", "cdef|"
+        ] as [String]).filter { !$0.isEmpty }.joined(separator: "\n")
+    }
+
+    private func render(_ abc: String) -> (pages: [PageGeometry], diagnostics: [Diagnostic]) {
+        let score = CeolKitParser().parse(abc, options: .default).score
+        var diagnostics: [Diagnostic] = []
+        let svgs = try! SVGRenderer().render(score, diagnostics: &diagnostics)
+        return (try! SVGGeometry.pages(from: svgs), diagnostics)
+    }
+
+    // MARK: - No plan
+
+    @Test("Without a plan the voices keep their declaration order")
+    func noPlan() {
+        let result = select(threeVoices())
+        #expect(result.voices == [.named("1"), .named("2"), .named("3")])
+        #expect(result.diagnostics.isEmpty)
+    }
+
+    @Test("Without a plan a declared voice the body never writes to is still not printed")
+    func noPlanDropsEmptyVoices() {
+        let result = select("""
+        X:1
+        L:1/4
+        V:1
+        V:2
+        K:C
+        V:1
+        CDEF|
+        """)
+        #expect(result.voices == [.named("1")])
+        #expect(result.diagnostics.isEmpty)
+    }
+
+    // MARK: - Selection
+
+    @Test("A plan omitting a voice does not print it, and says so")
+    func selectsNamedVoices() {
+        let result = select(threeVoices("%%score [1 2]"))
+        #expect(result.voices == [.named("1"), .named("2")])
+
+        let omitted = codes(result.diagnostics, .voiceNotInStaffPlan)
+        #expect(omitted.count == 1)
+        #expect(omitted.first?.message.contains("'3'") == true)
+        #expect(omitted.first?.severity == .info)
+    }
+
+    @Test("%%staves selects the same way %%score does")
+    func stavesSpellingSelects() {
+        #expect(select(threeVoices("%%staves [1|2]")).voices == [.named("1"), .named("2")])
+    }
+
+    // MARK: - Ordering
+
+    @Test("The plan's order wins over the order the voices were declared in")
+    func reordersVoices() {
+        #expect(select(threeVoices("%%score [2 1]")).voices == [.named("2"), .named("1")])
+    }
+
+    @Test("Reordering carries every voice, not just the ones that moved")
+    func reordersAllThree() {
+        let result = select(threeVoices("%%score [3 1 2]"))
+        #expect(result.voices == [.named("3"), .named("1"), .named("2")])
+        #expect(codes(result.diagnostics, .voiceNotInStaffPlan).isEmpty)
+    }
+
+    // MARK: - Approximations this phase makes
+
+    @Test("A shared-staff group is drawn as separate staves, and says so")
+    func sharedStaffIsSeparateForNow() {
+        let result = select(threeVoices("%%score (1 2)"))
+        #expect(result.voices == [.named("1"), .named("2")])
+
+        let notes = codes(result.diagnostics, .staffPlanNotFullyApplied)
+        #expect(notes.count == 1)
+        #expect(notes.first?.message.contains("share one staff") == true)
+        #expect(notes.first?.severity == .info)
+    }
+
+    @Test("A floating voice keeps the position it was written at, and says so")
+    func floatingVoiceKeepsItsPosition() {
+        let result = select(threeVoices("%%score {1 *2| 3}"))
+        #expect(result.voices == [.named("1"), .named("2"), .named("3")])
+
+        let notes = codes(result.diagnostics, .staffPlanNotFullyApplied)
+        #expect(notes.count == 1)
+        #expect(notes.first?.message.contains("floats between staves") == true)
+    }
+
+    @Test("A body plan is reported as not yet applied, and the tune renders")
+    func bodyPlanIsReported() {
+        let result = render("""
+        X:1
+        L:1/4
+        V:1
+        V:2
+        K:C
+        V:1
+        CDEF|
+        V:2
+        GABc|
+        %%score [1]
+        V:1
+        cdef|
+        V:2
+        CDEF|
+        """)
+        let notes = result.diagnostics.filter { $0.code == .staffPlanNotFullyApplied }
+        #expect(notes.count == 1)
+        #expect(notes.first?.message.contains("cannot change the staff count") == true)
+        // Both voices still print: the plan in effect at the start of the tune is none.
+        #expect(result.pages.flatMap(\.systems).count == 4)
+    }
+
+    // MARK: - Plans the tune cannot honour
+
+    @Test("A voice the tune does not have is a warning, and the rest of the plan stands")
+    func unknownVoiceWarns() {
+        let result = select(threeVoices("%%score [1 9 2]"))
+        #expect(result.voices == [.named("1"), .named("2")])
+
+        let warnings = codes(result.diagnostics, .staffPlanVoiceNotFound)
+        #expect(warnings.count == 1)
+        #expect(warnings.first?.message.contains("'9'") == true)
+        #expect(warnings.first?.severity == .warning)
+    }
+
+    @Test("A voice declared but never written to is skipped without complaint")
+    func declaredButEmptyVoiceIsQuiet() {
+        let result = select("""
+        X:1
+        L:1/4
+        %%score [1 2]
+        V:1
+        V:2
+        K:C
+        V:1
+        CDEF|
+        """)
+        #expect(result.voices == [.named("1")])
+        #expect(result.diagnostics.isEmpty)
+    }
+
+    @Test("A repeated voice is printed once, where it is first named")
+    func repeatedVoiceIsPrintedOnce() {
+        let result = select(threeVoices("%%score [1 2 1]"))
+        #expect(result.voices == [.named("1"), .named("2")])
+
+        let warnings = codes(result.diagnostics, .staffPlanVoiceRepeated)
+        #expect(warnings.count == 1)
+        #expect(warnings.first?.message.contains("'1'") == true)
+    }
+
+    @Test("A plan that selects nothing falls back to the no-plan layout")
+    func emptyPlanFallsBack() {
+        let result = select(threeVoices("%%score [8 9]"))
+        #expect(result.voices == [.named("1"), .named("2"), .named("3")])
+
+        #expect(codes(result.diagnostics, .staffPlanEmpty).count == 1)
+        #expect(codes(result.diagnostics, .staffPlanVoiceNotFound).count == 2)
+        // The fallback prints every voice, so reporting any as omitted would be a lie.
+        #expect(codes(result.diagnostics, .voiceNotInStaffPlan).isEmpty)
+    }
+
+    // MARK: - End to end
+
+    @Test("%%score [1 2] on a three-voice tune renders two staves")
+    func twoStavesOnThePage() {
+        #expect(render(threeVoices("%%score [1 2]")).pages.flatMap(\.systems).count == 2)
+    }
+
+    @Test("%%score (1 2) renders two staves at this phase, not one")
+    func sharedStaffStillDrawsTwo() {
+        #expect(render(threeVoices("%%score (1 2)")).pages.flatMap(\.systems).count == 2)
+    }
+
+    /// Two voices on known source lines.  The system's scroll-sync anchor is taken from the
+    /// first printed voice, so it names which voice the plan put on top.
+    private let twoVoicesOnKnownLines = [
+        "X:1",          // 1
+        "L:1/4",        // 2
+        "%%score PLAN", // 3
+        "V:1",          // 4
+        "V:2",          // 5
+        "K:C",          // 6
+        "V:1",          // 7
+        "CDEF|",        // 8
+        "V:2",          // 9
+        "cdef|"         // 10
+    ]
+
+    private func anchorLine(plan: String) -> Int? {
+        let abc = twoVoicesOnKnownLines.map { $0.replacing("PLAN", with: plan) }.joined(separator: "\n")
+        return render(abc).pages.flatMap(\.systems).first?.abcLine
+    }
+
+    @Test("The voice the plan names first is the one drawn on the top staff")
+    func planOrderReachesThePage() {
+        // Voice 1's music is on line 8, voice 2's on line 10.
+        #expect(anchorLine(plan: "[1 2]") == 8)
+        #expect(anchorLine(plan: "[2 1]") == 10)
+    }
+
+    @Test("A tune with no plan renders every voice it did before")
+    func noPlanRendersEveryVoice() {
+        let result = render(threeVoices())
+        #expect(result.pages.flatMap(\.systems).count == 3)
+        #expect(result.diagnostics.isEmpty)
+    }
+}


### PR DESCRIPTION
Closes #65. First visible behaviour change from `%%score`.

`VoiceSelector` sits between the tune and the aligner and answers the question §11.1 asks:

> Any voices appearing in the tune body will only be printed if it is mentioned in the score directive.

So a plan both **filters** and **orders**, and its order wins over the order the voices were declared in. The old `tune.voices.filter { !$0.isEmpty }` is absorbed into it, so the no-plan path returns the same list it always did.

## The deliberate intermediate

One staff per voice, always. The voices of a `( … )` group each get a staff of their own, and a floating `*V` gets one where it was written — both with a `staffPlanNotFullyApplied` info. The right voices print in the right order; only the vertical grouping is missing.

Giving a floating voice a staff at its written position is worth calling out: `StaffPlanLayout.staves` does not contain floating voices, so using it alone would have dropped one silently. Losing a voice the plan explicitly names is worse than drawing it ungrouped, and its written position is where #80 starts from when it assigns such a voice per note.

Only the plan governing the first stave is applied. A body plan gets an info saying the staff count cannot change mid-tune yet (#69) — without it the output is silently wrong with nothing to explain it.

## Diagnostics

| code | severity | when |
|---|---|---|
| `staffPlanVoiceNotFound` | warning | plan names a voice the tune does not have; the rest of the plan stands |
| `staffPlanVoiceRepeated` | warning | named twice; printed once, where it was first named |
| `voiceNotInStaffPlan` | info | body voice the plan omits — spec-mandated, but dropping music the author wrote is worth saying aloud |
| `staffPlanEmpty` | warning | nothing printable selected; the plan is abandoned and the tune laid out as though it had none |
| `staffPlanNotFullyApplied` | info | shared staff, floating voice, or mid-tune change — each approximated, message says which |

Two judgement calls in there:

- On the `staffPlanEmpty` fallback the per-voice omission infos are **suppressed**. The fallback prints every voice, so reporting them as unprinted would be a lie.
- A voice the plan names that the header declared and the body never wrote to is skipped **in silence**. It is in the model precisely so a plan can name it, and §11.1 prints the voices that appear in the body.

`staffPlanVoiceRepeated` is not in the issue's list — `%%score [1 1]` is degenerate, but it would otherwise have drawn the same music on two staves.

## Verification

**Byte-identical without a plan**: all 16 pages of `Tests/CeolKitSVGRendererTests/tunebook.abc` render identically to `develop` (`diff -rq`, no differences).

**Ordering reaches the page**: `%%score [2 1]` renders identically to declaring the voices in that order — the sole difference across the whole SVG is the scroll-sync anchor, which points at source lines and so genuinely differs between the two files.

## Acceptance

- [x] `%%score [1 2]` on a three-voice tune renders two staves.
- [x] `%%score [2 1]` renders voice 2 above voice 1.
- [x] `%%score (T1 T2)` renders two staves plus the "not yet shared" diagnostic.
- [x] No `%%score` → output byte-identical to today.

## Tests

17 new tests in `Tests/CeolKitSVGRendererTests/StaffPlanSelectionTests.swift`. Selection and ordering are asserted through `VoiceSelector` on real parses, because the geometry tells you how many staves were drawn but not which voice is on which; the end-to-end tests cover staff counts and one anchor-based ordering check.

Full suite: 786 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D18xaxjNXgpEsAVF1mhYFV
