### PR TITLE
Fix #67 — thread brace/bracket spans and bar-line joins through the layout

### DIFF
--- a/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
+++ b/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
@@ -92,8 +92,9 @@ public struct SVGRenderer: CeolKitRenderer {
                            + "yet; the plan in effect at the start of the tune governs throughout",
                     source: change.source))
             }
-            let printedVoices = VoiceSelector.select(from: tune.voices, plan: initialPlan,
-                                                     into: &diagnostics)
+            let selection = VoiceSelector.select(from: tune.voices, plan: initialPlan,
+                                                 into: &diagnostics)
+            let printedVoices = selection.voices
 
             // §7.3: a voice states its own `K:` and `L:` where it needs them, and the tune's
             // stand in where it does not.  Resolved once here — every measure of a voice is
@@ -149,7 +150,8 @@ public struct SVGRenderer: CeolKitRenderer {
                 let groups = breaker.breakIntoGroups(voiceLines, breaks: breaks,
                                                      usableWidth: usableWidth,
                                                      firstSystemHeaderWidth: firstHeaderW,
-                                                     laterSystemHeaderWidth: laterHeaderW)
+                                                     laterSystemHeaderWidth: laterHeaderW,
+                                                     grouping: selection.grouping)
                 let headerWidths = groups.indices.map { $0 == 0 ? firstHeaderW : laterHeaderW }
                 tuneGroups = justifier.justifyGroups(groups, usableWidth: usableWidth,
                                                      justifyLastSystem: justifyLastSystem,

--- a/Sources/CeolKitSVGRenderer/Layout/Justifier.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/Justifier.swift
@@ -100,7 +100,7 @@ public struct Justifier: Sendable {
             finalWidths = columnWidths
         }
 
-        return JustifiedSystemGroup(staves: group.staves.map { staff in
+        let staves = group.staves.map { staff -> JustifiedSystem in
             let measures = staff.measures.enumerated().map { column, sized -> JustifiedMeasure in
                 let finalWidth = finalWidths[column]
                 guard finalWidth != sized.naturalWidth else {
@@ -116,7 +116,8 @@ public struct Justifier: Sendable {
             return JustifiedSystem(measures: measures, isLastSystem: staff.isLastSystem,
                                    sourceForced: staff.sourceForced, clef: staff.clef,
                                    keySignature: staff.keySignature, meter: staff.meter)
-        })
+        }
+        return JustifiedSystemGroup(staves: staves, grouping: group.grouping)
     }
 
     /// The width the system's music is laid out to.

--- a/Sources/CeolKitSVGRenderer/Layout/LineBreaker.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/LineBreaker.swift
@@ -92,12 +92,16 @@ public struct LineBreaker: Sendable {
     ///   - firstSystemHeaderWidth: Header width on the tune's first system — already the
     ///     `max` across voices, since the group's staves must start at a common x.
     ///   - laterSystemHeaderWidth: Same for every later system (no time signature).
+    ///   - grouping: The staff plan's spans and bar-line joins, stamped on every group.
+    ///     Only the plan governing the tune's first stave applies, so every system of a
+    ///     tune is grouped the same way and the breaker has nothing to decide here.
     public func breakIntoGroups(
         _ voices: [VoiceLine],
         breaks: [ScoreLineBreak?],
         usableWidth: Double,
         firstSystemHeaderWidth: Double = 0,
-        laterSystemHeaderWidth: Double = 0
+        laterSystemHeaderWidth: Double = 0,
+        grouping: StaffGrouping? = nil
     ) -> [SystemGroup] {
         guard let first = voices.first, !first.measures.isEmpty else { return [] }
 
@@ -133,7 +137,7 @@ public struct LineBreaker: Sendable {
                         keySignature: voice.keySignature,
                         meter: isFirstOfTune ? voice.meter : nil
                     )
-                }))
+                }, grouping: grouping))
             }
         }
 
