### PR TITLE
Fix #66 — per-voice key signature and unit note length

### DIFF
--- a/Sources/CeolKitModel/Tune.swift
+++ b/Sources/CeolKitModel/Tune.swift
@@ -62,4 +62,20 @@ public struct Tune: Sendable {
         self.staffPlans = staffPlans
         self.source = source
     }
+
+    /// The key signature `voice` is engraved in: its own `K:` when it states one, this tune's
+    /// otherwise.
+    ///
+    /// The two places that need it are the key signature drawn at the head of the voice's
+    /// staff and the alterations its accidentals resolve against — both of which are wrong for
+    /// a voice that states a key the tune does not.
+    public func effectiveKey(for voice: Voice) -> KeySignature {
+        voice.key ?? key
+    }
+
+    /// The unit note length `voice`'s durations are written against: its own `L:` when it
+    /// states one, this tune's otherwise.
+    public func effectiveUnitNoteLength(for voice: Voice) -> Fraction {
+        voice.unitNoteLength ?? unitNoteLength
+    }
 }

--- a/Sources/CeolKitModel/Voice.swift
+++ b/Sources/CeolKitModel/Voice.swift
@@ -10,6 +10,22 @@ import Foundation
 public struct Voice: Sendable {
     public let id: VoiceId                       // "1", "soprano", etc.; "*" for all-voice
     public let properties: VoiceProperties       // clef, stafflines, transpose, name, subname, …
+    /// The key signature this voice opens in, or `nil` when it states none of its own and the
+    /// tune's `K:` governs — the signature to draw at the head of its staff.
+    ///
+    /// ABC §7.3 asks for a field that sets a music property to be repeated in every voice it
+    /// applies to, which only means anything if one voice's `K:` leaves the others alone.  A
+    /// voice that never writes a `K:` keeps `nil` here rather than a copy of the tune's, so
+    /// "states its own key" stays distinguishable from "agrees with the tune"; use
+    /// ``Tune/effectiveKey(for:)`` to resolve the two.
+    ///
+    /// A `K:` written part way through the voice changes how its accidentals resolve from
+    /// that point on, but does not appear here: it is a key change mid-staff, not the key the
+    /// staff opens in.
+    public let key: KeySignature?
+    /// The unit note length this voice's durations are written against, or `nil` when the
+    /// tune's `L:` governs.  See ``Tune/effectiveUnitNoteLength(for:)``.
+    public let unitNoteLength: Fraction?
     public let staves: [Staff]                   // usually 1; > 1 for grand staff voices
     public let directives: [CeolKitDirectiveScope]
     public let source: SourceRange
@@ -17,12 +33,16 @@ public struct Voice: Sendable {
     public init(
         id: VoiceId,
         properties: VoiceProperties,
+        key: KeySignature? = nil,
+        unitNoteLength: Fraction? = nil,
         staves: [Staff],
         directives: [CeolKitDirectiveScope],
         source: SourceRange
     ) {
         self.id = id
         self.properties = properties
+        self.key = key
+        self.unitNoteLength = unitNoteLength
         self.staves = staves
         self.directives = directives
         self.source = source

--- a/Sources/CeolKitParser/Semantic/BodyContext.swift
+++ b/Sources/CeolKitParser/Semantic/BodyContext.swift
@@ -24,6 +24,18 @@ struct VoiceAccumulator {
     /// (a lone `V:` line before any music makes one), so they are not counted here either.
     var completedStaveCount = 0
 
+    /// True once any musical content has landed in this voice — a closed measure, or a
+    /// non-spacer event in the measure now being written.
+    ///
+    /// What it distinguishes is a field stated at the head of a voice from one stated part
+    /// way through it: the first says what the voice opens in, the second is a change.
+    var hasMusic: Bool {
+        !closedMeasures.isEmpty || currentEvents.contains {
+            if case .spacer = $0 { return false }
+            return true
+        }
+    }
+
     /// True when measures or events have accumulated since the last boundary, so the stave
     /// now being written already holds music.
     var hasStaveInProgress: Bool {
@@ -111,6 +123,20 @@ struct VoiceState {
     /// bar *in the voice that wrote it*, so a `^F` in the melody must not make the harmony's
     /// `F` sound or print as F♯.
     var accidentals: AccidentalScope
+
+    /// The `K:` this voice stated before any of its music, or `nil` while the tune's stands —
+    /// ABC §7.3, which asks for a field that sets a music property to be repeated in every
+    /// voice it applies to, and so reads a `K:` as belonging to the voice that carries it.
+    ///
+    /// Only what the voice *opens* in, which is what gets drawn at the head of its staff.  A
+    /// later `K:` moves `accidentals` and leaves this alone: a key change part way through a
+    /// staff is not drawn at all yet, and reporting it here would put the wrong signature at
+    /// the head of the whole voice rather than no signature at the point of change.
+    var openingKey: KeySignature?
+
+    /// The `L:` this voice stated before any of its music, or `nil` while the tune's stands.
+    /// Mirrored into `accumulator.unitNoteLength`, which the beams are grouped against.
+    var openingUnitNoteLength: Fraction?
 
     // Pending attachments for this voice's next note/chord
     var pendingDecorations: [Decoration] = []
@@ -350,13 +376,18 @@ struct VoiceState {
 /// voice id from the caller, which threads it down the walk chain.  A method cannot reach a
 /// voice it was not handed.
 struct BodyContext {
-    var unitNoteLength: Fraction
+    /// The tune's `L:` — the header's, or the default for its meter.  It is the value a voice
+    /// is written against until that voice states an `L:` of its own; nothing moves it, because
+    /// an `L:` in the body belongs to the voice that carries it (§7.3).
+    let unitNoteLength: Fraction
     private(set) var meter: Meter
     /// Bumped by every `[M:]`, so each voice can tag its own next measure exactly once.
     private(set) var meterGeneration: Int = 0
-    private(set) var key: KeySignature
-    /// Always derived from `key`; `setKey` is the only thing that moves either.
-    private(set) var keySignatureAlterations: [DiatonicStep: Alteration]
+    /// The tune's `K:`, governing every voice that does not state one of its own.  Like
+    /// `unitNoteLength`, fixed for the tune: a body `K:` moves one voice, not this.
+    let key: KeySignature
+    /// Always derived from `key`.
+    let keySignatureAlterations: [DiatonicStep: Alteration]
     var userSymbols: [Character: Decoration]
 
     // Voice table — created on first musical content, never eagerly, so a voice that was
@@ -417,6 +448,9 @@ struct BodyContext {
         source: @autoclosure () -> SourceRange,
         _ body: (inout VoiceState) -> R
     ) -> R {
+        // Seeded from the tune, never from whichever voice was walked last: a voice that
+        // states no `K:`/`L:` of its own is written against the tune's, not against its
+        // neighbour's.
         let unitLen = unitNoteLength
         let alterations = keySignatureAlterations
         // Creating state for an id nothing has named yet also gives it a place in the print
@@ -488,17 +522,28 @@ struct BodyContext {
         meterGeneration += 1
     }
 
-    // MARK: Key
+    // MARK: Key and unit note length
 
-    /// The only way to move the key.  Re-seeds every voice's scope and drops all bar memory —
-    /// what the single shared scope did before, generalised to N voices.  `[K:]` is tune-wide
-    /// today; issue #66 makes it voice-local.
-    mutating func setKey(_ newKey: KeySignature) {
-        key = newKey
-        keySignatureAlterations = keyAlterations(for: newKey)
-        let alterations = keySignatureAlterations
-        for id in voices.keys {
-            voices[id]?.accidentals = AccidentalScope(keyAlterations: alterations)
+    /// Moves the key for one voice.  Re-seeds that voice's accidental scope and drops its bar
+    /// memory; every other voice keeps both, because a `K:` in the body belongs to the voice
+    /// that carries it — §7.3 asks for such a field to be repeated in every voice it should
+    /// affect, which is only meaningful if one voice's does not reach the rest.
+    mutating func setKey(_ newKey: KeySignature, in voice: String, source: SourceRange) {
+        let alterations = keyAlterations(for: newKey)
+        withVoice(voice, source: source) {
+            if !$0.accumulator.hasMusic { $0.openingKey = newKey }
+            $0.accidentals = AccidentalScope(keyAlterations: alterations)
+        }
+    }
+
+    /// Moves the unit note length for one voice, likewise — but only where it opens the
+    /// voice.  A change part way through has nowhere to land: one length sizes the whole
+    /// voice, in the beam resolver here and in the renderer's sizer alike.  Issue #85.
+    mutating func setUnitNoteLength(_ length: Fraction, in voice: String, source: SourceRange) {
+        withVoice(voice, source: source) {
+            guard !$0.accumulator.hasMusic else { return }
+            $0.openingUnitNoteLength = length
+            $0.accumulator.unitNoteLength = length
         }
     }
 

--- a/Sources/CeolKitParser/Semantic/SemanticPass.swift
+++ b/Sources/CeolKitParser/Semantic/SemanticPass.swift
@@ -549,11 +549,11 @@ struct SemanticPass {
     ) {
         switch field {
         case .key(let k):
-            ctx.setKey(k)
+            ctx.setKey(k, in: voice, source: source)
         case .meter(let m, _):
             ctx.setMeter(m)
         case .unitNoteLength(let f, _):
-            ctx.unitNoteLength = f
+            ctx.setUnitNoteLength(f, in: voice, source: source)
         case .tempo(let t, _):
             ctx.emit(.tempoChange(t), in: voice)
         case .voice(let id, let props, _):
@@ -1047,6 +1047,8 @@ struct SemanticPass {
             let voice = Voice(
                 id: vid,
                 properties: props,
+                key: state?.openingKey,
+                unitNoteLength: state?.openingUnitNoteLength,
                 staves: staves,
                 directives: voiceDirs,
                 source: tuneSource

--- a/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
+++ b/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
@@ -95,6 +95,12 @@ public struct SVGRenderer: CeolKitRenderer {
             let printedVoices = VoiceSelector.select(from: tune.voices, plan: initialPlan,
                                                      into: &diagnostics)
 
+            // §7.3: a voice states its own `K:` and `L:` where it needs them, and the tune's
+            // stand in where it does not.  Resolved once here — every measure of a voice is
+            // sized against the same unit note length, and its staff head draws the same key.
+            let voiceKeys = printedVoices.map { tune.effectiveKey(for: $0) }
+            let voiceUnitLengths = printedVoices.map { tune.effectiveUnitNoteLength(for: $0) }
+
             // Bring the voices into agreement about how much music each source line holds,
             // so the break points chosen below are legal for every one of them. Voices that
             // disagree are padded and warned about rather than laid out sequentially.
@@ -112,7 +118,7 @@ public struct SVGRenderer: CeolKitRenderer {
                     for voiceIndex in printedVoices.indices {
                         columnsPerVoice[voiceIndex].append(
                             sizer.size(stave.measures[voiceIndex][column],
-                                       unitNoteLength: tune.unitNoteLength))
+                                       unitNoteLength: voiceUnitLengths[voiceIndex]))
                     }
                 }
             }
@@ -122,19 +128,21 @@ public struct SVGRenderer: CeolKitRenderer {
                 let voiceLines = printedVoices.enumerated().map { index, voice in
                     LineBreaker.VoiceLine(measures: columnsPerVoice[index],
                                           clef: voice.properties.clef,
-                                          keySignature: tune.key,
+                                          keySignature: voiceKeys[index],
                                           meter: tune.meter)
                 }
                 // Header widths differ between the first system (has time sig) and later
                 // ones, and are the max across the group: the staves of a system have to
                 // start at the same x even when one voice's clef or key signature is wider.
-                let firstHeaderW = printedVoices.reduce(0.0) { widest, voice in
-                    max(widest, systemHeaderWidth(clef: voice.properties.clef, keySignature: tune.key,
+                let firstHeaderW = printedVoices.indices.reduce(0.0) { widest, index in
+                    max(widest, systemHeaderWidth(clef: printedVoices[index].properties.clef,
+                                                  keySignature: voiceKeys[index],
                                                   meter: tune.meter, metadata: metadata,
                                                   staffSize: tuneConfig.staffSize))
                 }
-                let laterHeaderW = printedVoices.reduce(0.0) { widest, voice in
-                    max(widest, systemHeaderWidth(clef: voice.properties.clef, keySignature: tune.key,
+                let laterHeaderW = printedVoices.indices.reduce(0.0) { widest, index in
+                    max(widest, systemHeaderWidth(clef: printedVoices[index].properties.clef,
+                                                  keySignature: voiceKeys[index],
                                                   meter: nil, metadata: metadata,
                                                   staffSize: tuneConfig.staffSize))
                 }

--- a/Tests/CeolKitParserTests/Conformance/AccidentalScopeTests.swift
+++ b/Tests/CeolKitParserTests/Conformance/AccidentalScopeTests.swift
@@ -202,14 +202,22 @@ struct AccidentalScopeTests {
         #expect(two[1].pitch.alteration == Alteration(numerator: 0, denominator: 1))
     }
 
-    @Test("An inline [K:] still re-seeds every voice")
-    func keyChangeRekeysAllVoices() {
-        // [K:] is tune-wide until issue #66 makes it per voice; a voice that has not been
-        // walked since the change must still pick the new key up.
+    @Test("An inline [K:] re-seeds only the voice that wrote it")
+    func keyChangeRekeysOnlyItsOwnVoice() {
+        // §7.3: a field that sets a music property should be repeated in every voice it
+        // applies to — so voice 1's [K:G] moves voice 1 and leaves voice 2 in C.
         let result = parse(Self.twoVoiceHeader + "[V:1] F [K:G] F [V:2] F F|\n")
+        let one = voiceMeasures(result, "1").first?.noteEvents ?? []
         let two = voiceMeasures(result, "2").first?.noteEvents ?? []
-        guard two.count >= 2 else { Issue.record("Parser prerequisite not met"); return }
-        #expect(two[0].pitch.alteration == Alteration(numerator: 1, denominator: 1))
-        #expect(two[0].displayedAccidental == nil)
+        guard one.count >= 2, two.count >= 2 else { Issue.record("Parser prerequisite not met"); return }
+        let sharp = Alteration(numerator: 1, denominator: 1)
+        let natural = Alteration(numerator: 0, denominator: 1)
+        // Voice 1: natural before the change, sharpened by G major after it.
+        #expect(one[0].pitch.alteration == natural)
+        #expect(one[1].pitch.alteration == sharp)
+        #expect(one[1].displayedAccidental == nil)
+        // Voice 2 never wrote a K: and stays in the tune's C major.
+        #expect(two.allSatisfy { $0.pitch.alteration == natural })
+        #expect(two.allSatisfy { $0.displayedAccidental == nil })
     }
 }

--- a/Tests/CeolKitParserTests/Conformance/VoiceKeyAndLengthTests.swift
+++ b/Tests/CeolKitParserTests/Conformance/VoiceKeyAndLengthTests.swift
@@ -1,0 +1,95 @@
+// Per-voice K: and L: — issue #66.
+//
+// ABC §7.3 asks for a field that sets a music property to be repeated in every voice it
+// applies to. That instruction is only meaningful if a `K:` or `L:` written in one voice
+// leaves the others alone, so these check that it does, and that what each voice opens in
+// reaches the model where a renderer can find it.
+import Testing
+import CeolKitModel
+import CeolKitParser
+
+@Suite("Per-voice key and unit note length")
+struct VoiceKeyAndLengthTests {
+
+    private static let twoVoiceHeader = "X:1\nT:T\nM:4/4\nL:1/4\nK:C\nV:1\nV:2\n"
+
+    private func parseTune(_ abc: String) -> Tune? { parse(abc).score.firstTune }
+
+    private func voice(_ tune: Tune?, _ id: String) -> Voice? {
+        tune?.voices.first { $0.id == .named(id) }
+    }
+
+    // MARK: Key
+
+    @Test("A voice's own K: is recorded on that voice and nowhere else")
+    func voiceKeyIsRecordedOnItsOwnVoice() throws {
+        let tune = try #require(parseTune(Self.twoVoiceHeader + "V:1\nK:G\nCDEF|\nV:2\nCDEF|\n"))
+        let one = try #require(voice(tune, "1"))
+        let two = try #require(voice(tune, "2"))
+
+        #expect(one.key?.tonic?.step == .g)
+        #expect(tune.effectiveKey(for: one).tonic?.step == .g)
+        // Voice 2 stated nothing, so it keeps the tune's C — and says so by holding nil
+        // rather than a copy of it.
+        #expect(two.key == nil)
+        #expect(tune.effectiveKey(for: two).tonic?.step == .c)
+        // The tune's own K: is untouched by either.
+        #expect(tune.key.tonic?.step == .c)
+    }
+
+    @Test("A K: written part way through a voice is a key change, not the key it opens in")
+    func midVoiceKeyChangeIsNotTheOpeningKey() throws {
+        let tune = try #require(parseTune(Self.twoVoiceHeader + "[V:1] CDEF | [K:G] GAFc |\n[V:2] CDEF|CDEF|\n"))
+        let one = try #require(voice(tune, "1"))
+        // Nothing to draw at the head of the staff but the tune's key: the change belongs to
+        // bar 2, and a signature drawn at bar 1 would be wrong for bar 1.
+        #expect(one.key == nil)
+        #expect(tune.effectiveKey(for: one).tonic?.step == .c)
+        // It still moved the voice's accidentals: F in bar 2 is F# under G major.
+        let bars = one.allMeasures
+        guard bars.count >= 2 else { Issue.record("Parser prerequisite not met"); return }
+        let barTwo = bars[1].noteEvents
+        #expect(barTwo.contains { $0.pitch.step == .f && $0.pitch.alteration == Alteration(numerator: 1, denominator: 1) })
+    }
+
+    @Test("Each voice opens in the key it stated for itself")
+    func voicesOpenInTheirOwnKeys() throws {
+        let tune = try #require(parseTune(Self.twoVoiceHeader + "V:1\nK:G\nCDEF|\nV:2\nK:F\nCDEF|\n"))
+        #expect(voice(tune, "1")?.key?.tonic?.step == .g)
+        #expect(voice(tune, "2")?.key?.tonic?.step == .f)
+    }
+
+    // MARK: Unit note length
+
+    @Test("A voice's own L: is recorded on that voice and nowhere else")
+    func voiceUnitNoteLengthIsRecordedOnItsOwnVoice() throws {
+        let tune = try #require(parseTune(Self.twoVoiceHeader + "V:1\nL:1/8\nCDEF|\nV:2\nCDEF|\n"))
+        let one = try #require(voice(tune, "1"))
+        let two = try #require(voice(tune, "2"))
+
+        #expect(one.unitNoteLength == Fraction(numerator: 1, denominator: 8))
+        #expect(tune.effectiveUnitNoteLength(for: one) == Fraction(numerator: 1, denominator: 8))
+        #expect(two.unitNoteLength == nil)
+        #expect(tune.effectiveUnitNoteLength(for: two) == Fraction(numerator: 1, denominator: 4))
+        #expect(tune.unitNoteLength == Fraction(numerator: 1, denominator: 4))
+    }
+
+    @Test("An inline [L:] at the head of a voice is that voice's, not its neighbour's")
+    func inlineUnitNoteLengthDoesNotLeakToTheNextVoice() throws {
+        let tune = try #require(parseTune(Self.twoVoiceHeader + "[V:1][L:1/16] CDEF|\n[V:2] CDEF|\n"))
+        #expect(voice(tune, "1")?.unitNoteLength == Fraction(numerator: 1, denominator: 16))
+        #expect(voice(tune, "2")?.unitNoteLength == nil)
+    }
+
+    // MARK: Single voice
+
+    @Test("A single-voice tune with no K:/L: of its own is unchanged")
+    func singleVoiceInheritsTheTune() throws {
+        let tune = try #require(parseTune("X:1\nT:T\nM:4/4\nL:1/8\nK:D\nabcd efga|\n"))
+        let only = try #require(tune.voices.first)
+        #expect(only.key == nil)
+        #expect(only.unitNoteLength == nil)
+        #expect(tune.effectiveKey(for: only).tonic?.step == .d)
+        #expect(tune.effectiveUnitNoteLength(for: only) == Fraction(numerator: 1, denominator: 8))
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/PerVoiceKeyAndLengthTests.swift
+++ b/Tests/CeolKitSVGRendererTests/PerVoiceKeyAndLengthTests.swift
@@ -1,0 +1,147 @@
+import Testing
+import CeolKitModel
+import CeolKitParser
+import CeolKitSVGGeometry
+@testable import CeolKitSVGRenderer
+
+/// Issue #66: the key signature and unit note length handed to a staff are the voice's own
+/// where it states them, not the tune's for everybody.
+///
+/// End to end, because the bug was in the wiring: both values existed on the layout types
+/// already and the driver simply fed `tune.key` and `tune.unitNoteLength` into every one.
+@Suite("Per-voice key signature and unit note length")
+struct PerVoiceKeyAndLengthTests {
+
+    /// The `<text>` runs carrying `glyph`, as (x, y) pairs.  `.fontFace` output states a
+    /// glyph's position directly; outline output would state the same thing through a
+    /// transform — see ``textProbeRenderer``.
+    private func glyphPositions(of glyph: SMuFLGlyph, in svg: String) -> [(x: Double, y: Double)] {
+        let character = String(glyph.character)
+        var found: [(x: Double, y: Double)] = []
+        for segment in svg.components(separatedBy: "<text ").dropFirst() {
+            guard segment.contains(character) else { continue }
+            func attribute(_ name: String) -> Double? {
+                guard let start = segment.range(of: "\(name)=\"") else { return nil }
+                let after = segment[start.upperBound...]
+                guard let end = after.firstIndex(of: "\"") else { return nil }
+                return Double(after[after.startIndex..<end])
+            }
+            guard let x = attribute("x"), let y = attribute("y") else { continue }
+            found.append((x, y))
+        }
+        return found
+    }
+
+    /// How many of `positions` sit on each staff of `page`, in staff order.  A glyph is
+    /// assigned to the staff whose vertical middle it is nearest — the staves of a system are
+    /// further apart than a staff is tall, so nothing lands ambiguously.
+    private func countPerStaff(_ positions: [(x: Double, y: Double)],
+                               on page: PageGeometry) -> [Int] {
+        var counts = [Int](repeating: 0, count: page.systems.count)
+        for position in positions {
+            let nearest = page.systems.indices.min {
+                let middleA = page.systems[$0].topY + page.systems[$0].staffLineGap * 2
+                let middleB = page.systems[$1].topY + page.systems[$1].staffLineGap * 2
+                return abs(position.y - middleA) < abs(position.y - middleB)
+            }
+            if let nearest { counts[nearest] += 1 }
+        }
+        return counts
+    }
+
+    private func render(_ abc: String) throws -> (svg: String, page: PageGeometry) {
+        let score = CeolKitParser().parse(abc, options: .default).score
+        let svgs = try textProbeRenderer().render(score)
+        let svg = try #require(svgs.first)
+        let page = try #require(try SVGGeometry.pages(from: svgs).first)
+        return (svg, page)
+    }
+
+    // MARK: Key signature
+
+    @Test("A voice with its own K: gets that key signature at the head of its staff")
+    func voiceKeySignatureIsDrawnOnItsOwnStaff() throws {
+        // The tune is in C and voice 1 is in G. Nothing in the music prints an accidental of
+        // its own, so every sharp glyph on the page belongs to a key signature.
+        let (svg, page) = try render("""
+            X:1
+            T:Per-voice key
+            M:4/4
+            L:1/4
+            K:C
+            V:1
+            K:G
+            cdec | cdec |
+            V:2
+            cdec | cdec |
+            """)
+        #expect(page.systems.count == 2)   // one system, two staves
+        let sharps = countPerStaff(glyphPositions(of: .accidentalSharp, in: svg), on: page)
+        #expect(sharps == [1, 0])
+    }
+
+    @Test("A voice with no K: of its own keeps the tune's")
+    func voiceWithoutItsOwnKeyKeepsTheTunes() throws {
+        // The mirror image: the tune's two sharps stand on voice 1's staff, and voice 2's
+        // K:C cancels them on its own staff only.
+        let (svg, page) = try render("""
+            X:1
+            T:Per-voice key
+            M:4/4
+            L:1/4
+            K:D
+            V:1
+            cdec | cdec |
+            V:2
+            K:C
+            cdec | cdec |
+            """)
+        #expect(page.systems.count == 2)
+        let sharps = countPerStaff(glyphPositions(of: .accidentalSharp, in: svg), on: page)
+        #expect(sharps == [2, 0])
+    }
+
+    @Test("A single-voice tune draws the tune's key, once")
+    func singleVoiceIsUnchanged() throws {
+        let (svg, page) = try render("""
+            X:1
+            T:Single
+            M:4/4
+            L:1/4
+            K:D
+            cdec | cdec |
+            """)
+        #expect(page.systems.count == 1)
+        #expect(glyphPositions(of: .accidentalSharp, in: svg).count == 2)
+    }
+
+    // MARK: Unit note length
+
+    @Test("A voice with its own L: is sized against it")
+    func voiceUnitNoteLengthReachesTheSizer() throws {
+        // Same music either way — only voice 1's L: differs. Sized against 1/1 its notes are
+        // whole notes and need far more room than the 1/16ths the tune's L: would make of
+        // them, so the same source line no longer fits in as few systems.
+        func systemCount(voiceOneLength: String?) throws -> Int {
+            let voiceOneHeader = voiceOneLength.map { "L:\($0)\n" } ?? ""
+            let bar = "cccc cccc cccc cccc |"
+            return try render("""
+                X:1
+                T:Per-voice length
+                M:4/4
+                L:1/16
+                K:C
+                V:1
+                \(voiceOneHeader)\(String(repeating: bar, count: 4))
+                V:2
+                \(String(repeating: bar, count: 4))
+                """).page.systems.count
+        }
+        let inherited = try systemCount(voiceOneLength: nil)
+        let widened = try systemCount(voiceOneLength: "1/1")
+        #expect(widened > inherited)
+        // And the voice that states nothing is unaffected: with both voices on the tune's L:
+        // the count is the same whichever voice we leave alone.
+        #expect(inherited == (try systemCount(voiceOneLength: "1/16")))
+    }
+}


### PR DESCRIPTION
Closes #66.

Key signature and unit note length were taken tune-wide and handed to every voice, so a voice that stated a `K:` or `L:` of its own was engraved against somebody else's.

ABC §7.3 asks for a field that sets a music property to be repeated in every voice it applies to — which only means anything if one voice's `K:` leaves the others alone. So a `K:` or `L:` written in the body now moves the voice that carries it.

## Parser

- `VoiceState` records the `K:` and `L:` a voice states *before any of its music* — what it opens in, which is what the head of its staff draws. A later `K:` still re-seeds that voice's accidental scope and drops its bar memory, but it is a key change mid-staff, not the key the staff opens in, so it is not reported as one. (Drawing it at the point of change is a separate piece of work; reporting it here would put the wrong signature at the head of the whole voice.)
- A later `L:` is not applied at all, for the same reason it never was: one length sizes the whole voice, in the beam resolver and in the renderer's sizer alike — #85.
- `BodyContext.key` and `.unitNoteLength` are now the tune's and fixed. A voice's state is seeded from the tune, never from whichever voice was walked last.

## Model

- `Voice.key` and `Voice.unitNoteLength` carry the voice's own where it states one, `nil` where the tune's stands — so "states its own key" stays distinguishable from "agrees with the tune".
- `Tune.effectiveKey(for:)` and `Tune.effectiveUnitNoteLength(for:)` resolve the two in one place.
- Both are optional with defaults, so `Voice.init` stays source-compatible.

## Renderer

The driver feeds each voice its own key into `LineBreaker.VoiceLine` and into the first/later system header widths, and its own unit note length into `MeasureSizer`.

## Acceptance

- A voice with its own `K:` prints that key signature on its staff — `PerVoiceKeyAndLengthTests`, end to end through `SVGGeometry`, counting key-signature glyphs per staff.
- A voice with its own `L:` has its durations sized against it — same suite, via the system count a widened voice forces.
- Voices without either are unchanged; a single-voice tune is unchanged. 796 tests pass, snapshots included.

Each renderer test was checked against a reverted driver and fails there.

`AccidentalScopeTests` carried the old tune-wide contract as an explicit placeholder for this issue ("`[K:]` is tune-wide until issue #66 makes it per voice"); it now asserts the per-voice one in both directions.

## Noticed while here, not fixed

`keyAccidentals(for:)` takes no clef, so a key signature on a bass-clef staff is laid out at treble staff positions. Pre-existing — it has no clef parameter on `develop` either — but per-voice keys make it easier to hit, since a bass voice can now carry a key the tune does not. Filed as #98, along with two octave slips in the same two arrays that measurement turned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D18xaxjNXgpEsAVF1mhYFV
