### PR TITLE
Fix #69 — segment the render driver per plan region

### DIFF
--- a/Sources/CeolKitModel/Diagnostic.swift
+++ b/Sources/CeolKitModel/Diagnostic.swift
@@ -73,9 +73,9 @@ public enum DiagnosticCode: String, Codable, Sendable {
     /// A staff plan names no voice the tune can print.  The plan is abandoned and the tune
     /// laid out as though it had none, rather than rendered empty.
     case staffPlanEmpty
-    /// The plan parsed and was applied as far as the renderer goes today: voice selection
-    /// and ordering.  Shared staves, floating voices and mid-tune plan changes are each
-    /// approximated, and the message says which one this is.
+    /// The plan parsed and was applied as far as the renderer goes today: voice selection,
+    /// ordering, and where it takes effect.  Shared staves and floating voices are each
+    /// approximated by a staff per voice, and the message says which one this is.
     case staffPlanNotFullyApplied
     // Field keys
     case unknownKey

--- a/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
+++ b/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
@@ -81,64 +81,72 @@ public struct SVGRenderer: CeolKitRenderer {
             let sizer = MeasureSizer(config: tuneConfig, metadata: metadata)
 
             // §11.1: a `%%score` / `%%staves` plan decides which voices are printed and in
-            // what order. Only the plan governing the first stave applies — a plan written
-            // in the body changes the staff count part-way through the tune, and the driver
-            // below sizes its column store once for the whole tune.
-            let initialPlan = tune.staffPlans.last { $0.effectiveFromStave == 0 }?.plan
-            for change in tune.staffPlans where change.effectiveFromStave > 0 {
-                diagnostics.append(Diagnostic(
-                    severity: .info, code: .staffPlanNotFullyApplied,
-                    message: "a staff plan inside the tune body cannot change the staff count "
-                           + "yet; the plan in effect at the start of the tune governs throughout",
-                    source: change.source))
-            }
-            let selection = VoiceSelector.select(from: tune.voices, plan: initialPlan,
-                                                 into: &diagnostics)
-            let printedVoices = selection.voices
+            // what order, and one written in the tune body resets that part-way through.
+            // The staff count is therefore not a property of the tune, so the whole
+            // align → size → break block below runs once per *plan region* — a maximal run
+            // of staves under one plan — and the systems are concatenated.  A region
+            // boundary is always a system break; a staff plan cannot change mid-system.
+            var groups: [SystemGroup] = []
+            var headerWidths: [Double] = []
 
-            // §7.3: a voice states its own `K:` and `L:` where it needs them, and the tune's
-            // stand in where it does not.  Resolved once here — every measure of a voice is
-            // sized against the same unit note length, and its staff head draws the same key.
-            let voiceKeys = printedVoices.map { tune.effectiveKey(for: $0) }
-            let voiceUnitLengths = printedVoices.map { tune.effectiveUnitNoteLength(for: $0) }
+            for region in PlanRegions.segment(tune) {
+                let selection = VoiceSelector.select(from: region.voices, plan: region.plan,
+                                                     into: &diagnostics)
+                let printedVoices = selection.voices
+                guard !printedVoices.isEmpty else { continue }
 
-            // Bring the voices into agreement about how much music each source line holds,
-            // so the break points chosen below are legal for every one of them. Voices that
-            // disagree are padded and warned about rather than laid out sequentially.
-            let alignedStaves = VoiceAligner.align(printedVoices, into: &diagnostics)
+                // §7.3: a voice states its own `K:` and `L:` where it needs them, and the
+                // tune's stand in where it does not.  Resolved once here — every measure of
+                // a voice is sized against the same unit note length, and its staff head
+                // draws the same key.
+                let voiceKeys = printedVoices.map { tune.effectiveKey(for: $0) }
+                let voiceUnitLengths = printedVoices.map { tune.effectiveUnitNoteLength(for: $0) }
 
-            // Flatten the aligned staves into one measure column per bar, carrying the
-            // stave boundaries as .hard breaks: the semantic pass makes one Staff per source
-            // line-break, so the last column of every non-final stave forces a system break.
-            var breaks: [ScoreLineBreak?] = []
-            var columnsPerVoice = [[SizedMeasure]](repeating: [], count: printedVoices.count)
-            for (si, stave) in alignedStaves.enumerated() {
-                let isLastStave = si == alignedStaves.count - 1
-                for column in 0..<stave.measureCount {
-                    breaks.append(!isLastStave && column == stave.measureCount - 1 ? .hard : nil)
-                    for voiceIndex in printedVoices.indices {
-                        columnsPerVoice[voiceIndex].append(
-                            sizer.size(stave.measures[voiceIndex][column],
-                                       unitNoteLength: voiceUnitLengths[voiceIndex]))
+                // Bring the voices into agreement about how much music each source line
+                // holds, so the break points chosen below are legal for every one of them.
+                // Voices that disagree are padded and warned about rather than laid out
+                // sequentially.
+                let alignedStaves = VoiceAligner.align(printedVoices, into: &diagnostics)
+
+                // Flatten the aligned staves into one measure column per bar, carrying the
+                // stave boundaries as .hard breaks: the semantic pass makes one Staff per
+                // source line-break, so the last column of every non-final stave forces a
+                // system break.  The region's own final stave needs none — the region ends
+                // there, and the next one starts a new system anyway.
+                var breaks: [ScoreLineBreak?] = []
+                var columnsPerVoice = [[SizedMeasure]](repeating: [], count: printedVoices.count)
+                for (si, stave) in alignedStaves.enumerated() {
+                    let isLastStave = si == alignedStaves.count - 1
+                    for column in 0..<stave.measureCount {
+                        breaks.append(!isLastStave && column == stave.measureCount - 1 ? .hard : nil)
+                        for voiceIndex in printedVoices.indices {
+                            columnsPerVoice[voiceIndex].append(
+                                sizer.size(stave.measures[voiceIndex][column],
+                                           unitNoteLength: voiceUnitLengths[voiceIndex]))
+                        }
                     }
                 }
-            }
+                guard !breaks.isEmpty else { continue }
 
-            var tuneGroups: [JustifiedSystemGroup] = []
-            if !breaks.isEmpty {
+                // A time signature is drawn once, on the tune's very first system.  A later
+                // region opens a fresh set of staves, but it is still the same tune, and a
+                // meter no more repeats at a staff-plan change than it does at a line break.
+                let isOpeningRegion = groups.isEmpty
+                let regionMeter = isOpeningRegion ? tune.meter : nil
+
                 let voiceLines = printedVoices.enumerated().map { index, voice in
                     LineBreaker.VoiceLine(measures: columnsPerVoice[index],
                                           clef: voice.properties.clef,
                                           keySignature: voiceKeys[index],
-                                          meter: tune.meter)
+                                          meter: regionMeter)
                 }
                 // Header widths differ between the first system (has time sig) and later
                 // ones, and are the max across the group: the staves of a system have to
                 // start at the same x even when one voice's clef or key signature is wider.
-                let firstHeaderW = printedVoices.indices.reduce(0.0) { widest, index in
+                let openingHeaderW = printedVoices.indices.reduce(0.0) { widest, index in
                     max(widest, systemHeaderWidth(clef: printedVoices[index].properties.clef,
                                                   keySignature: voiceKeys[index],
-                                                  meter: tune.meter, metadata: metadata,
+                                                  meter: regionMeter, metadata: metadata,
                                                   staffSize: tuneConfig.staffSize))
                 }
                 let laterHeaderW = printedVoices.indices.reduce(0.0) { widest, index in
@@ -147,16 +155,24 @@ public struct SVGRenderer: CeolKitRenderer {
                                                   meter: nil, metadata: metadata,
                                                   staffSize: tuneConfig.staffSize))
                 }
-                let groups = breaker.breakIntoGroups(voiceLines, breaks: breaks,
-                                                     usableWidth: usableWidth,
-                                                     firstSystemHeaderWidth: firstHeaderW,
-                                                     laterSystemHeaderWidth: laterHeaderW,
-                                                     grouping: selection.grouping)
-                let headerWidths = groups.indices.map { $0 == 0 ? firstHeaderW : laterHeaderW }
-                tuneGroups = justifier.justifyGroups(groups, usableWidth: usableWidth,
-                                                     justifyLastSystem: justifyLastSystem,
-                                                     systemHeaderWidths: headerWidths)
+                let regionGroups = breaker.breakIntoGroups(voiceLines, breaks: breaks,
+                                                           usableWidth: usableWidth,
+                                                           firstSystemHeaderWidth: openingHeaderW,
+                                                           laterSystemHeaderWidth: laterHeaderW,
+                                                           grouping: selection.grouping)
+                headerWidths += regionGroups.indices.map { $0 == 0 ? openingHeaderW : laterHeaderW }
+                groups += regionGroups
             }
+
+            // The line breaker marks the last system of whatever it was handed, and it was
+            // handed one region at a time; only the last system of the last region ends the
+            // tune.
+            groups = groups.enumerated().map {
+                $0.element.markingLastSystem($0.offset == groups.count - 1)
+            }
+            let tuneGroups = groups.isEmpty ? [] : justifier.justifyGroups(
+                groups, usableWidth: usableWidth, justifyLastSystem: justifyLastSystem,
+                systemHeaderWidths: headerWidths)
 
             // Build the title block for this tune per §6.1.3.
             // Title row baselineY values are tune-relative; the layout engine offsets
@@ -287,5 +303,19 @@ public struct SVGRenderer: CeolKitRenderer {
             }
         }
         return effective
+    }
+}
+
+// MARK: - Plan regions
+
+private extension SystemGroup {
+    /// The same group with `isLastSystem` set to `isLast` on every staff.
+    func markingLastSystem(_ isLast: Bool) -> SystemGroup {
+        guard isLastSystem != isLast else { return self }
+        return SystemGroup(staves: staves.map {
+            System(measures: $0.measures, isLastSystem: isLast, sourceForced: $0.sourceForced,
+                   staveWasSplit: $0.staveWasSplit, clef: $0.clef,
+                   keySignature: $0.keySignature, meter: $0.meter)
+        }, grouping: grouping)
     }
 }

--- a/Sources/CeolKitSVGRenderer/Layout/LineBreaker.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/LineBreaker.swift
@@ -93,8 +93,8 @@ public struct LineBreaker: Sendable {
     ///     `max` across voices, since the group's staves must start at a common x.
     ///   - laterSystemHeaderWidth: Same for every later system (no time signature).
     ///   - grouping: The staff plan's spans and bar-line joins, stamped on every group.
-    ///     Only the plan governing the tune's first stave applies, so every system of a
-    ///     tune is grouped the same way and the breaker has nothing to decide here.
+    ///     One call covers one plan region (see `PlanRegions`), so a single grouping governs
+    ///     everything the breaker is handed and it has nothing to decide here.
     public func breakIntoGroups(
         _ voices: [VoiceLine],
         breaks: [ScoreLineBreak?],

--- a/Sources/CeolKitSVGRenderer/Layout/PlanRegion.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/PlanRegion.swift
@@ -1,0 +1,91 @@
+import CeolKitModel
+
+/// Pass 1⅛: cuts a tune into the runs of staves that one `%%score` / `%%staves` plan governs.
+///
+/// §11.1: a plan written in the tune body "resets the music generator, so that voices may
+/// appear and disappear for some period of time".  That makes the set of printed voices — and
+/// so the number of staves in a system — a property of *where* you are in the tune, not of the
+/// tune.  Everything downstream of `VoiceSelector` assumes one staff count for everything it
+/// is handed, so the tune is handed over one region at a time and the results concatenated.
+///
+/// A region boundary is therefore always a system break: the staves of a system are laid out
+/// together, so the plan cannot change part-way through one.  The parser has already snapped
+/// each plan back to the start of the stave enclosing it (see ``StaffPlanChange``), which is
+/// what makes a region a whole number of staves.
+///
+/// **Regions are cut by stave index**, which is the same numbering ``VoiceAligner`` aligns on:
+/// stave *k* of one voice is stave *k* of every other.  A source that gives a voice no line at
+/// all in some line-set breaks that assumption before a plan is involved — the voice's later
+/// staves all shift up one — and a region cut then lands in the wrong place for it, exactly as
+/// the aligner's padding already does.  Write every voice a line per system and the numbering
+/// holds.
+struct PlanRegion {
+    /// The plan governing this region, or `nil` for the opening region of a tune whose plans
+    /// all start later — that stretch is laid out exactly as a tune with no plan at all.
+    let plan: StaffPlan?
+    /// Every voice of the tune, with its staves cut down to the ones this region covers.  A
+    /// voice with nothing to say here is empty, and so is not printed; it resumes on its own
+    /// staff in the next region that has music for it.
+    let voices: [Voice]
+    /// The staves this region covers, as indices into the tune's stave numbering.  Carried for
+    /// diagnostics and tests; the layout works from ``voices``.
+    let staves: Range<Int>
+}
+
+enum PlanRegions {
+
+    /// Segments `tune` into maximal runs of staves governed by one plan, in source order.
+    ///
+    /// Always returns at least one region, so a tune with no plan — the overwhelming majority —
+    /// takes exactly the path it did before regions existed: one region, the tune's own voices,
+    /// no slicing.
+    static func segment(_ tune: Tune) -> [PlanRegion] {
+        let staveCount = tune.voices.reduce(0) { max($0, $1.staves.count) }
+
+        // Two changes can share a stave — a file-preamble plan and a tune-header plan both
+        // govern from stave 0 — and the last one written wins, as it does for every other
+        // directive.  A plan starting past the end of the music governs nothing and is dropped.
+        var planByStave: [Int: StaffPlan] = [:]
+        for change in tune.staffPlans where change.effectiveFromStave < staveCount {
+            planByStave[change.effectiveFromStave] = change.plan
+        }
+
+        // No music, or every plan governs from the very first stave: one region over the whole
+        // tune, and no `Voice` is rebuilt.
+        guard let boundaries = boundaries(planByStave.keys, staveCount: staveCount) else {
+            let plan = tune.staffPlans.last { $0.effectiveFromStave == 0 }?.plan
+            return [PlanRegion(plan: plan, voices: tune.voices, staves: 0..<staveCount)]
+        }
+
+        return boundaries.indices.map { index in
+            let start = boundaries[index]
+            let end = index + 1 < boundaries.count ? boundaries[index + 1] : staveCount
+            let range = start..<end
+            return PlanRegion(
+                plan: planByStave[start],
+                voices: tune.voices.map { $0.covering(range) },
+                staves: range
+            )
+        }
+    }
+
+    /// The stave indices each region starts at, or `nil` when there is only one region.
+    ///
+    /// The opening region always starts at stave 0, whether or not a plan does.
+    private static func boundaries(_ starts: some Collection<Int>, staveCount: Int) -> [Int]? {
+        guard staveCount > 0 else { return nil }
+        var all = Set(starts)
+        all.insert(0)
+        guard all.count > 1 else { return nil }
+        return all.sorted()
+    }
+}
+
+private extension Voice {
+    /// The same voice holding only the staves in `range`.
+    func covering(_ range: Range<Int>) -> Voice {
+        Voice(id: id, properties: properties, key: key, unitNoteLength: unitNoteLength,
+              staves: Array(staves[range.clamped(to: staves.indices)]),
+              directives: directives, source: source)
+    }
+}

--- a/Sources/CeolKitSVGRenderer/Layout/PlanRegion.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/PlanRegion.swift
@@ -17,8 +17,9 @@ import CeolKitModel
 /// stave *k* of one voice is stave *k* of every other.  A source that gives a voice no line at
 /// all in some line-set breaks that assumption before a plan is involved — the voice's later
 /// staves all shift up one — and a region cut then lands in the wrong place for it, exactly as
-/// the aligner's padding already does.  Write every voice a line per system and the numbering
-/// holds.
+/// the aligner's padding already does.  That is issue #102, and it is the parser that has to
+/// fix it: nothing here can recover a stave the model never recorded.  Until then, write every
+/// voice a line per system and the numbering holds.
 struct PlanRegion {
     /// The plan governing this region, or `nil` for the opening region of a tune whose plans
     /// all start later — that stretch is laid out exactly as a tune with no plan at all.

--- a/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
@@ -119,9 +119,10 @@ public struct SystemGroup: Sendable {
     /// breaker ever saw them.
     public let staves: [System]
 
-    /// The plan's spans and bar-line joins for this system, or `nil` when the tune has no
-    /// plan.  Identical on every group of a tune: only the plan governing the first stave
-    /// applies (see `CeolKitSVGRenderer.render`).
+    /// The plan's spans and bar-line joins for this system, or `nil` when no plan governs
+    /// it.  Identical on every group of one plan region, and free to differ between regions:
+    /// a `%%score` in the tune body changes both the staves and how they are grouped (see
+    /// `PlanRegions`).
     public let grouping: StaffGrouping?
 
     public init(staves: [System], grouping: StaffGrouping? = nil) {

--- a/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
@@ -222,10 +222,10 @@ public struct VerticalLayoutEngine: Sendable {
         // staff to the bottom staff line of its last.  Keyed by first staff, which is the
         // one that draws it.
         //
-        // A span reaching past the group's last staff is dropped rather than clamped: every
-        // group of a tune carries the same grouping, so one that does not fit did not come
-        // from this tune's selection, and drawing a bracket to a staff that is not there
-        // would be worse than drawing none.
+        // A span reaching past the group's last staff is dropped rather than clamped: a
+        // grouping is built over the very staves of the region it is stamped on, so one that
+        // does not fit did not come from this group's selection, and drawing a bracket to a
+        // staff that is not there would be worse than drawing none.
         let spansByFirstStaff = Dictionary(
             grouping: (group.grouping?.spans ?? []).filter {
                 $0.staves.upperBound < metrics.staves.count

--- a/Tests/CeolKitSVGRendererTests/StaffPlanRegionTests.swift
+++ b/Tests/CeolKitSVGRendererTests/StaffPlanRegionTests.swift
@@ -1,0 +1,206 @@
+import Testing
+import CeolKitModel
+import CeolKitParser
+import CeolKitSVGGeometry
+@testable import CeolKitSVGRenderer
+
+/// Issue #69: a `%%score` in the tune body changes the set of printed voices, so the number
+/// of staves differs between systems (ABC v2.2 §11.1).  The renderer runs its whole
+/// align → size → break block once per *plan region* and concatenates the results.
+@Suite("Staff Plan Regions")
+struct StaffPlanRegionTests {
+
+    // MARK: - Helpers
+
+    private func tune(_ abc: String) -> Tune {
+        CeolKitParser().parse(abc, options: .default).score.tunes[0]
+    }
+
+    private func render(_ abc: String) -> (pages: [PageGeometry], diagnostics: [Diagnostic]) {
+        let score = CeolKitParser().parse(abc, options: .default).score
+        var diagnostics: [Diagnostic] = []
+        let svgs = try! SVGRenderer().render(score, diagnostics: &diagnostics)
+        return (try! SVGGeometry.pages(from: svgs), diagnostics)
+    }
+
+    /// The number of staves in each system group, in page order.
+    ///
+    /// The vertical layout stamps the group's source line on every staff of it, so a run of
+    /// staves reporting the same line is one group.  Sound for these fixtures, where every
+    /// source line fits on one system and no two consecutive groups come from one line.
+    private func stavesPerSystem(_ abc: String) -> [Int] {
+        let systems = render(abc).pages.flatMap(\.systems)
+        return systems.reduce(into: [(line: Int?, count: Int)]()) { runs, system in
+            if runs.last?.line == system.abcLine { runs[runs.count - 1].count += 1 }
+            else { runs.append((system.abcLine, 1)) }
+        }.map(\.count)
+    }
+
+    private func anchorLines(_ abc: String) -> [Int] {
+        render(abc).pages.flatMap(\.systems).compactMap(\.abcLine)
+    }
+
+    /// Three voices with `header` above the `K:`, one line each per line-set, and `body`
+    /// written between the first and second line-set.
+    private func threeVoices(header: String, body: String = "") -> String {
+        ([
+            "X:1", "L:1/4", header,
+            "V:1", "V:2", "V:3", "K:C",
+            "V:1", "CDEF|", "V:2", "GABc|", "V:3", "cdef|",
+            body,
+            "V:1", "CDEF|", "V:2", "GABc|", "V:3", "cdef|"
+        ] as [String]).filter { !$0.isEmpty }.joined(separator: "\n")
+    }
+
+    // MARK: - Segmentation
+
+    @Test("A tune with no plan is one region over every stave, holding the tune's own voices")
+    func noPlanIsOneRegion() {
+        let parsed = tune(threeVoices(header: ""))
+        let regions = PlanRegions.segment(parsed)
+        #expect(regions.count == 1)
+        #expect(regions[0].plan == nil)
+        #expect(regions[0].staves == 0..<2)
+        #expect(regions[0].voices.map(\.staves.count) == parsed.voices.map(\.staves.count))
+    }
+
+    @Test("A header plan is one region: nothing about the tune changes part-way through")
+    func headerPlanIsOneRegion() {
+        let regions = PlanRegions.segment(tune(threeVoices(header: "%%score [1 2]")))
+        #expect(regions.count == 1)
+        #expect(regions[0].plan != nil)
+        #expect(regions[0].staves == 0..<2)
+    }
+
+    @Test("A preamble plan and a header plan both govern from stave 0, and stay one region")
+    func twoPlansAtStaveZeroAreOneRegion() {
+        // Both reach the tune with `effectiveFromStave: 0`; the later one wins, as it does
+        // for every other directive, and neither opens a second region.
+        let abc = """
+        %%score [1 2 3]
+        X:1
+        L:1/4
+        %%score [1 2]
+        V:1
+        V:2
+        V:3
+        K:C
+        V:1
+        CDEF|
+        V:2
+        GABc|
+        V:3
+        cdef|
+        """
+        let parsed = tune(abc)
+        #expect(parsed.staffPlans.filter { $0.effectiveFromStave == 0 }.count == 2)
+
+        let regions = PlanRegions.segment(parsed)
+        #expect(regions.count == 1)
+        // The later plan won: two staves print, not three.
+        #expect(stavesPerSystem(abc) == [2])
+    }
+
+    @Test("A body plan opens a second region at the stave it governs from")
+    func bodyPlanOpensARegion() {
+        let regions = PlanRegions.segment(
+            tune(threeVoices(header: "%%score [1 2 3]", body: "%%score [1 2]")))
+        #expect(regions.map(\.staves) == [0..<1, 1..<2])
+        #expect(regions.allSatisfy { $0.plan != nil })
+    }
+
+    @Test("A body plan with no plan before it leaves the opening region unplanned")
+    func openingRegionCanHaveNoPlan() {
+        let regions = PlanRegions.segment(tune(threeVoices(header: "", body: "%%score [1 2]")))
+        #expect(regions.map(\.staves) == [0..<1, 1..<2])
+        #expect(regions[0].plan == nil)
+        #expect(regions[1].plan != nil)
+    }
+
+    @Test("A plan that starts past the end of the music governs nothing")
+    func planPastTheEndIsDropped() {
+        // The trailing `%%score` is the last thing in the body, so it governs stave 2 — a
+        // stave the tune never writes.  Cutting a region there would produce an empty one.
+        let abc = threeVoices(header: "%%score [1 2 3]") + "\n%%score [1]"
+        let parsed = tune(abc)
+        #expect(parsed.staffPlans.map(\.effectiveFromStave) == [0, 2])
+        #expect(PlanRegions.segment(parsed).map(\.staves) == [0..<2])
+    }
+
+    // MARK: - The page
+
+    @Test("%%score [1 2 3] then %%score [1 2] renders three staves, then two")
+    func staffCountChangesMidTune() {
+        #expect(stavesPerSystem(
+            threeVoices(header: "%%score [1 2 3]", body: "%%score [1 2]")) == [3, 2])
+    }
+
+    @Test("The system at a region boundary is broken there, not stretched across it")
+    func theBoundaryIsASystemBreak() {
+        // Two staves of one bar each would otherwise pack onto one system: the first line's
+        // bar is nowhere near a page wide.  The plan change forces the break.
+        let abc = threeVoices(header: "%%score [1 2 3]", body: "%%score [1 2]")
+        let systems = render(abc).pages.flatMap(\.systems)
+        #expect(systems.count == 5)
+        // Every staff of the first group came from the first line-set, and none of the
+        // second group's did.
+        #expect(systems.prefix(3).allSatisfy { $0.abcLine == systems[0].abcLine })
+        #expect(systems.suffix(2).allSatisfy { $0.abcLine != systems[0].abcLine })
+    }
+
+    @Test("Anchor lines stay monotonic across a region boundary")
+    func anchorsStayMonotonic() {
+        let lines = anchorLines(threeVoices(header: "%%score [1 2 3]", body: "%%score [1 2]"))
+        #expect(lines == lines.sorted())
+        #expect(lines.first != lines.last)
+    }
+
+    @Test("A voice a later plan names again resumes on its own staff")
+    func aDroppedVoiceComesBack() {
+        let abc = ([
+            "X:1", "L:1/4", "%%score [1 2]",
+            "V:1", "V:2", "K:C",
+            "V:1", "CDEF|", "V:2", "GABc|",
+            "%%score [1]",
+            "V:1", "CDEF|", "V:2", "GABc|",
+            "%%score [1 2]",
+            "V:1", "cdef|", "V:2", "GABc|"
+        ] as [String]).joined(separator: "\n")
+
+        #expect(stavesPerSystem(abc) == [2, 1, 2])
+        // The middle region does not print voice 2, and §11.1 says so out loud.
+        let dropped = render(abc).diagnostics.filter { $0.code == .voiceNotInStaffPlan }
+        #expect(dropped.count == 1)
+        #expect(dropped.first?.message.contains("'2'") == true)
+    }
+
+    @Test("Only the tune's very last system is the last one, however many regions there are")
+    func onlyTheFinalRegionEndsTheTune() {
+        // `justifyLastSystem` is off by default, so only a system marked last is left short;
+        // a region boundary in the middle must not leave the system before it unstretched.
+        let abc = threeVoices(header: "%%score [1 2 3]", body: "%%score [1 2]")
+        let systems = render(abc).pages.flatMap(\.systems)
+        let firstRegionWidth = systems[0].width
+        let lastRegionWidth  = systems[3].width
+        #expect(firstRegionWidth > lastRegionWidth)
+        #expect(systems.prefix(3).allSatisfy { $0.width == firstRegionWidth })
+    }
+
+    @Test("A time signature is drawn on the tune's first system only, not on each region's")
+    func theMeterDoesNotRepeatAtARegionBoundary() {
+        // The header eats width, so the first system's music starts further right than the
+        // second region's, which opens with clef and key alone.
+        let abc = ([
+            "X:1", "L:1/4", "M:4/4", "%%score [1 2]",
+            "V:1", "V:2", "K:C",
+            "V:1", "CDEF|", "V:2", "GABc|",
+            "%%score [1]",
+            "V:1", "CDEF|", "V:2", "GABc|"
+        ] as [String]).joined(separator: "\n")
+        let systems = render(abc).pages.flatMap(\.systems)
+        #expect(systems.count == 3)
+        // Bar lines are the only thing that moves: same page, same music, narrower header.
+        let firstBarOfSystem = systems.map { $0.barlineXs.first ?? 0 }
+        #expect(firstBarOfSystem[2] < firstBarOfSystem[0])
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/StaffPlanSelectionTests.swift
+++ b/Tests/CeolKitSVGRendererTests/StaffPlanSelectionTests.swift
@@ -131,8 +131,8 @@ struct StaffPlanSelectionTests {
         #expect(notes.first?.message.contains("floats between staves") == true)
     }
 
-    @Test("A body plan is reported as not yet applied, and the tune renders")
-    func bodyPlanIsReported() {
+    @Test("A body plan takes effect from its own stave, without complaint")
+    func bodyPlanTakesEffect() {
         let result = render("""
         X:1
         L:1/4
@@ -149,11 +149,12 @@ struct StaffPlanSelectionTests {
         V:2
         CDEF|
         """)
-        let notes = result.diagnostics.filter { $0.code == .staffPlanNotFullyApplied }
-        #expect(notes.count == 1)
-        #expect(notes.first?.message.contains("cannot change the staff count") == true)
-        // Both voices still print: the plan in effect at the start of the tune is none.
-        #expect(result.pages.flatMap(\.systems).count == 4)
+        // Two staves before the plan, one after — see `StaffPlanRegionTests` for the
+        // segmentation this rests on.
+        #expect(result.pages.flatMap(\.systems).count == 3)
+        #expect(result.diagnostics.filter { $0.code == .staffPlanNotFullyApplied }.isEmpty)
+        // Voice 2 still has music the second plan does not print, and §11.1 says so.
+        #expect(codes(result.diagnostics, .voiceNotInStaffPlan).count == 1)
     }
 
     // MARK: - Plans the tune cannot honour


### PR DESCRIPTION
Closes #69.

A `%%score` in the tune body resets which voices print, so the number of staves differs between systems. The driver sized its per-voice column store once for the whole tune (`columnsPerVoice` at `CeolKitSVGRenderer.swift:91`), and `SystemGroup.staves[0]` was documented as speaking for every staff of every group, so there was nowhere to put a staff count that changes.

## What it does

`PlanRegions.segment(_:)` cuts a tune into **plan regions** — maximal runs of staves governed by one `StaffPlanChange` — and the whole align → size → break block runs once per region, concatenating the groups. Each region gets its own `VoiceSelector` pass, so the printed set, the order, and the `StaffGrouping` all change at the boundary. The boundary is a system break by construction.

Regions are deduped **by stave index**, not by plan: a file-preamble plan and a tune-header plan both govern from stave 0, and only the later one wins (per the implementation note on #69). A plan that starts past the end of the music governs nothing and is dropped.

Two things `LineBreaker` stamps per call had to move up to the tune, since it is now called once per region rather than once per tune:

- `isLastSystem` — it marks the last system of whatever it is handed; only the final region's last system ends the tune.
- the time signature — it belongs on the tune's first system, and no more repeats at a staff-plan change than it does at a line break. The wide first-system header width follows it.

The `staffPlanNotFullyApplied` diagnostic saying a body plan could not change the staff count is gone, along with the doc comments claiming one grouping per tune.

## Acceptance

| | |
|---|---|
| Header `%%score` behaves exactly as before | ✅ one region, holding the tune's own `Voice` values — nothing rebuilt |
| `[1 2 3]` then `[1 2]` renders three staves, then two | ✅ `staffCountChangesMidTune` |
| The system at the boundary is broken there, not stretched across | ✅ `theBoundaryIsASystemBreak` |
| `abcLine` anchors stay monotonic across the boundary (#41) | ✅ `anchorsStayMonotonic` |
| Voices that reappear under a later plan resume on their own staff | ✅ `aDroppedVoiceComesBack` |
| Single-voice and single-plan output byte-identical | ✅ existing golden snapshots unchanged |

12 new tests in `StaffPlanRegionTests`; `StaffPlanSelectionTests.bodyPlanIsReported` was rewritten to assert the new behaviour. Full suite: 827 tests passing.

## One limitation, documented on `PlanRegion`

Regions are cut by stave index — the same numbering `VoiceAligner` already aligns on, where stave *k* of one voice is stave *k* of every other. A source that gives a voice **no line at all** in some line-set breaks that: the voice's later staves all shift up one, and a region cut then lands in the wrong place for it.

This predates the change — the aligner mis-pads the same tune today, with no plan involved — but it bites harder here. With `%%score [1]` / omit `V:2` / `%%score [1 2]`, voice 2's third line is drawn against the second region and so is not printed. It is not silent: `voiceNotInStaffPlan` fires and names the voice.

The real fix is parser-side — recording a stave boundary in every voice at each line-set, which the semantic pass cannot currently detect, since `splitStave` only ever fires for the voice active at the end of a source line. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ayYZ4S3yNxpfC98ACuVGP