@@ -143,7 +147,7 @@ public struct LineBreaker: Sendable {
                 System(measures: staff.measures, isLastSystem: true,
                        sourceForced: staff.sourceForced, staveWasSplit: staff.staveWasSplit,
                        clef: staff.clef, keySignature: staff.keySignature, meter: staff.meter)
-            }))
+            }, grouping: last.grouping))
         }
 
         return groups

--- a/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
@@ -69,6 +69,43 @@ public struct System: Sendable {
     }
 }
 
+/// The brace/bracket spans and continued bar-line boundaries of one system, expressed in
+/// *printed* staff indices — positions in ``SystemGroup/staves``.
+///
+/// `%%score` / `%%staves` states them over the staves of the *plan*, which are not the
+/// staves that get printed: a voice the body never wrote to is dropped, a `( … )` shared
+/// staff is still drawn one staff per voice, and a floating `*V` takes a staff of its own.
+/// ``VoiceSelector`` translates them as it selects, so everything below this point can read
+/// the indices straight off.
+///
+/// `nil` on a group means the tune had no plan (or the selector fell back from one), and
+/// every stage behaves exactly as it did before plans existed.
+public struct StaffGrouping: Sendable {
+    /// Outermost first.  May be empty: a plan can order the voices without grouping them.
+    public let spans: [Span]
+    /// Printed staff `i` is joined to `i + 1` by a bar line that runs through the gap.
+    public let barlineJoins: Set<Int>
+
+    public init(spans: [Span], barlineJoins: Set<Int>) {
+        self.spans = spans
+        self.barlineJoins = barlineJoins
+    }
+
+    public struct Span: Hashable, Sendable {
+        public let bracket: StaffPlanBracket
+        /// Printed staff indices, inclusive.
+        public let staves: ClosedRange<Int>
+        /// 0 = outermost; drives sub-bracket thickness.
+        public let depth: Int
+
+        public init(bracket: StaffPlanBracket, staves: ClosedRange<Int>, depth: Int) {
+            self.bracket = bracket
+            self.staves = staves
+            self.depth = depth
+        }
+    }
+}
+
 /// One system's worth of unjustified music: the staves of every voice that is active on
 /// the source line the system came from, in `V:` declaration order.
 ///
