### PR TITLE
Fix #70 — draw the staff bracket, and reserve the indent it needs

### DIFF
--- a/Sources/CeolKitSVGGeometry/SVGGeometry.swift
+++ b/Sources/CeolKitSVGGeometry/SVGGeometry.swift
@@ -105,6 +105,10 @@ public enum SVGGeometry {
     /// left edge outruns the staff too, and is excluded by the same stroke-width test that
     /// excludes stems: the emitter draws it at the staff lines' own thickness.
     ///
+    /// The third filter is horizontal: a barline stands over the staff, and the brace or
+    /// bracket joining a group stands left of it, in the indent reserved for it.  A bracket
+    /// spine is drawn *thicker* than a barline, so nothing but its x tells the two apart.
+    ///
     /// This reads drawing output rather than the model, so it stays approximate: it
     /// rests on those three constants keeping their present order.
     static func barlines(in lines: [SVGLine], crossing staff: Staff) -> [Double] {
@@ -114,6 +118,7 @@ public enum SVGGeometry {
         let xs = lines
             .filter(\.isVertical)
             .filter { abs($0.y1 - staff.topY) < tolerance && $0.y2 > bottomY - tolerance }
+            .filter { $0.x1 >= staff.left - tolerance }
             .filter { line in
                 // Keep the stroke when either width is unknown: better to over-report
                 // than to silently drop barlines from output we don't fully recognise.

--- a/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
+++ b/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
@@ -140,16 +140,26 @@ public struct SVGRenderer: CeolKitRenderer {
                                           keySignature: voiceKeys[index],
                                           meter: regionMeter)
                 }
+                // Space for the region's braces and brackets, reserved before anything is
+                // packed into the line.  It is added to the header widths rather than taken
+                // off `usableWidth` because that is the one number both the breaker and the
+                // justifier already subtract, and `VerticalLayoutEngine` spends exactly the
+                // same amount moving the staves right (see `BracketColumns`).
+                let indent = BracketColumns(grouping: selection.grouping,
+                                            staffCount: printedVoices.count,
+                                            metadata: metadata,
+                                            staffSize: tuneConfig.staffSize).indent
+
                 // Header widths differ between the first system (has time sig) and later
                 // ones, and are the max across the group: the staves of a system have to
                 // start at the same x even when one voice's clef or key signature is wider.
-                let openingHeaderW = printedVoices.indices.reduce(0.0) { widest, index in
+                let openingHeaderW = indent + printedVoices.indices.reduce(0.0) { widest, index in
                     max(widest, systemHeaderWidth(clef: printedVoices[index].properties.clef,
                                                   keySignature: voiceKeys[index],
                                                   meter: regionMeter, metadata: metadata,
                                                   staffSize: tuneConfig.staffSize))
                 }
-                let laterHeaderW = printedVoices.indices.reduce(0.0) { widest, index in
+                let laterHeaderW = indent + printedVoices.indices.reduce(0.0) { widest, index in
                     max(widest, systemHeaderWidth(clef: printedVoices[index].properties.clef,
                                                   keySignature: voiceKeys[index],
                                                   meter: nil, metadata: metadata,

--- a/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
@@ -241,25 +241,65 @@ struct SVGEmitter: Sendable {
         }
     }
 
-    /// The vertical rule at the left edge that joins the staves of a multi-voice system.
+    /// The furniture at the left edge of a multi-voice system: the rule that joins its
+    /// staves, and a bracket over each span the tune's `%%score`/`%%staves` plan states.
     ///
-    /// Without it the staves of a system are just neighbouring staves; with it they read as
-    /// one system, which is what tells a player that the parts are to be followed together.
-    /// Drawn once per group, by its top staff.
+    /// Without the rule the staves of a system are just neighbouring staves; with it they
+    /// read as one system, which is what tells a player that the parts are to be followed
+    /// together.  It is drawn once per group, by its top staff, and at the staff lines' own
+    /// weight rather than a barline's: it is a continuation of the staff furniture, so that
+    /// is what it should look like — and it is what lets `CeolKitSVGGeometry` tell it apart
+    /// from the barlines it sits alongside, which are thicker.
     ///
-    /// Deliberately just the joining rule, and no brace or bracket: which staves a brace or
-    /// bracket spans is a property of `%%score`/`%%staves`, which CeolKit does not parse yet.
-    ///
-    /// Drawn at the staff lines' own weight rather than a barline's.  It is a continuation
-    /// of the staff furniture, so that is what it should look like — and it is what lets
-    /// `CeolKitSVGGeometry` tell it apart from the barlines it now sits alongside, which
-    /// are thicker.
+    /// The spans are drawn each by the staff it starts at, which is where
+    /// `VerticalLayoutEngine` anchored it, so a span opening below the group's top staff is
+    /// drawn by that staff and not by the leader.
     private func emitStaffGroupConnector(_ system: ResolvedSystem, builder: inout SVGBuilder) {
-        guard let group = system.staffGroup, group.isGroupLeader else { return }
-        let topY = system.origin.y + system.staffOrigin
-        let thickness = metadata.engravingDefaults.staffLineThickness * config.staffSize
-        builder.line(x1: system.origin.x, y1: topY, x2: system.origin.x, y2: group.bottomY,
+        guard let group = system.staffGroup else { return }
+        if group.isGroupLeader {
+            let topY = system.origin.y + system.staffOrigin
+            let thickness = metadata.engravingDefaults.staffLineThickness * config.staffSize
+            builder.line(x1: system.origin.x, y1: topY, x2: system.origin.x, y2: group.bottomY,
+                         stroke: "black", strokeWidth: thickness)
+        }
+        for span in group.spans { emitStaffSpanBracket(span, builder: &builder) }
+    }
+
+    /// One brace or bracket, standing in the indent reserved for its depth.
+    ///
+    /// Every span is drawn as a bracket for now, the brace glyph being stretchy and so a
+    /// piece of `SVGBuilder` work of its own (issue #72).  A bracket over a braced span says
+    /// less than the brace will, but it says the true thing — these staves are one group —
+    /// which drawing nothing does not.
+    ///
+    /// A nested span is drawn at `subBracketThickness` with short hooks in place of the
+    /// bracket's flared tips: SMuFL publishes no sub-bracket glyph, a sub-bracket being a
+    /// thin spine serifed at each end.
+    private func emitStaffSpanBracket(_ span: StaffGroup.Span, builder: inout SVGBuilder) {
+        let s = config.staffSize
+        let defaults = metadata.engravingDefaults
+        let isNested = span.depth > 0
+        let thickness = (isNested ? defaults.subBracketThickness : defaults.bracketThickness) * s
+        // `span.x` is the spine's left edge; a stroke is drawn centred on its x.
+        let spineX = span.x + thickness / 2
+        builder.line(x1: spineX, y1: span.topY, x2: spineX, y2: span.bottomY,
                      stroke: "black", strokeWidth: thickness)
+
+        guard isNested else {
+            let fontSize = 4.0 * s
+            builder.text(String(SMuFLGlyph.bracketTop.character), x: span.x, y: span.topY,
+                         fontFamily: "Bravura", fontSize: fontSize)
+            builder.text(String(SMuFLGlyph.bracketBottom.character), x: span.x, y: span.bottomY,
+                         fontFamily: "Bravura", fontSize: fontSize)
+            return
+        }
+        // Inset by half the spine's weight so the hooks stay inside the span rather than
+        // overhanging the staff lines they terminate on.
+        let hookEndX = span.x + BracketColumns.subBracketHookLength(staffSize: s)
+        for y in [span.topY + thickness / 2, span.bottomY - thickness / 2] {
+            builder.line(x1: spineX, y1: y, x2: hookEndX, y2: y,
+                         stroke: "black", strokeWidth: thickness)
+        }
     }
 
     // MARK: - Clef

--- a/Sources/CeolKitSVGRenderer/Font/BravuraMetadata.swift
+++ b/Sources/CeolKitSVGRenderer/Font/BravuraMetadata.swift
@@ -13,6 +13,10 @@ public struct BravuraMetadata: Sendable {
         public let thickBarlineThickness: Double
         public let barlineSeparation: Double
         public let repeatBarlineDotSeparation: Double
+        /// Thickness of the vertical spine of a brace or bracket joining a group of staves.
+        public let bracketThickness: Double
+        /// Thickness of that spine where the span is nested inside another one.
+        public let subBracketThickness: Double
         /// Thickness of a slur at its two ends; SMuFL models a slur as tapered, so this is
         /// the thinner of the pair.
         public let slurEndpointThickness: Double
@@ -75,9 +79,8 @@ private struct RawBBox: Decodable {
 /// falls back to `0`, as it did when these were dictionary lookups.
 ///
 /// The keys Bravura supplies that are deliberately *not* read describe notation this
-/// renderer does not yet draw: `bracketThickness`, `subBracketThickness`,
-/// `dashedBarlineDashLength`, `dashedBarlineGapLength`, `dashedBarlineThickness`,
-/// `hairpinThickness`, `octaveLineThickness`, `pedalLineThickness`,
+/// renderer does not yet draw: `dashedBarlineDashLength`, `dashedBarlineGapLength`,
+/// `dashedBarlineThickness`, `hairpinThickness`, `octaveLineThickness`, `pedalLineThickness`,
 /// `repeatEndingLineThickness`, `textEnclosureThickness`, `tupletBracketThickness`,
 /// `lyricLineThickness`, `arrowShaftThickness`, `hBarThickness`, `textFontFamily`.
 /// Each becomes worth decoding when the corresponding mark starts being emitted, not
@@ -93,6 +96,8 @@ private struct RawEngravingDefaults: Decodable {
     let thickBarlineThickness: Double?
     let barlineSeparation: Double?
     let repeatBarlineDotSeparation: Double?
+    let bracketThickness: Double?
+    let subBracketThickness: Double?
     let slurEndpointThickness: Double?
     let slurMidpointThickness: Double?
     let tieEndpointThickness: Double?
@@ -124,6 +129,10 @@ private extension BravuraMetadata {
             // it draws nothing at all, or stacks the repeat dots against the bar line. A face
             // omitting these gets Bravura's values, the reference face SMuFL publishes.
             repeatBarlineDotSeparation: ed.repeatBarlineDotSeparation ?? 0.16,
+            // Same reasoning: a bracket of thickness zero is an invisible bracket, and the
+            // staves it was meant to join read as unrelated.
+            bracketThickness:    ed.bracketThickness    ?? 0.5,
+            subBracketThickness: ed.subBracketThickness ?? 0.16,
             slurEndpointThickness: ed.slurEndpointThickness ?? 0.1,
             slurMidpointThickness: ed.slurMidpointThickness ?? 0.22,
             tieEndpointThickness:  ed.tieEndpointThickness  ?? 0.1,

--- a/Sources/CeolKitSVGRenderer/Font/SMuFLGlyph.swift
+++ b/Sources/CeolKitSVGRenderer/Font/SMuFLGlyph.swift
@@ -68,6 +68,10 @@ public enum SMuFLGlyph: String, Sendable, CaseIterable {
     case fermataAbove
     case fermataBelow
 
+    // Staff brackets
+    case bracketTop
+    case bracketBottom
+
     public var unicodeScalar: Unicode.Scalar {
         // swiftlint:disable:next force_unwrapping — all values are valid PUA codepoints
         Unicode.Scalar(codepoint)!
@@ -118,6 +122,8 @@ public enum SMuFLGlyph: String, Sendable, CaseIterable {
         case .repeatDot:                   return 0xE044
         case .fermataAbove:                return 0xE4C0
         case .fermataBelow:                return 0xE4C1
+        case .bracketTop:                  return 0xE003
+        case .bracketBottom:               return 0xE004
         }
     }
 }

--- a/Sources/CeolKitSVGRenderer/Layout/BracketColumns.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/BracketColumns.swift
@@ -1,0 +1,78 @@
+/// The columns of space to the left of a system's staves that its braces and brackets
+/// occupy, and where each one's spine stands.
+///
+/// The indent and the furniture that fills it are one calculation deliberately.  The width
+/// reserved here is subtracted from the music twice over — the line breaker packs into what
+/// is left, and the justifier stretches into it — while the layout engine spends it by
+/// moving the staves right and the emitter draws into what that vacates.  Four callers
+/// agreeing by construction is the only way the bracket lands inside the page margin and
+/// the last note still lands on it.
+///
+/// One column per nesting depth, outermost leftmost, so `[{A B} C]` reads as a bracket
+/// standing left of a brace rather than the two overlapping.
+struct BracketColumns: Sendable {
+
+    /// Sizes in staff spaces.  The tip widths come from the face's own bounding boxes;
+    /// these are the clearances around them, which no metadata states.
+    private enum Clearance {
+        /// Space between a column's furniture and whatever stands to its right — the next
+        /// column in, or the staff itself.
+        static let column = 0.4
+        /// How far a nested span's end hooks reach towards the staff.  A sub-bracket has no
+        /// glyph of its own in SMuFL: it is a thin spine with short serifs at each end.
+        static let subBracketHook = 0.5
+    }
+
+    /// The spans that are actually drawn, and so the ones that get to reserve space.
+    let spans: [StaffGrouping.Span]
+    /// Width of the column at each depth, outermost (depth 0) first.  Empty when nothing
+    /// is drawn, which is the no-plan case and every single-staff system.
+    let widths: [Double]
+
+    /// Total space reserved to the left of the staves.  Zero unless something is drawn.
+    var indent: Double { widths.reduce(0, +) }
+
+    /// - Parameters:
+    ///   - grouping: the system's plan-derived spans, or `nil` where it has no plan.
+    ///   - staffCount: staves in the system, used to drop a span that reaches past them.
+    init(grouping: StaffGrouping?, staffCount: Int,
+         metadata: BravuraMetadata, staffSize: Double) {
+        spans = Self.drawable(grouping?.spans ?? [], staffCount: staffCount)
+        guard let deepest = spans.map(\.depth).max() else {
+            widths = []
+            return
+        }
+        let tipWidth = metadata.glyphBBoxes["bracketTop"].map { $0.width } ?? 1.876
+        widths = (0...deepest).map { depth in
+            ((depth == 0 ? tipWidth : Clearance.subBracketHook) + Clearance.column) * staffSize
+        }
+    }
+
+    /// Absolute x of the left edge of the spine drawn for a span at `depth`, given the x the
+    /// staves start at.
+    func spineX(depth: Int, staffLeftX: Double) -> Double {
+        staffLeftX - widths[min(depth, widths.count - 1)...].reduce(0, +)
+    }
+
+    /// How far a nested span's end hooks reach towards the staff, at `staffSize`.  The
+    /// emitter draws them; this is where their length is stated, so the column reserved for
+    /// them and the hooks drawn into it stay the same size.
+    static func subBracketHookLength(staffSize: Double) -> Double {
+        Clearance.subBracketHook * staffSize
+    }
+
+    /// The spans worth drawing furniture for, of the ones the plan states.
+    ///
+    /// A span reaching past the last staff is dropped rather than clamped: a grouping is
+    /// built over the very staves of the region it is stamped on, so one that does not fit
+    /// did not come from this system's selection, and a bracket drawn to a staff that is
+    /// not there would be worse than none.
+    ///
+    /// A span over a single staff is dropped for a different reason: the furniture that
+    /// joins staves is drawn by the system's group, and a one-staff system has none.
+    /// Reserving space for a bracket nothing would draw is what leaves a gap on the page.
+    private static func drawable(_ spans: [StaffGrouping.Span],
+                                 staffCount: Int) -> [StaffGrouping.Span] {
+        spans.filter { $0.staves.count > 1 && $0.staves.upperBound < staffCount }
+    }
+}

--- a/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
@@ -349,16 +349,21 @@ public struct StaffGroup: Sendable {
         public let staves: ClosedRange<Int>
         /// 0 = outermost; drives sub-bracket thickness.
         public let depth: Int
+        /// Absolute x of the left edge of the span's vertical spine.  Left of the staves,
+        /// in the indent ``BracketColumns`` reserved for it — the deeper the span, the
+        /// closer to them.
+        public let x: Double
         /// Absolute y of the top staff line of the span's first staff.
         public let topY: Double
         /// Absolute y of the bottom staff line of the span's last staff.
         public let bottomY: Double
 
         public init(bracket: StaffPlanBracket, staves: ClosedRange<Int>, depth: Int,
-                    topY: Double, bottomY: Double) {
+                    x: Double, topY: Double, bottomY: Double) {
             self.bracket = bracket
             self.staves = staves
             self.depth = depth
+            self.x = x
             self.topY = topY
             self.bottomY = bottomY
         }

--- a/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
@@ -218,23 +218,25 @@ public struct VerticalLayoutEngine: Sendable {
         let last = metrics.staves[metrics.staves.count - 1]
         let groupBottomY = topY + last.staffTopOffset + staffHeight
 
+        // The staves start right of the margin by whatever the group's braces and brackets
+        // need, and nowhere else: with no plan, or a plan that groups nothing, the indent is
+        // zero and the page is the one the renderer drew before brackets existed.  The line
+        // breaker was handed the same reservation, so the music still ends on the right
+        // margin (see `BracketColumns`).
+        let columns = BracketColumns(grouping: group.grouping, staffCount: metrics.staves.count,
+                                     metadata: metadata, staffSize: staffSize)
+        let staffLeftX = config.margins.left + columns.indent
+
         // The plan's spans, placed: a span reaches from the top staff line of its first
-        // staff to the bottom staff line of its last.  Keyed by first staff, which is the
-        // one that draws it.
-        //
-        // A span reaching past the group's last staff is dropped rather than clamped: a
-        // grouping is built over the very staves of the region it is stamped on, so one that
-        // does not fit did not come from this group's selection, and drawing a bracket to a
-        // staff that is not there would be worse than drawing none.
+        // staff to the bottom staff line of its last, standing in the column its depth was
+        // given.  Keyed by first staff, which is the one that draws it.
         let spansByFirstStaff = Dictionary(
-            grouping: (group.grouping?.spans ?? []).filter {
-                $0.staves.upperBound < metrics.staves.count
-            },
-            by: \.staves.lowerBound
+            grouping: columns.spans, by: \.staves.lowerBound
         ).mapValues { spans in
             spans.map { span in
                 StaffGroup.Span(
                     bracket: span.bracket, staves: span.staves, depth: span.depth,
+                    x: columns.spineX(depth: span.depth, staffLeftX: staffLeftX),
                     topY: topY + metrics.staves[span.staves.lowerBound].staffTopOffset,
                     bottomY: topY + metrics.staves[span.staves.upperBound].staffTopOffset
                              + staffHeight)
@@ -245,7 +247,7 @@ public struct VerticalLayoutEngine: Sendable {
             let (extraAbove, extraBelow, staffTopOffset) = metrics.staves[i]
             // `origin.y` is the top of the staff's own band; `staffOrigin` walks down from
             // there to the top staff line, exactly as in the single-staff case.
-            let systemOrigin = Point(x: config.margins.left, y: topY + staffTopOffset - extraAbove)
+            let systemOrigin = Point(x: staffLeftX, y: topY + staffTopOffset - extraAbove)
             let measures = resolveMeasures(
                 staff.measures,
                 systemOrigin: systemOrigin,

--- a/Tests/CeolKitSVGRendererTests/BravuraMetadataTests.swift
+++ b/Tests/CeolKitSVGRendererTests/BravuraMetadataTests.swift
@@ -55,6 +55,25 @@ import Testing
         #expect(ed.repeatBarlineDotSeparation < ed.barlineSeparation)
     }
 
+    /// A bracket's spine is drawn at its own weight, and a nested one thinner still, so the
+    /// two read as an outer group and an inner one rather than as two brackets.
+    @Test func bracketThicknessesAreDecoded() {
+        let ed = metadata.engravingDefaults
+        #expect(ed.bracketThickness == 0.5)
+        #expect(ed.subBracketThickness == 0.16)
+        #expect(ed.subBracketThickness < ed.bracketThickness)
+    }
+
+    /// The bracket is drawn as a spine the renderer strokes plus the face's own end glyphs,
+    /// so a face without them would leave a bracket with no tips.
+    @Test func bracketTipGlyphsHaveBoundingBoxes() throws {
+        for name in ["bracketTop", "bracketBottom"] {
+            let bbox = try #require(metadata.glyphBBoxes[name])
+            #expect(bbox.width  > 0)
+            #expect(bbox.height > 0)
+        }
+    }
+
     /// `CeolKitSVGGeometry` tells a bar line from a note stem by comparing each stroke
     /// against the staff line's, so what it depends on is not the three weights but their
     /// order.  A metadata swap that reordered them would leave it misreading every drawing

--- a/Tests/CeolKitSVGRendererTests/StaffBracketTests.swift
+++ b/Tests/CeolKitSVGRendererTests/StaffBracketTests.swift
@@ -1,0 +1,191 @@
+import Testing
+import CeolKitModel
+import CeolKitParser
+import CeolKitSVGGeometry
+@testable import CeolKitSVGRenderer
+
+/// Issue #70: a `%%score` / `%%staves` span is drawn as a bracket at the left edge, and the
+/// space it stands in is reserved before the music is broken into lines (ABC v2.2 §11.1).
+///
+/// End to end — source in, SVG out — because the two halves only mean anything together:
+/// the reservation is right when the bracket lands inside the page margin and the music
+/// still reaches the right one.
+@Suite("Staff Brackets")
+struct StaffBracketTests {
+
+    private let config = SVGRenderConfig()
+    private let metadata = try! BravuraMetadata.load()
+
+    /// One vertical stroke of the emitted drawing.
+    private struct Stroke {
+        let x: Double, y1: Double, y2: Double, width: Double?
+    }
+
+    private func render(_ abc: String, config: SVGRenderConfig? = nil)
+    -> (svg: String, staves: [SystemGeometry]) {
+        let score = CeolKitParser().parse(abc, options: .default).score
+        var diagnostics: [Diagnostic] = []
+        let svgs = try! SVGRenderer(config: config ?? self.config).render(score,
+                                                                         diagnostics: &diagnostics)
+        return (svgs.joined(), try! SVGGeometry.pages(from: svgs).flatMap(\.systems))
+    }
+
+    /// The drawing's vertical strokes.  Read straight out of the SVG: `CeolKitSVGGeometry`
+    /// reports staves and bar lines, and a bracket is deliberately neither.
+    private func verticalStrokes(in svg: String) -> [Stroke] {
+        svg.matches(of: /<line x1="([-0-9.]+)" y1="([-0-9.]+)" x2="([-0-9.]+)" y2="([-0-9.]+)"(?: stroke="[^"]*")?(?: stroke-width="([-0-9.]+)")?/)
+            .compactMap { match in
+                guard let x1 = Double(match.1), let y1 = Double(match.2),
+                      let x2 = Double(match.3), let y2 = Double(match.4),
+                      abs(x1 - x2) < 1e-9 else { return nil }
+                return Stroke(x: x1, y1: min(y1, y2), y2: max(y1, y2),
+                              width: match.5.flatMap { Double($0) })
+            }
+    }
+
+    /// The strokes standing left of the staves — the brackets, and nothing else.
+    private func bracketSpines(_ svg: String, staves: [SystemGeometry]) -> [Stroke] {
+        guard let left = staves.first?.left else { return [] }
+        return verticalStrokes(in: svg).filter { $0.x < left - 1e-9 }.sorted { $0.x < $1.x }
+    }
+
+    /// Three voices, one line of two bars each, with `directive` above the `K:`.
+    private func threeVoices(_ directive: String = "") -> String {
+        ([
+            "X:1", "T:Three Voices", "M:4/4", "L:1/8", directive, "K:D", "V:1", "V:2", "V:3",
+            "[V:1] abcd efga | bage dcBA |",
+            "[V:2] ABcd efga | bage dcBA |",
+            "[V:3] ABcd efga | bage dcBA |",
+        ] as [String]).filter { !$0.isEmpty }.joined(separator: "\n")
+    }
+
+    // MARK: - Reservation
+
+    @Test("A bracketed system starts right of the margin, and an unbracketed one does not")
+    func bracketIsIndentedFromTheMargin() {
+        let plain = render(threeVoices()).staves
+        let bracketed = render(threeVoices("%%score [1 2 3]")).staves
+
+        #expect(plain.allSatisfy { $0.left == config.margins.left })
+        #expect(bracketed.allSatisfy { $0.left > config.margins.left })
+        // Every staff of the system starts at the same x: the indent belongs to the system,
+        // not to the staff that happens to carry the span.
+        #expect(Set(bracketed.map(\.left)).count == 1)
+    }
+
+    @Test("The music still ends on the right margin: the indent came out of the line, not off the page")
+    func indentIsTakenOutOfTheLine() {
+        // `justifyLastSystem` so the one system in each tune is stretched to the full line.
+        var config = config
+        config.justifyLastSystem = true
+        let plain = render(threeVoices(), config: config).staves
+        let bracketed = render(threeVoices("%%score [1 2 3]"), config: config).staves
+
+        let rightMargin = config.pageSize.width - config.margins.right
+        #expect(plain.allSatisfy { abs($0.right - rightMargin) < 0.5 })
+        #expect(bracketed.allSatisfy { abs($0.right - rightMargin) < 0.5 })
+    }
+
+    @Test("A plan that only orders the voices reserves nothing")
+    func planWithoutSpansReservesNothing() {
+        let staves = render(threeVoices("%%score 2 1 3")).staves
+        #expect(staves.allSatisfy { $0.left == config.margins.left })
+    }
+
+    @Test("The indent scales with the music")
+    func indentScalesWithTheTune() {
+        let full = render(threeVoices("%%score [1 2 3]")).staves
+        let half = render(threeVoices("%%score [1 2 3]\n%%ceolkit:scale 0.5")).staves
+        let fullIndent = full[0].left - config.margins.left
+        let halfIndent = half[0].left - config.margins.left
+        #expect(abs(halfIndent - fullIndent / 2) < 1e-6)
+    }
+
+    // MARK: - Drawing
+
+    @Test("The bracket spans the staves it covers, at the face's bracket thickness")
+    func bracketSpansTheGroup() throws {
+        let (svg, staves) = render(threeVoices("%%score [1 2 3]"))
+        let spines = bracketSpines(svg, staves: staves)
+        let spine = try #require(spines.first)
+        #expect(spines.count == 1)
+
+        let expected = metadata.engravingDefaults.bracketThickness * config.staffSize
+        #expect(abs((spine.width ?? 0) - expected) < 1e-3)
+        // Top staff line of the first staff to bottom staff line of the last.
+        #expect(abs(spine.y1 - staves[0].topY) < 1e-3)
+        #expect(abs(spine.y2 - (staves[2].topY + 4 * staves[2].staffLineGap)) < 1e-3)
+    }
+
+    @Test("Nothing crosses the left margin, bracket included")
+    func nothingCrossesTheLeftMargin() {
+        let (svg, staves) = render(threeVoices("%%score [1 2 3]"))
+        let spine = bracketSpines(svg, staves: staves)[0]
+        let tipWidth = (metadata.glyphBBoxes["bracketTop"]?.width ?? 0) * config.staffSize
+        let bracketLeft = spine.x - (spine.width ?? 0) / 2
+
+        #expect(bracketLeft >= config.margins.left - 1e-9)
+        // …and the tips, which flare right from the spine, stop short of the staff lines.
+        #expect(bracketLeft + tipWidth < staves[0].left)
+    }
+
+    @Test("The bracket is drawn with the SMuFL tip glyphs, at the ends of its spine")
+    func bracketHasSMuFLTips() throws {
+        // `.fontFace`, so the glyphs reach the page as `<text>` and can be read back.
+        let score = CeolKitParser().parse(threeVoices("%%score [1 2 3]"), options: .default).score
+        var diagnostics: [Diagnostic] = []
+        let svg = try textProbeRenderer().render(score, diagnostics: &diagnostics).joined()
+        let staves = try SVGGeometry.pages(from: [svg]).flatMap(\.systems)
+        let spine = bracketSpines(svg, staves: staves)[0]
+        let bracketLeft = spine.x - (spine.width ?? 0) / 2
+
+        for (glyph, y) in [(SMuFLGlyph.bracketTop, spine.y1), (.bracketBottom, spine.y2)] {
+            let tip = try #require(svg.matches(of: /<text x="([-0-9.]+)" y="([-0-9.]+)" font-family="Bravura"[^>]*>(.)<\/text>/)
+                .first { String($0.3) == String(glyph.character) })
+            #expect(abs((Double(tip.1) ?? 0) - bracketLeft) < 1e-3)
+            #expect(abs((Double(tip.2) ?? 0) - y) < 1e-3)
+        }
+    }
+
+    @Test("A nested span is drawn inside the outer one, at sub-bracket thickness")
+    func nestedSpanIsThinnerAndCloserToTheStaff() throws {
+        let (svg, staves) = render(threeVoices("%%score [{1 2} 3]"))
+        let spines = bracketSpines(svg, staves: staves)
+        #expect(spines.count == 2)
+        let (outer, inner) = (spines[0], spines[1])
+
+        let defaults = metadata.engravingDefaults
+        #expect(abs((outer.width ?? 0) - defaults.bracketThickness * config.staffSize) < 1e-3)
+        #expect(abs((inner.width ?? 0) - defaults.subBracketThickness * config.staffSize) < 1e-3)
+        // The outer span covers all three staves; the brace inside it stops at the second.
+        #expect(abs(outer.y2 - (staves[2].topY + 4 * staves[2].staffLineGap)) < 1e-3)
+        #expect(abs(inner.y2 - (staves[1].topY + 4 * staves[1].staffLineGap)) < 1e-3)
+    }
+
+    @Test("A span opening below the top staff is drawn from the staff it opens at")
+    func spanOpeningLowerDownIsStillDrawn() throws {
+        let (svg, staves) = render(threeVoices("%%score [1 {2 3}]"))
+        let spines = bracketSpines(svg, staves: staves)
+        #expect(spines.count == 2)
+        let inner = try #require(spines.last)
+        #expect(abs(inner.y1 - staves[1].topY) < 1e-3)
+        #expect(abs(inner.y2 - (staves[2].topY + 4 * staves[2].staffLineGap)) < 1e-3)
+    }
+
+    // MARK: - What the bracket must not disturb
+
+    @Test("A bracket is not read back as a bar line")
+    func bracketIsNotABarLine() {
+        let plain = render(threeVoices()).staves
+        let bracketed = render(threeVoices("%%score [1 2 3]")).staves
+        #expect(bracketed.map(\.barlineXs.count) == plain.map(\.barlineXs.count))
+        #expect(bracketed.allSatisfy { staff in staff.barlineXs.allSatisfy { $0 >= staff.left } })
+    }
+
+    @Test("A tune with no plan is drawn exactly as it was before brackets existed")
+    func noPlanDrawsNoFurniture() {
+        let (svg, staves) = render(threeVoices())
+        #expect(bracketSpines(svg, staves: staves).isEmpty)
+        #expect(!svg.contains(String(SMuFLGlyph.bracketTop.character)))
+    }
+}


### PR DESCRIPTION
Closes #70.

A `%%score` / `%%staves` span now reaches the page as a bracket at the left edge, standing in space reserved for it before the music is broken into lines. The two halves ship together because either alone is a regression: the reservation without the bracket is a visible gap, and the bracket without the reservation hangs into the page margin.

## What changed

- **`BracketColumns`** (new, `Sources/CeolKitSVGRenderer/Layout/BracketColumns.swift`) is the one place the reserved width is decided — one column per nesting depth, outermost leftmost, sized from the face's own `bracketTop` bounding box plus clearance. It also decides which spans are drawn (dropping a one-staff span, and one reaching past the system's last staff), so the space reserved and the furniture drawn agree by construction.
- **The driver** adds that width to the region's header widths, which is the number the line breaker packs against and the justifier stretches to, and **`VerticalLayoutEngine`** spends exactly the same amount moving the staves right. So the bracket lands inside the left margin and the last note still lands on the right one. Each span's spine x is resolved there and carried on `StaffGroup.Span`.
- **`SVGEmitter.emitStaffGroupConnector`** now draws the joining rule *and* each span's bracket — spine at `bracketThickness` with Bravura's `bracketTop`/`bracketBottom` tips. A span is drawn by the staff it opens at, not only by the group leader, so `[1 {2 3}]` draws its inner span from the middle staff.
- **Nested spans** are drawn at `subBracketThickness` with short end hooks: SMuFL publishes no sub-bracket glyph, a sub-bracket being a thin spine serifed at each end.
- **`SMuFLGlyph`** gained `bracketTop` (U+E003) and `bracketBottom` (U+E004); **`BravuraMetadata`** now decodes `bracketThickness` and `subBracketThickness`, with Bravura's own values as the fallback rather than `0`, which would draw an invisible bracket. Both are off the "deliberately not read" list.
- **`CeolKitSVGGeometry`** gains a horizontal filter on barline detection. A bracket spine runs the height of the group and is drawn *thicker* than a barline, so unlike the joining rule it is not separated by the stroke-width test — only its x tells the two apart.

## A decision worth flagging

Brace spans are drawn as brackets for now, the brace glyph being stretchy and so `SVGBuilder` work of its own (#72). Drawing nothing would leave the reserved indent as an empty gap for `%%score {A B}` — the exact failure the issue warns about — so a bracket over a braced span says less than the brace will, but says the true thing: these staves are one group. #72 swaps the glyph without touching the reservation.

## Verification

- `swift test` — 840 tests, all passing. The existing goldens are unchanged: a tune with no plan reserves nothing and draws nothing.
- New `StaffBracketTests` (11 tests, end to end) covers the indent, that the music still ends on the right margin, that the indent scales with `%%ceolkit:scale`, the spine's span and thickness, the SMuFL tips' positions, the nested case, a span opening below the top staff, and that a bracket is not read back as a bar line.
- Rasterised with `ckprobe` + `rsvg-convert` for `[1 2 3]`, `[{1 2} 3]`, and a mid-tune plan change — the bracketed region is indented and justified to the right margin, the unbracketed region flush at the margin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JASj9t8ca2nZSFNbct2NT3