@@ -82,8 +119,14 @@ public struct SystemGroup: Sendable {
     /// breaker ever saw them.
     public let staves: [System]
 
-    public init(staves: [System]) {
+    /// The plan's spans and bar-line joins for this system, or `nil` when the tune has no
+    /// plan.  Identical on every group of a tune: only the plan governing the first stave
+    /// applies (see `CeolKitSVGRenderer.render`).
+    public let grouping: StaffGrouping?
+
+    public init(staves: [System], grouping: StaffGrouping? = nil) {
         self.staves = staves
+        self.grouping = grouping
     }
 
     /// The properties the line breaker assigned to the group as a whole.  They are recorded
@@ -145,8 +188,13 @@ public struct JustifiedSystemGroup: Sendable {
     /// One entry per voice, top to bottom.  Never empty.
     public let staves: [JustifiedSystem]
 
-    public init(staves: [JustifiedSystem]) {
+    /// Carried through from ``SystemGroup/grouping`` — justification changes x positions,
+    /// never which staves a brace or bracket covers.
+    public let grouping: StaffGrouping?
+
+    public init(staves: [JustifiedSystem], grouping: StaffGrouping? = nil) {
         self.staves = staves
+        self.grouping = grouping
     }
 
     public var isLastSystem: Bool { staves[0].isLastSystem }
@@ -276,12 +324,53 @@ public struct StaffGroup: Sendable {
     /// Absolute y of the bottom staff line of the group's last staff — the foot of the
     /// vertical line that joins the staves at the left edge.
     public let bottomY: Double
+    /// The brace/bracket spans that *begin* at this staff, outermost first, resolved to
+    /// absolute y.  Empty on a staff no span starts at, and on every staff of a group whose
+    /// tune has no plan.
+    ///
+    /// Anchored on the first staff rather than listed on every staff it covers, because that
+    /// is the staff which draws the furniture spanning a group — see ``isGroupLeader``.  Two
+    /// spans can start on the same staff (`[{A B} C]`), so this is a list and not a single
+    /// bracket kind.
+    public let spans: [Span]
+    /// Whether the bar line at the boundary *below* this staff runs on into the next one.
+    /// Always `false` on the group's last staff.
+    ///
+    /// With no plan every boundary continues, which is the behaviour multi-voice systems
+    /// have had since they were introduced.  A plan states the boundaries it wants with `|`
+    /// and the rest stop at their own staff (issue #68).
+    public let continuesBarlineBelow: Bool
 
-    public init(index: Int, count: Int, nextStaffTopY: Double?, bottomY: Double) {
+    /// One brace or bracket, placed on the page.
+    public struct Span: Sendable {
+        public let bracket: StaffPlanBracket
+        /// Indices within the group, inclusive.  `lowerBound` is the staff carrying this span.
+        public let staves: ClosedRange<Int>
+        /// 0 = outermost; drives sub-bracket thickness.
+        public let depth: Int
+        /// Absolute y of the top staff line of the span's first staff.
+        public let topY: Double
+        /// Absolute y of the bottom staff line of the span's last staff.
+        public let bottomY: Double
+
+        public init(bracket: StaffPlanBracket, staves: ClosedRange<Int>, depth: Int,
+                    topY: Double, bottomY: Double) {
+            self.bracket = bracket
+            self.staves = staves
+            self.depth = depth
+            self.topY = topY
+            self.bottomY = bottomY
+        }
+    }
+
+    public init(index: Int, count: Int, nextStaffTopY: Double?, bottomY: Double,
+                spans: [Span] = [], continuesBarlineBelow: Bool = false) {
         self.index = index
         self.count = count
         self.nextStaffTopY = nextStaffTopY
         self.bottomY = bottomY
+        self.spans = spans
+        self.continuesBarlineBelow = continuesBarlineBelow
     }
 
     /// `true` on the staff that draws the furniture spanning the whole group.

--- a/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
@@ -218,6 +218,29 @@ public struct VerticalLayoutEngine: Sendable {
         let last = metrics.staves[metrics.staves.count - 1]
         let groupBottomY = topY + last.staffTopOffset + staffHeight
 
+        // The plan's spans, placed: a span reaches from the top staff line of its first
+        // staff to the bottom staff line of its last.  Keyed by first staff, which is the
+        // one that draws it.
+        //
+        // A span reaching past the group's last staff is dropped rather than clamped: every
+        // group of a tune carries the same grouping, so one that does not fit did not come
+        // from this tune's selection, and drawing a bracket to a staff that is not there
+        // would be worse than drawing none.
+        let spansByFirstStaff = Dictionary(
+            grouping: (group.grouping?.spans ?? []).filter {
+                $0.staves.upperBound < metrics.staves.count
+            },
+            by: \.staves.lowerBound
+        ).mapValues { spans in
+            spans.map { span in
+                StaffGroup.Span(
+                    bracket: span.bracket, staves: span.staves, depth: span.depth,
+                    topY: topY + metrics.staves[span.staves.lowerBound].staffTopOffset,
+                    bottomY: topY + metrics.staves[span.staves.upperBound].staffTopOffset
+                             + staffHeight)
+            }
+        }
+
         return group.staves.enumerated().map { i, staff in
             let (extraAbove, extraBelow, staffTopOffset) = metrics.staves[i]
             // `origin.y` is the top of the staff's own band; `staffOrigin` walks down from
@@ -235,7 +258,13 @@ public struct VerticalLayoutEngine: Sendable {
                 nextStaffTopY: i + 1 < metrics.staves.count
                     ? topY + metrics.staves[i + 1].staffTopOffset
                     : nil,
-                bottomY: groupBottomY
+                bottomY: groupBottomY,
+                spans: spansByFirstStaff[i] ?? [],
+                // No plan means every boundary continues, as it has since multi-voice
+                // systems were introduced; a plan states the ones it wants and the rest
+                // stop at their own staff.
+                continuesBarlineBelow: i + 1 < group.staves.count
+                    && (group.grouping?.barlineJoins.contains(i) ?? true)
             ) : nil
             return ResolvedSystem(
                 origin: systemOrigin,

--- a/Sources/CeolKitSVGRenderer/Layout/VoiceSelector.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VoiceSelector.swift
@@ -13,7 +13,21 @@ import CeolKitModel
 /// That is strictly better than ignoring the directive — the right voices print in the right
 /// order, and only the vertical grouping is missing — and it keeps every voice the plan
 /// names on the page, which silently dropping the ones this pass cannot group would not.
+///
+/// **It also translates the plan's grouping into printed staff indices.**  `StaffPlanLayout`
+/// counts staves in the *plan*, and the four approximations above mean those are not the
+/// staves that reach the page.  This is the only pass that sees both numberings at once, so
+/// it is the one that has to do the translation; see ``Selection/grouping``.
 enum VoiceSelector {
+
+    /// What the plan asked for, in the terms the rest of the layout works in.
+    struct Selection {
+        /// The voices to print, top to bottom — one staff each.
+        let voices: [Voice]
+        /// The plan's spans and bar-line joins over ``voices``, or `nil` when there was no
+        /// plan to take them from, or the plan selected nothing and was fallen back from.
+        let grouping: StaffGrouping?
+    }
 
     /// - Parameters:
     ///   - voices: every voice of the tune, including ones the body never wrote to.  Those
@@ -26,16 +40,20 @@ enum VoiceSelector {
         from voices: [Voice],
         plan: StaffPlan?,
         into diagnostics: inout [Diagnostic]
-    ) -> [Voice] {
+    ) -> Selection {
         let printable = voices.filter { !$0.isEmpty }
-        guard let plan else { return printable }
+        guard let plan else { return Selection(voices: printable, grouping: nil) }
 
         let layout = plan.layout
         let byId = Dictionary(voices.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
 
         var printed: [Voice] = []
         var seen: Set<VoiceId> = []
-        for id in order(of: layout) {
+        // Printed staff indices contributed by each staff of the plan, in order.  Empty for a
+        // plan staff whose every voice was dropped; more than one where a `( … )` shared staff
+        // was expanded to a staff per voice.
+        var printedByPlanStaff = [[Int]](repeating: [], count: layout.staves.count)
+        for (id, planStaff) in order(of: layout) {
             guard seen.insert(id).inserted else {
                 diagnostics.append(Diagnostic(
                     severity: .warning, code: .staffPlanVoiceRepeated,
@@ -55,6 +73,7 @@ enum VoiceSelector {
             // the tune body, and this one does not appear there.  Not worth a diagnostic —
             // the plan is right and the body simply has nothing to say.
             guard !voice.isEmpty else { continue }
+            if let planStaff { printedByPlanStaff[planStaff].append(printed.count) }
             printed.append(voice)
         }
 
@@ -65,12 +84,13 @@ enum VoiceSelector {
                 message: "staff plan selects none of this tune's voices; "
                        + "laying the tune out as though it had no plan",
                 source: plan.source))
-            return printable
+            return Selection(voices: printable, grouping: nil)
         }
 
         diagnostics += omissions(from: printable, namedBy: layout, plan: plan)
         diagnostics += approximations(of: layout, printedBy: printed, plan: plan)
-        return printed
+        return Selection(voices: printed,
+                         grouping: grouping(of: layout, printedBy: printedByPlanStaff))
     }
 
     // MARK: - Order
@@ -81,14 +101,57 @@ enum VoiceSelector {
     /// below — or first, where the plan gives it nothing above.  That is where the author
     /// wrote it, and it is the position `#80` will start from when it assigns such a voice
     /// per note.
-    private static func order(of layout: StaffPlanLayout) -> [VoiceId] {
+    ///
+    /// The staff index is the plan's, and `nil` for a floating voice — it belongs to no
+    /// staff of the plan, so no span or joint is stated over it.
+    private static func order(of layout: StaffPlanLayout) -> [(id: VoiceId, planStaff: Int?)] {
         let floatingByStaffAbove = Dictionary(grouping: layout.floating, by: \.above)
-        var ordered = (floatingByStaffAbove[nil] ?? []).map(\.id)
+        var ordered = (floatingByStaffAbove[nil] ?? []).map { (id: $0.id, planStaff: Int?.none) }
         for (index, staff) in layout.staves.enumerated() {
-            ordered += staff
-            ordered += (floatingByStaffAbove[index] ?? []).map(\.id)
+            ordered += staff.map { (id: $0, planStaff: Int?.some(index)) }
+            ordered += (floatingByStaffAbove[index] ?? []).map { (id: $0.id, planStaff: Int?.none) }
         }
         return ordered
+    }
+
+    // MARK: - Grouping
+
+    /// The plan's spans and joints, re-expressed over the staves that will actually print.
+    ///
+    /// Returned even when it is empty of both: a plan that groups nothing still says the
+    /// bar lines are *not* to run between its staves, which is not the same as having no
+    /// plan at all.
+    private static func grouping(
+        of layout: StaffPlanLayout,
+        printedBy printedByPlanStaff: [[Int]]
+    ) -> StaffGrouping {
+        // A span covers whichever printed staves its plan staves produced.  Taking the
+        // extremes rather than the union also pulls in a floating voice that was written
+        // inside the span, which is where its author put it.
+        let spans = layout.spans.compactMap { span -> StaffGrouping.Span? in
+            let covered = span.staves.flatMap { printedByPlanStaff[$0] }
+            guard let first = covered.min(), let last = covered.max() else { return nil }
+            return StaffGrouping.Span(bracket: span.bracket, staves: first...last,
+                                      depth: span.depth)
+        }
+
+        var joins: Set<Int> = []
+        for above in layout.barlineJoins {
+            // A joint whose staff above or below printed nothing joins nothing.  Where a
+            // floating voice sits between the two, every boundary it introduces is joined,
+            // so the continuation reads as the one stroke the plan asked for.
+            guard let top = printedByPlanStaff[above].last,
+                  let bottom = printedByPlanStaff[above + 1].first else { continue }
+            joins.formUnion(top..<bottom)
+        }
+        // §11.1 says nothing about the boundary between two staves that are one staff in the
+        // source: a `( … )` group the shared-staff work has not landed for yet.  Continuing
+        // the bar line through it is the closest drawing to the single staff it stands in for.
+        for printed in printedByPlanStaff where printed.count > 1 {
+            joins.formUnion(printed.dropLast())
+        }
+
+        return StaffGrouping(spans: spans, barlineJoins: joins)
     }
 
     // MARK: - Diagnostics

--- a/Tests/CeolKitSVGRendererTests/StaffPlanSelectionTests.swift
+++ b/Tests/CeolKitSVGRendererTests/StaffPlanSelectionTests.swift
@@ -21,7 +21,7 @@ struct StaffPlanSelectionTests {
         var diagnostics: [Diagnostic] = []
         let plan = tune.staffPlans.last { $0.effectiveFromStave == 0 }?.plan
         let chosen = VoiceSelector.select(from: tune.voices, plan: plan, into: &diagnostics)
-        return (chosen.map(\.id), diagnostics)
+        return (chosen.voices.map(\.id), diagnostics)
     }
 
     private func codes(_ diagnostics: [Diagnostic], _ code: DiagnosticCode) -> [Diagnostic] {

--- a/Tests/CeolKitSVGRendererTests/StaffSpanThreadingTests.swift
+++ b/Tests/CeolKitSVGRendererTests/StaffSpanThreadingTests.swift
@@ -1,0 +1,194 @@
+import Testing
+import CeolKitModel
+import CeolKitParser
+@testable import CeolKitSVGRenderer
+
+// MARK: - Helpers
+
+private let dummyRange = SourceRange(file: nil, byteOffset: 0, length: 0, line: 0, column: 0)
+private let dummyBar   = BarLine(kind: .single, source: dummyRange)
+private let config     = SVGRenderConfig()
+private let metadata   = try! BravuraMetadata.load()
+
+private func emptyMeasure(line: Int = 0) -> Measure {
+    Measure(openingBar: nil, events: [], closingBar: dummyBar, endingNumber: nil,
+            source: SourceRange(file: nil, byteOffset: 0, length: 0, line: line, column: 0))
+}
+
+private func sizedMeasure(width: Double = 100) -> SizedMeasure {
+    SizedMeasure(measure: emptyMeasure(), naturalWidth: width, eventOffsets: [])
+}
+
+private func justifiedSystem(isLast: Bool = false) -> JustifiedSystem {
+    JustifiedSystem(measures: [JustifiedMeasure(source: sizedMeasure(), finalWidth: 100,
+                                                eventOffsets: [])],
+                    isLastSystem: isLast, sourceForced: false)
+}
+
+/// Issue #67: the plan's brace/bracket spans and continued bar-line boundaries reach the
+/// layout, expressed in the indices of the staves that actually print (ABC v2.2 §11.1).
+///
+/// Nothing draws them yet — #68 and #70 do that — so these tests assert the data and the
+/// existing golden tests assert that the page is unchanged.
+@Suite("Staff Span Threading")
+struct StaffSpanThreadingTests {
+
+    // MARK: - Selection
+
+    /// The grouping the renderer would hand the line breaker, from a real parse.
+    private func selectGrouping(_ abc: String) -> StaffGrouping? {
+        let tune = CeolKitParser().parse(abc, options: .default).score.tunes[0]
+        var diagnostics: [Diagnostic] = []
+        let plan = tune.staffPlans.last { $0.effectiveFromStave == 0 }?.plan
+        return VoiceSelector.select(from: tune.voices, plan: plan, into: &diagnostics).grouping
+    }
+
+    /// Three voices, one bar each, with `directive` above the `K:`.  A voice listed in
+    /// `silent` is declared but never written to, so the plan may name it and it still
+    /// does not print.
+    private func threeVoices(_ directive: String = "", silent: Set<String> = []) -> String {
+        let body = ["1", "2", "3"].filter { !silent.contains($0) }
+                                  .flatMap { ["V:\($0)", "CDEF|"] }
+        return (["X:1", "L:1/4", directive, "V:1", "V:2", "V:3", "K:C"] + body)
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+    }
+
+    @Test("A tune with no plan has no grouping at all")
+    func noPlanNoGrouping() {
+        #expect(selectGrouping(threeVoices()) == nil)
+    }
+
+    @Test("%%score [1 2] is one bracket over both staves, and no joins")
+    func bracketOverTwoStaves() throws {
+        let grouping = try #require(selectGrouping(threeVoices("%%score [1 2]")))
+        #expect(grouping.spans == [StaffGrouping.Span(bracket: .bracket, staves: 0...1, depth: 0)])
+        #expect(grouping.barlineJoins.isEmpty)
+    }
+
+    @Test("%%score [{1 | 2} | 3] nests a brace inside a bracket and joins both boundaries")
+    func nestedBraceInsideBracket() throws {
+        let grouping = try #require(selectGrouping(threeVoices("%%score [{1 | 2} | 3]")))
+        #expect(grouping.spans == [
+            StaffGrouping.Span(bracket: .bracket, staves: 0...2, depth: 0),
+            StaffGrouping.Span(bracket: .brace, staves: 0...1, depth: 1),
+        ])
+        #expect(grouping.barlineJoins == [0, 1])
+    }
+
+    @Test("A plan that only orders the voices groups none of them, and says so")
+    func planWithoutDelimitersGroupsNothing() throws {
+        // Not the same as having no plan: the bar lines are not to run between these staves.
+        let grouping = try #require(selectGrouping(threeVoices("%%score 2 1")))
+        #expect(grouping.spans.isEmpty)
+        #expect(grouping.barlineJoins.isEmpty)
+    }
+
+    @Test("A span shrinks to the staves that print when a voice it covers has no music")
+    func spanShrinksPastAVoiceWithNoMusic() throws {
+        // The plan names three voices; the middle one is declared but never written to, so
+        // §11.1 does not print it and the bracket covers the two staves that are left.
+        let grouping = try #require(selectGrouping(threeVoices("%%score [1 2 3]", silent: ["2"])))
+        #expect(grouping.spans == [StaffGrouping.Span(bracket: .bracket, staves: 0...1, depth: 0)])
+    }
+
+    @Test("A join reaches through the staff a floating voice was given")
+    func joinReachesThroughAFloatingVoice() throws {
+        // `*2` has no staff in the plan, but is drawn on one of its own for now, so the
+        // join written between staves 1 and 3 spans two printed boundaries, not one.
+        let grouping = try #require(selectGrouping(threeVoices("%%score {1 *2| 3}")))
+        #expect(grouping.spans == [StaffGrouping.Span(bracket: .brace, staves: 0...2, depth: 0)])
+        #expect(grouping.barlineJoins == [0, 1])
+    }
+
+    @Test("The staves standing in for one shared staff are joined")
+    func sharedStaffStandInsAreJoined() throws {
+        // `(1 2)` is one staff in the source and two on the page until the shared-staff work
+        // lands; a continued bar line is the closest drawing to the staff it stands in for.
+        let grouping = try #require(selectGrouping(threeVoices("%%score [(1 2) 3]")))
+        #expect(grouping.spans == [StaffGrouping.Span(bracket: .bracket, staves: 0...2, depth: 0)])
+        #expect(grouping.barlineJoins == [0])
+    }
+
+    @Test("A plan that selects no voice is fallen back from, grouping and all")
+    func fallbackHasNoGrouping() {
+        #expect(selectGrouping(threeVoices("%%score [8 9]")) == nil)
+    }
+
+    // MARK: - Threading through the breaker and justifier
+
+    @Test("Every system of a tune carries the tune's grouping, the last one included")
+    func groupingSurvivesBreakingAndJustification() {
+        let grouping = StaffGrouping(
+            spans: [StaffGrouping.Span(bracket: .bracket, staves: 0...1, depth: 0)],
+            barlineJoins: [0])
+        // Five 90 pt measures over a 300 pt line: more than one system, so the last-system
+        // rebuild inside the breaker is exercised too.
+        let voiceLines = (0..<2).map { _ in
+            LineBreaker.VoiceLine(measures: (0..<5).map { _ in sizedMeasure(width: 90) })
+        }
+        let groups = LineBreaker().breakIntoGroups(
+            voiceLines, breaks: Array(repeating: nil, count: 5), usableWidth: 300,
+            grouping: grouping)
+        #expect(groups.count > 1)
+        #expect(groups.allSatisfy { $0.grouping?.spans == grouping.spans })
+        #expect(groups.allSatisfy { $0.grouping?.barlineJoins == grouping.barlineJoins })
+
+        let justified = Justifier().justifyGroups(groups, usableWidth: 300, justifyLastSystem: false)
+        #expect(justified.allSatisfy { $0.grouping?.spans == grouping.spans })
+    }
+
+    // MARK: - Placement
+
+    private func layout(_ grouping: StaffGrouping?, staves: Int) -> [ResolvedSystem] {
+        let systems = (0..<staves).map { justifiedSystem(isLast: $0 == staves - 1) }
+        let block = TuneBlock(systemGroups: [JustifiedSystemGroup(staves: systems,
+                                                                  grouping: grouping)])
+        return VerticalLayoutEngine(config: config, metadata: metadata)
+            .layout([block]).pages[0].systems
+    }
+
+    @Test("A span is placed from the top line of its first staff to the bottom line of its last")
+    func spansAreResolvedToAbsoluteY() throws {
+        let systems = layout(StaffGrouping(spans: [
+            StaffGrouping.Span(bracket: .bracket, staves: 0...2, depth: 0),
+            StaffGrouping.Span(bracket: .brace, staves: 0...1, depth: 1),
+        ], barlineJoins: [1]), staves: 3)
+
+        // Both spans start on the top staff, which is the staff that draws group furniture.
+        let leader = try #require(systems[0].staffGroup)
+        #expect(leader.isGroupLeader)
+        #expect(leader.spans.map(\.bracket) == [.bracket, .brace])
+        #expect(leader.spans.map(\.depth) == [0, 1])
+
+        let staffHeight = 4.0 * config.staffSize
+        let topLine = systems[0].origin.y + systems[0].staffOrigin
+        #expect(leader.spans[0].topY == topLine)
+        #expect(leader.spans[1].topY == topLine)
+        // The bracket reaches the foot of the group; the brace stops at the middle staff.
+        #expect(abs(leader.spans[0].bottomY - leader.bottomY) < 1e-9)
+        #expect(abs(leader.spans[1].bottomY
+                    - (systems[1].origin.y + systems[1].staffOrigin + staffHeight)) < 1e-9)
+
+        // A span is listed once, on the staff it starts at — not on every staff it covers.
+        let middle = try #require(systems[1].staffGroup)
+        let bottom = try #require(systems[2].staffGroup)
+        #expect(middle.spans.isEmpty)
+        #expect(bottom.spans.isEmpty)
+    }
+
+    @Test("Only the boundaries the plan joins continue")
+    func onlyPlannedBoundariesContinue() throws {
+        let systems = layout(StaffGrouping(spans: [], barlineJoins: [1]), staves: 3)
+        let flags = try systems.map { try #require($0.staffGroup).continuesBarlineBelow }
+        #expect(flags == [false, true, false])
+    }
+
+    @Test("With no plan every boundary continues, as it did before plans existed")
+    func withoutAPlanEveryBoundaryContinues() throws {
+        let systems = layout(nil, staves: 3)
+        let flags = try systems.map { try #require($0.staffGroup).continuesBarlineBelow }
+        #expect(flags == [true, true, false])
+        #expect(systems.allSatisfy { $0.staffGroup?.spans.isEmpty ?? true })
+    }
+}


### PR DESCRIPTION
Carries the staff plan's brace/bracket spans and continued bar-line boundaries through the layout passes so #68 and #70 can draw them. **Data only — nothing draws, and rendered output is byte-identical with and without a plan.**

## The part the issue statement did not cover

`StaffPlanLayout.spans` / `.barlineJoins` are expressed in *plan* staff indices, and after #65 those are not printed staff indices: a voice with no music is dropped, a repeat is printed once, a `( … )` shared staff is still drawn one staff per voice, and a floating `*V` gets a staff of its own. `VoiceSelector` is the only pass that sees both numberings, so it now translates as it selects and returns a `Selection` (voices + `StaffGrouping`).

## Shape

- `StaffGrouping` — `spans: [Span]` (bracket kind, printed staff range, depth) and `barlineJoins: Set<Int>`. `nil` means "no plan"; empty-but-present means "a plan that groups nothing", which is not the same thing.
- `SystemGroup` / `JustifiedSystemGroup` gain `grouping`, defaulted to `nil` so every existing call site is untouched.
- `StaffGroup` gains `spans: [Span]` resolved to absolute y (anchored on the span's first staff, which is the staff that draws group furniture — `[{A B} C]` starts two spans there, hence a list rather than a single bracket kind) and `continuesBarlineBelow`.

## Two readings §11.1 leaves open

Both are commented where they are made:

- A join written across a floating voice covers **every** boundary that voice's stand-in staff introduces, so the continuation reads as the one stroke the plan asked for.
- The staves standing in for one `( … )` shared staff are **joined** to each other — they are one staff in the source, so a continued bar line is the closest drawing to what was written.

## Acceptance

- `%%score [1 2]` → one bracket span over printed staves 0...1 at depth 0. ✅
- `%%score [{1 | 2} | 3]` → bracket 0...2 depth 0, brace 0...1 depth 1, joins at both boundaries. ✅
- No plan → no spans, `StaffGroup` otherwise unchanged, every boundary continues. ✅
- Output byte-identical: 808 tests pass, and `ckprobe` renders a two-voice tune to the same bytes as `develop` both with and without `%%score`. ✅

`emitStaffGroupConnector` is untouched, as the issue asks.

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D18xaxjNXgpEsAVF1mhYFV