### PR TITLE
Fix #72 — draw the brace, stretched to the staves it joins

### DIFF
--- a/Sources/CeolKitSVGRenderer/Emission/SVGBuilder.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGBuilder.swift
@@ -78,6 +78,61 @@ struct SVGBuilder: Sendable {
                           className: className)
     }
 
+    /// Draws `content` stretched independently in x and y — the shape a *stretchy* glyph
+    /// needs, and the one a `font-size` cannot express.
+    ///
+    /// SMuFL designs the brace to be drawn at whatever height the staves it joins happen to
+    /// span — three times its natural height over a piano system — while its arms thicken by
+    /// nothing like as much.  So the two axes have to move independently: `fontSize` fixes
+    /// the natural size on both, and `xScale`/`yScale` stretch from there, `1` leaving an
+    /// axis alone.
+    ///
+    /// `x` and `y` are where the run's origin lands on the page; the stretch is applied
+    /// about that point, so a glyph sitting on its baseline stays on it however far it is
+    /// stretched.
+    mutating func stretchedText(
+        _ content: String,
+        x: Double, y: Double,
+        fontFamily: String,
+        fontSize: Double,
+        xScale: Double,
+        yScale: Double,
+        fill: String = "black",
+        className: String? = nil
+    ) {
+        if textRendering.emitsOutlines,
+           let resolved = fonts?.resolve(family: fontFamily, italic: false) {
+            appendOutlineRun(content, x: x, y: y,
+                             face: resolved.key, font: resolved.font,
+                             fontSize: fontSize, fill: fill,
+                             textAnchor: "start", className: className,
+                             xScale: xScale, yScale: yScale)
+            guard textRendering == .both else { return }
+            appendStretchedTextElement(content, x: x, y: y, fontFamily: fontFamily,
+                                       fontSize: fontSize, xScale: xScale, yScale: yScale,
+                                       fill: "none", className: className)
+            return
+        }
+        appendStretchedTextElement(content, x: x, y: y, fontFamily: fontFamily,
+                                   fontSize: fontSize, xScale: xScale, yScale: yScale,
+                                   fill: fill, className: className)
+    }
+
+    /// Wraps everything `body` draws in a `<g>` carrying `transform`.
+    ///
+    /// The one thing a group is needed for here is the stretch above: a `<text>` element
+    /// carries a single `font-size`, so the only way to scale a run of text by different
+    /// factors on the two axes is to put the factors on an element around it.  A group that
+    /// wraps nothing is dropped rather than emitted empty.
+    mutating func group(transform: String, _ body: (inout SVGBuilder) -> Void) {
+        let start = elements.count
+        body(&self)
+        guard elements.count > start else { return }
+        let inner = elements[start...].map { "  " + $0 }
+        elements.replaceSubrange(start..., with:
+            ["<g transform=\"\(esc(transform))\">"] + inner + ["</g>"])
+    }
+
     mutating func path(
         d: String,
         fill: String? = nil,
@@ -166,6 +221,31 @@ struct SVGBuilder: Sendable {
         elements.append("<text \(attrs)>\(esc(content))</text>")
     }
 
+    /// The `<text>` route for `stretchedText`: the run drawn at the origin of a group that
+    /// carries the placement and the stretch.  Identity factors would produce the element
+    /// `appendTextElement` writes on its own, wrapped in a group that does nothing, so they
+    /// take that path instead and the ordinary output is untouched.
+    private mutating func appendStretchedTextElement(
+        _ content: String, x: Double, y: Double,
+        fontFamily: String, fontSize: Double,
+        xScale: Double, yScale: Double,
+        fill: String, className: String?
+    ) {
+        guard xScale != 1 || yScale != 1 else {
+            appendTextElement(content, x: x, y: y, fontFamily: fontFamily, fontSize: fontSize,
+                              fill: fill, textAnchor: "start", fontStyle: nil,
+                              className: className)
+            return
+        }
+        let transform = "translate(\(fmt(x)) \(fmt(y))) " +
+                        "scale(\(fmtScale(xScale)) \(fmtScale(yScale)))"
+        group(transform: transform) {
+            $0.appendTextElement(content, x: 0, y: 0, fontFamily: fontFamily,
+                                 fontSize: fontSize, fill: fill, textAnchor: "start",
+                                 fontStyle: nil, className: className)
+        }
+    }
+
     /// Lays out `content` one glyph per Unicode scalar and emits a `<use>` per glyph.
     ///
     /// There is no shaping, kerning, or ligature substitution here. That is not a shortcut
@@ -175,9 +255,14 @@ struct SVGBuilder: Sendable {
     private mutating func appendOutlineRun(
         _ content: String, x: Double, y: Double,
         face: OutlineFontSet.FaceKey, font: OpenTypeFont,
-        fontSize: Double, fill: String, textAnchor: String, className: String?
+        fontSize: Double, fill: String, textAnchor: String, className: String?,
+        xScale: Double = 1, yScale: Double = 1
     ) {
         let scale = fontSize / font.unitsPerEm
+        // A `<use>` already carries a transform of its own, so an anisotropic stretch costs
+        // nothing here beyond the two factors: no wrapping group, and the same `<defs>`
+        // entry the glyph has at its natural size.
+        let (scaleX, scaleY) = (scale * xScale, scale * yScale)
         // An unencoded scalar falls back to glyph 0, whose .notdef box is what a rasteriser
         // would have drawn: a visible gap beats a run that silently shortens.
         let glyphs = content.unicodeScalars.map { font.glyphID(for: $0) ?? 0 }
@@ -186,9 +271,9 @@ struct SVGBuilder: Sendable {
         var penX = x
         switch textAnchor {
         case "middle":
-            penX -= glyphs.reduce(0) { $0 + font.advance(forGlyph: $1) } * scale / 2
+            penX -= glyphs.reduce(0) { $0 + font.advance(forGlyph: $1) } * scaleX / 2
         case "end":
-            penX -= glyphs.reduce(0) { $0 + font.advance(forGlyph: $1) } * scale
+            penX -= glyphs.reduce(0) { $0 + font.advance(forGlyph: $1) } * scaleX
         default:
             break
         }
@@ -197,12 +282,12 @@ struct SVGBuilder: Sendable {
             if let id = registerGlyph(face: face, glyph: glyph, font: font) {
                 var attrs = "href=\"#\(id)\" xlink:href=\"#\(id)\""
                 attrs += " transform=\"translate(\(fmt(penX)) \(fmt(y)))"
-                attrs += " scale(\(fmtScale(scale)) \(fmtScale(-scale)))\""
+                attrs += " scale(\(fmtScale(scaleX)) \(fmtScale(-scaleY)))\""
                 if fill != "black" { attrs += " fill=\"\(esc(fill))\"" }
                 if let cls = className { attrs += " class=\"\(esc(cls))\"" }
                 elements.append("<use \(attrs)/>")
             }
-            penX += font.advance(forGlyph: glyph) * scale
+            penX += font.advance(forGlyph: glyph) * scaleX
         }
     }
 

--- a/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
@@ -242,7 +242,8 @@ struct SVGEmitter: Sendable {
     }
 
     /// The furniture at the left edge of a multi-voice system: the rule that joins its
-    /// staves, and a bracket over each span the tune's `%%score`/`%%staves` plan states.
+    /// staves, and the brace or bracket over each span the tune's `%%score`/`%%staves`
+    /// plan states.
     ///
     /// Without the rule the staves of a system are just neighbouring staves; with it they
     /// read as one system, which is what tells a player that the parts are to be followed
@@ -262,19 +263,49 @@ struct SVGEmitter: Sendable {
             builder.line(x1: system.origin.x, y1: topY, x2: system.origin.x, y2: group.bottomY,
                          stroke: "black", strokeWidth: thickness)
         }
-        for span in group.spans { emitStaffSpanBracket(span, builder: &builder) }
+        for span in group.spans { emitStaffSpan(span, builder: &builder) }
     }
 
     /// One brace or bracket, standing in the indent reserved for its depth.
+    private func emitStaffSpan(_ span: StaffGroup.Span, builder: inout SVGBuilder) {
+        switch span.bracket {
+        case .brace:   emitStaffSpanBrace(span, builder: &builder)
+        case .bracket: emitStaffSpanBracket(span, builder: &builder)
+        }
+    }
+
+    /// The brace over a `{ … }` span, stretched from the first staff's top line to the
+    /// last's bottom one.
     ///
-    /// Every span is drawn as a bracket for now, the brace glyph being stretchy and so a
-    /// piece of `SVGBuilder` work of its own (issue #72).  A bracket over a braced span says
-    /// less than the brace will, but it says the true thing — these staves are one group —
-    /// which drawing nothing does not.
+    /// SMuFL's brace is a *stretchy* glyph: the face draws it 3.988 staff spaces tall, a
+    /// third of what two staves of a piano system span, so it is never drawn at its natural
+    /// size.  The two axes move independently — see ``BracketColumns/braceScale(height:metadata:staffSize:)``
+    /// for how far the arms are allowed to thicken as the span grows.
     ///
-    /// A nested span is drawn at `subBracketThickness` with short hooks in place of the
-    /// bracket's flared tips: SMuFL publishes no sub-bracket glyph, a sub-bracket being a
-    /// thin spine serifed at each end.
+    /// A nested brace is drawn exactly like an outer one.  Unlike the bracket it has no
+    /// thinner form to fall back to, and it needs none: it stands in its own column, so the
+    /// nesting is legible from where it sits.
+    private func emitStaffSpanBrace(_ span: StaffGroup.Span, builder: inout SVGBuilder) {
+        let s = config.staffSize
+        guard let scale = BracketColumns.braceScale(height: span.bottomY - span.topY,
+                                                    metadata: metadata, staffSize: s)
+        else { return }
+        // The glyph stands on its baseline — Bravura's `bBoxSW.y` is 0 — but read the offset
+        // rather than assume it, and stretch it along with everything else, so the brace's
+        // foot lands on the bottom staff line and not near it.
+        let footOffset = (metadata.glyphBBoxes["brace"]?.swY ?? 0) * s * scale.y
+        builder.stretchedText(String(SMuFLGlyph.brace.character),
+                              x: span.x, y: span.bottomY + footOffset,
+                              fontFamily: "Bravura", fontSize: 4.0 * s,
+                              xScale: scale.x, yScale: scale.y)
+    }
+
+    /// The bracket over a `[ … ]` span: a spine at `bracketThickness` with the face's
+    /// flared tips at its ends.
+    ///
+    /// A nested span is drawn at `subBracketThickness` with short hooks in place of those
+    /// tips: SMuFL publishes no sub-bracket glyph, a sub-bracket being a thin spine serifed
+    /// at each end.
     private func emitStaffSpanBracket(_ span: StaffGroup.Span, builder: inout SVGBuilder) {
         let s = config.staffSize
         let defaults = metadata.engravingDefaults

--- a/Sources/CeolKitSVGRenderer/Font/SMuFLGlyph.swift
+++ b/Sources/CeolKitSVGRenderer/Font/SMuFLGlyph.swift
@@ -68,9 +68,11 @@ public enum SMuFLGlyph: String, Sendable, CaseIterable {
     case fermataAbove
     case fermataBelow
 
-    // Staff brackets
+    // Staff brackets and braces
     case bracketTop
     case bracketBottom
+    /// Stretchy: drawn at whatever height the staves it joins span, not at its natural one.
+    case brace
 
     public var unicodeScalar: Unicode.Scalar {
         // swiftlint:disable:next force_unwrapping — all values are valid PUA codepoints
@@ -124,6 +126,7 @@ public enum SMuFLGlyph: String, Sendable, CaseIterable {
         case .fermataBelow:                return 0xE4C1
         case .bracketTop:                  return 0xE003
         case .bracketBottom:               return 0xE004
+        case .brace:                       return 0xE000
         }
     }
 }

--- a/Sources/CeolKitSVGRenderer/Layout/BracketColumns.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/BracketColumns.swift
@@ -21,6 +21,17 @@ struct BracketColumns: Sendable {
         /// How far a nested span's end hooks reach towards the staff.  A sub-bracket has no
         /// glyph of its own in SMuFL: it is a thin spine with short serifs at each end.
         static let subBracketHook = 0.5
+        /// The widest a brace is ever drawn.
+        ///
+        /// Bravura draws its brace 0.32 spaces wide at a natural height of 3.988 — the
+        /// proportions of a brace over *one* staff.  Stretched to a piano system's 11
+        /// spaces on the vertical axis alone it comes out four times too thin to read as a
+        /// brace at all, so the arms grow with it; past a staff space of width they stop,
+        /// or a brace over five staves is a slab.  abcm2ps settles on a constant width too,
+        /// and by the same reasoning from the other end: its brace is drawn at system
+        /// height and only ever compressed, leaving it a shade heavier than this at about
+        /// 1.5 spaces.
+        static let braceMaxWidth = 1.0
     }
 
     /// The spans that are actually drawn, and so the ones that get to reserve space.
@@ -42,9 +53,41 @@ struct BracketColumns: Sendable {
             widths = []
             return
         }
-        let tipWidth = metadata.glyphBBoxes["bracketTop"].map { $0.width } ?? 1.876
+        // One column per depth, wide enough for the widest thing standing in it: one depth
+        // can hold both kinds at once — `[{A B} [C D]]` puts a brace and a sub-bracket in
+        // the same column — and they are nothing like the same width.
+        var ink: [Int: Double] = [:]
+        for span in spans {
+            ink[span.depth] = max(ink[span.depth] ?? 0, Self.inkWidth(of: span, metadata: metadata))
+        }
         widths = (0...deepest).map { depth in
-            ((depth == 0 ? tipWidth : Clearance.subBracketHook) + Clearance.column) * staffSize
+            // A depth with nothing left in it reserves nothing: `drawable` can empty an
+            // outer depth while an inner span survives, and a column no furniture stands
+            // in would just be a gap.
+            guard let width = ink[depth] else { return 0 }
+            return (width + Clearance.column) * staffSize
+        }
+    }
+
+    /// How far right of its column's left edge a span's furniture reaches, in staff spaces.
+    ///
+    /// Read off the face's own bounding box where a glyph is drawn — measured from the
+    /// glyph origin, which is what the emitter places at the column's left edge, so the
+    /// reservation covers the ink and not just its width.
+    private static func inkWidth(of span: StaffGrouping.Span,
+                                 metadata: BravuraMetadata) -> Double {
+        switch span.bracket {
+        // The brace grows with its span, so what is reserved is the widest it can get.  A
+        // shorter one leaves a little air rather than a differently indented system: the
+        // indent is a property of the plan, and a plan does not change between systems of
+        // one region while the staves it covers may.
+        case .brace:
+            guard let box = metadata.glyphBBoxes["brace"] else { return 0.328 }
+            return box.neX * Self.braceWidthScale(box: box)
+        case .bracket:
+            guard span.depth == 0 else { return Clearance.subBracketHook }
+            guard let box = metadata.glyphBBoxes["bracketTop"] else { return 1.876 }
+            return box.neX
         }
     }
 
@@ -59,6 +102,29 @@ struct BracketColumns: Sendable {
     /// them and the hooks drawn into it stay the same size.
     static func subBracketHookLength(staffSize: Double) -> Double {
         Clearance.subBracketHook * staffSize
+    }
+
+    /// The factors a brace is scaled by to reach `height` points: uniform until its arms
+    /// are ``Clearance/braceMaxWidth`` wide, vertical-only after that.
+    ///
+    /// `nil` where there is nothing to draw — a span of no height, or a face whose brace
+    /// has none.  Stated here, next to the space reserved for it, so that the column and
+    /// the glyph standing in it cannot disagree about how wide a brace gets.
+    static func braceScale(height: Double, metadata: BravuraMetadata,
+                           staffSize: Double) -> (x: Double, y: Double)? {
+        let box = metadata.glyphBBoxes["brace"]
+        let naturalHeight = (box?.height ?? 3.988) * staffSize
+        guard naturalHeight > 0, height > 0 else { return nil }
+        let yScale = height / naturalHeight
+        let cap = box.map(braceWidthScale) ?? Clearance.braceMaxWidth / 0.32
+        return (min(yScale, cap), yScale)
+    }
+
+    /// The largest horizontal factor a brace is drawn at, for a face whose brace has the
+    /// given box: the one that makes its arms exactly ``Clearance/braceMaxWidth`` wide.
+    private static func braceWidthScale(box: BravuraMetadata.BoundingBox) -> Double {
+        guard box.width > 0 else { return 1 }
+        return Clearance.braceMaxWidth / box.width
     }
 
     /// The spans worth drawing furniture for, of the ones the plan states.

--- a/Tests/CeolKitSVGRendererTests/StaffBraceTests.swift
+++ b/Tests/CeolKitSVGRendererTests/StaffBraceTests.swift
@@ -1,0 +1,310 @@
+import Testing
+import CeolKitModel
+import CeolKitParser
+import CeolKitSVGGeometry
+@testable import CeolKitSVGRenderer
+
+/// Issue #72: a `{ … }` span is drawn as a brace, which is a *stretchy* glyph — the face
+/// draws it 3.988 staff spaces tall and it has to reach whatever the staves it joins span.
+///
+/// The tests read the drawing back in both rendering modes, because the brace is the first
+/// thing the renderer draws that the two modes express differently: `.outlines` puts the
+/// stretch on the `<use>` transform, `.fontFace` on a group around the `<text>`.
+@Suite("Staff Braces")
+struct StaffBraceTests {
+
+    private let config = SVGRenderConfig()
+    private let metadata = try! BravuraMetadata.load()
+
+    /// The brace as it reaches the page in `.fontFace`: a group carrying the placement and
+    /// the two stretch factors, around a `<text>` drawn at the origin.
+    private struct DrawnBrace {
+        let x: Double, y: Double, xScale: Double, yScale: Double
+    }
+
+    private func render(_ abc: String, config: SVGRenderConfig? = nil)
+    -> (svg: String, staves: [SystemGeometry]) {
+        let score = CeolKitParser().parse(abc, options: .default).score
+        var diagnostics: [Diagnostic] = []
+        let svgs = try! SVGRenderer(config: config ?? self.config).render(score,
+                                                                         diagnostics: &diagnostics)
+        return (svgs.joined(), try! SVGGeometry.pages(from: svgs).flatMap(\.systems))
+    }
+
+    /// The same tune through the `.fontFace` renderer, where the brace can be read back
+    /// element by element rather than out of a glyph transform.
+    private func renderWithText(_ abc: String, config: SVGRenderConfig? = nil)
+    -> (svg: String, staves: [SystemGeometry]) {
+        var pinned = config ?? self.config
+        pinned.textRendering = .fontFace
+        let score = CeolKitParser().parse(abc, options: .default).score
+        var diagnostics: [Diagnostic] = []
+        let svgs = try! SVGRenderer(config: pinned).render(score, diagnostics: &diagnostics)
+        return (svgs.joined(), try! SVGGeometry.pages(from: svgs).flatMap(\.systems))
+    }
+
+    private func braces(in svg: String) -> [DrawnBrace] {
+        let brace = String(SMuFLGlyph.brace.character)
+        return svg.matches(of: /<g transform="translate\(([-0-9.]+) ([-0-9.]+)\) scale\(([-0-9.]+) ([-0-9.]+)\)">\s*<text [^>]*>(.)<\/text>/)
+            .compactMap { match in
+                guard String(match.5) == brace,
+                      let x = Double(match.1), let y = Double(match.2),
+                      let sx = Double(match.3), let sy = Double(match.4) else { return nil }
+                return DrawnBrace(x: x, y: y, xScale: sx, yScale: sy)
+            }
+    }
+
+    /// The `<use>` elements drawing the brace glyph in `.outlines`, as (x, y, sx, sy).
+    private func outlineBraces(in svg: String) throws -> [DrawnBrace] {
+        let font = try #require(OutlineFontSet.shared().resolve(family: "Bravura", italic: false))
+        let gid = try #require(font.font.glyphID(for: SMuFLGlyph.brace.unicodeScalar))
+        return svg.matches(of: /<use href="#(bravura-g[0-9]+)"[^>]*transform="translate\(([-0-9.]+) ([-0-9.]+)\) scale\(([-0-9.]+) ([-0-9.]+)\)"/)
+            .compactMap { match in
+                guard String(match.1) == "bravura-g\(gid)",
+                      let x = Double(match.2), let y = Double(match.3),
+                      let sx = Double(match.4), let sy = Double(match.5) else { return nil }
+                return DrawnBrace(x: x, y: y, xScale: sx, yScale: sy)
+            }
+    }
+
+    /// The drawing's vertical strokes left of the staves — the bracket spines, which a brace
+    /// is deliberately not one of.
+    private func spines(_ svg: String, staves: [SystemGeometry]) -> [Double] {
+        guard let left = staves.first?.left else { return [] }
+        return svg.matches(of: /<line x1="([-0-9.]+)" y1="([-0-9.]+)" x2="([-0-9.]+)" y2="([-0-9.]+)"/)
+            .compactMap { match in
+                guard let x1 = Double(match.1), let x2 = Double(match.3),
+                      abs(x1 - x2) < 1e-9, x1 < left - 1e-9 else { return nil }
+                return x1
+            }
+            .sorted()
+    }
+
+    /// `n` voices, one line of two bars each, with `directive` above the `K:`.
+    private func voices(_ count: Int, _ directive: String) -> String {
+        let heads = (1...count).map { "V:\($0)" }
+        let bodies = (1...count).map { "[V:\($0)] abcd efga | bage dcBA |" }
+        return (["X:1", "T:Braced", "M:4/4", "L:1/8", directive, "K:D"] + heads + bodies)
+            .joined(separator: "\n")
+    }
+
+    /// Bottom staff line of the last staff — where a brace's foot belongs.
+    private func bottomLine(of staff: SystemGeometry) -> Double {
+        staff.topY + 4 * staff.staffLineGap
+    }
+
+    // MARK: - Drawing
+
+    @Test("A braced span is drawn as a brace, reaching the outer staff lines of the group")
+    func braceSpansTheGroup() throws {
+        let (svg, staves) = renderWithText(voices(2, "%%score {1 2}"))
+        let brace = try #require(braces(in: svg).first)
+        #expect(braces(in: svg).count == 1)
+
+        let natural = try #require(metadata.glyphBBoxes["brace"])
+        // The glyph stands on its baseline, so its foot is the group's bottom staff line…
+        #expect(abs(brace.y - bottomLine(of: staves[1])) < 1e-3)
+        // …and its head, `naturalHeight` scaled, is the top staff line of the first staff.
+        let head = brace.y - natural.height * config.staffSize * brace.yScale
+        #expect(abs(head - staves[0].topY) < 1e-3)
+    }
+
+    @Test("A brace is a glyph, not a spine: nothing is stroked left of the staves")
+    func braceDrawsNoSpine() {
+        let (braced, bracedStaves) = render(voices(2, "%%score {1 2}"))
+        let (bracketed, bracketedStaves) = render(voices(2, "%%score [1 2]"))
+        #expect(spines(braced, staves: bracedStaves).isEmpty)
+        #expect(spines(bracketed, staves: bracketedStaves).count == 1)
+    }
+
+    @Test("The brace stands inside the indent reserved for it, clear of the staves")
+    func braceStandsInItsColumn() throws {
+        let (svg, staves) = renderWithText(voices(2, "%%score {1 2}"))
+        let brace = try #require(braces(in: svg).first)
+        let box = try #require(metadata.glyphBBoxes["brace"])
+
+        let ink = (left: brace.x + box.swX * config.staffSize * brace.xScale,
+                   right: brace.x + box.neX * config.staffSize * brace.xScale)
+        #expect(ink.left >= config.margins.left - 1e-9)
+        #expect(ink.right < staves[0].left)
+    }
+
+    @Test("The music still ends on the right margin: the brace's indent came out of the line")
+    func indentIsTakenOutOfTheLine() {
+        var config = config
+        config.justifyLastSystem = true
+        let staves = render(voices(2, "%%score {1 2}"), config: config).staves
+        let rightMargin = config.pageSize.width - config.margins.right
+        #expect(staves.allSatisfy { $0.left > config.margins.left })
+        #expect(staves.allSatisfy { abs($0.right - rightMargin) < 0.5 })
+    }
+
+    // MARK: - Stretch
+
+    @Test("A two-staff brace keeps the face's proportions; a taller one stops thickening")
+    func armsThickenWithTheSpanUpToAStaffSpace() throws {
+        let box = try #require(metadata.glyphBBoxes["brace"])
+
+        let two = try #require(braces(in: renderWithText(voices(2, "%%score {1 2}")).svg).first)
+        // Below the cap the brace is simply drawn larger, at the proportions Bravura drew.
+        #expect(abs(two.xScale - two.yScale) < 1e-3)
+
+        let four = try #require(braces(in: renderWithText(voices(4, "%%score {1 2 3 4}")).svg).first)
+        #expect(four.yScale > two.yScale)
+        // Past it the arms hold at a staff space wide however far the span stretches, which
+        // is what keeps a brace over four staves from reading as a slab.
+        #expect(four.xScale < four.yScale)
+        #expect(abs(box.width * four.xScale - 1.0) < 1e-3)
+    }
+
+    @Test("The brace scales with the music")
+    func braceScalesWithTheTune() throws {
+        let box = try #require(metadata.glyphBBoxes["brace"])
+        let full = renderWithText(voices(2, "%%score {1 2}"))
+        let half = renderWithText(voices(2, "%%score {1 2}\n%%ceolkit:scale 0.5"))
+        let fullBrace = try #require(braces(in: full.svg).first)
+        let halfBrace = try #require(braces(in: half.svg).first)
+
+        // The factors are ratios against a natural size stated in staff spaces, so they do
+        // not change with the staff size: a half-size tune stretches the brace by the same
+        // amount and draws it half as big.
+        #expect(abs(halfBrace.xScale - fullBrace.xScale) < 1e-6)
+        #expect(abs(halfBrace.yScale - fullBrace.yScale) < 1e-6)
+
+        // Which is what reaches the page — measured in the staff spaces of each tune.
+        func ink(_ brace: DrawnBrace, _ staves: [SystemGeometry]) -> (Double, Double) {
+            let staffSize = staves[0].staffLineGap
+            return (box.width * staffSize * brace.xScale,
+                    box.height * staffSize * brace.yScale)
+        }
+        let (fullWidth, fullHeight) = ink(fullBrace, full.staves)
+        let (halfWidth, halfHeight) = ink(halfBrace, half.staves)
+        #expect(abs(halfWidth - fullWidth / 2) < 1e-6)
+        #expect(abs(halfHeight - fullHeight / 2) < 1e-6)
+    }
+
+    @Test("Both rendering modes draw the same brace in the same place")
+    func outlineAndFontFaceAgree() throws {
+        let abc = voices(3, "%%score {1 2 3}")
+        let text = try #require(braces(in: renderWithText(abc).svg).first)
+        let outline = try #require(try outlineBraces(in: render(abc).svg).first)
+        let font = try #require(OutlineFontSet.shared().resolve(family: "Bravura", italic: false))
+        // The outline carries the em-to-point factor in the same transform, and flips out of
+        // font design space; the `<text>` route has it in `font-size` instead.
+        let em = 4.0 * config.staffSize / font.font.unitsPerEm
+
+        #expect(abs(outline.x - text.x) < 1e-3)
+        #expect(abs(outline.y - text.y) < 1e-3)
+        #expect(abs(outline.xScale - text.xScale * em) < 1e-5)
+        #expect(abs(outline.yScale + text.yScale * em) < 1e-5)
+    }
+
+    // MARK: - Alongside brackets
+
+    @Test("A brace nested in a bracket is still a brace, in its own column")
+    func nestedBraceIsStillABrace() throws {
+        let (svg, staves) = renderWithText(voices(3, "%%score [{1 2} 3]"))
+        let brace = try #require(braces(in: svg).first)
+        let spine = try #require(spines(svg, staves: staves).first)
+        #expect(spines(svg, staves: staves).count == 1)
+
+        // The bracket outside it, the brace inside — the nesting read off the page.
+        #expect(brace.x > spine)
+        // The brace covers the first two staves, and the bracket all three.
+        let natural = try #require(metadata.glyphBBoxes["brace"])
+        #expect(abs(brace.y - bottomLine(of: staves[1])) < 1e-3)
+        #expect(abs(brace.y - natural.height * config.staffSize * brace.yScale
+                    - staves[0].topY) < 1e-3)
+    }
+
+    @Test("A tune with no braced span draws no brace, and no group around anything")
+    func nothingIsWrappedWhenNothingIsStretched() {
+        let svg = render(voices(3, "%%score [1 2 3]")).svg
+        #expect(!svg.contains(String(SMuFLGlyph.brace.character)))
+        #expect(!svg.contains("<g transform="))
+        // Every other glyph is still drawn at one factor on both axes.
+        for match in svg.matches(of: /scale\(([-0-9.]+) ([-0-9.]+)\)/) {
+            let (sx, sy) = (Double(match.1) ?? 0, Double(match.2) ?? 0)
+            #expect(abs(abs(sx) - abs(sy)) < 1e-9)
+        }
+    }
+}
+
+/// The `SVGBuilder` surface the brace needed: a run scaled differently on the two axes, and
+/// the group that carries it where a `<text>` element cannot.
+@Suite("Anisotropic glyph scaling")
+struct StretchedTextTests {
+
+    private let fonts = try! OutlineFontSet.shared()
+    /// A glyph Bravura actually draws, so the outline route has an outline to emit.
+    private let glyph = String(SMuFLGlyph.brace.character)
+
+    @Test("An unstretched run is written exactly as `text` writes it, in both modes")
+    func identityStretchChangesNothing() {
+        for rendering in [TextRendering.fontFace, .outlines, .both] {
+            var plain = SVGBuilder(textRendering: rendering, fonts: fonts)
+            plain.text(glyph, x: 10, y: 20, fontFamily: "Bravura", fontSize: 24)
+            var stretched = SVGBuilder(textRendering: rendering, fonts: fonts)
+            stretched.stretchedText(glyph, x: 10, y: 20, fontFamily: "Bravura", fontSize: 24,
+                                    xScale: 1, yScale: 1)
+            #expect(plain.elements == stretched.elements)
+        }
+    }
+
+    @Test("The `<use>` transform carries the two factors, still flipped out of design space")
+    func outlineRunCarriesBothFactors() throws {
+        var builder = SVGBuilder(textRendering: .outlines, fonts: fonts)
+        builder.stretchedText(glyph, x: 0, y: 0, fontFamily: "Bravura", fontSize: 1000,
+                              xScale: 2, yScale: 3)
+        let element = try #require(builder.elements.first)
+        // `font-size` 1000 against Bravura's 1000-unit em makes the base factor exactly 1.
+        #expect(element.contains("scale(2 -3)"))
+    }
+
+    @Test("In `.both`, the stretch reaches the outline and the text copy alike")
+    func bothModesCarryTheStretch() {
+        var builder = SVGBuilder(textRendering: .both, fonts: fonts)
+        builder.stretchedText(glyph, x: 10, y: 20, fontFamily: "Bravura", fontSize: 1000,
+                              xScale: 2, yScale: 3)
+        // The painted outline…
+        #expect(builder.elements.contains { $0.hasPrefix("<use ") && $0.contains("scale(2 -3)") })
+        // …and the non-painting `<text>` copy that keeps the document selectable, stretched
+        // the same way so the two describe the same shape.
+        #expect(builder.elements.contains { $0 == "<g transform=\"translate(10 20) scale(2 3)\">" })
+        #expect(builder.elements.contains { $0.contains("<text ") && $0.contains("fill=\"none\"") })
+    }
+
+    @Test("A stretched `<text>` is drawn at the origin of a group carrying the transform")
+    func fontFaceRunIsWrappedInAGroup() {
+        var builder = SVGBuilder(textRendering: .fontFace, fonts: fonts)
+        builder.stretchedText(glyph, x: 10, y: 20, fontFamily: "Bravura", fontSize: 24,
+                              xScale: 2, yScale: 3)
+        #expect(builder.elements == [
+            "<g transform=\"translate(10 20) scale(2 3)\">",
+            "  <text x=\"0\" y=\"0\" font-family=\"Bravura\" font-size=\"24\" fill=\"black\">\(glyph)</text>",
+            "</g>",
+        ])
+    }
+
+    @Test("A group that wraps nothing is not emitted")
+    func emptyGroupIsDropped() {
+        var builder = SVGBuilder(textRendering: .fontFace, fonts: fonts)
+        builder.group(transform: "scale(2 3)") { _ in }
+        #expect(builder.elements.isEmpty)
+    }
+
+    @Test("A group nests, and its contents are indented inside it")
+    func groupsNest() {
+        var builder = SVGBuilder(textRendering: .fontFace, fonts: fonts)
+        builder.group(transform: "translate(1 2)") { outer in
+            outer.group(transform: "scale(2 3)") { $0.comment("inner") }
+        }
+        #expect(builder.elements == [
+            "<g transform=\"translate(1 2)\">",
+            "  <g transform=\"scale(2 3)\">",
+            "    <!-- inner -->",
+            "  </g>",
+            "</g>",
+        ])
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/StaffBracketTests.swift
+++ b/Tests/CeolKitSVGRendererTests/StaffBracketTests.swift
@@ -149,7 +149,7 @@ struct StaffBracketTests {
 
     @Test("A nested span is drawn inside the outer one, at sub-bracket thickness")
     func nestedSpanIsThinnerAndCloserToTheStaff() throws {
-        let (svg, staves) = render(threeVoices("%%score [{1 2} 3]"))
+        let (svg, staves) = render(threeVoices("%%score [[1 2] 3]"))
         let spines = bracketSpines(svg, staves: staves)
         #expect(spines.count == 2)
         let (outer, inner) = (spines[0], spines[1])
@@ -157,14 +157,14 @@ struct StaffBracketTests {
         let defaults = metadata.engravingDefaults
         #expect(abs((outer.width ?? 0) - defaults.bracketThickness * config.staffSize) < 1e-3)
         #expect(abs((inner.width ?? 0) - defaults.subBracketThickness * config.staffSize) < 1e-3)
-        // The outer span covers all three staves; the brace inside it stops at the second.
+        // The outer span covers all three staves; the one inside it stops at the second.
         #expect(abs(outer.y2 - (staves[2].topY + 4 * staves[2].staffLineGap)) < 1e-3)
         #expect(abs(inner.y2 - (staves[1].topY + 4 * staves[1].staffLineGap)) < 1e-3)
     }
 
     @Test("A span opening below the top staff is drawn from the staff it opens at")
     func spanOpeningLowerDownIsStillDrawn() throws {
-        let (svg, staves) = render(threeVoices("%%score [1 {2 3}]"))
+        let (svg, staves) = render(threeVoices("%%score [1 [2 3]]"))
         let spines = bracketSpines(svg, staves: staves)
         #expect(spines.count == 2)
         let inner = try #require(spines.last)


### PR DESCRIPTION
Closes #72.

A `{ … }` span now reaches the page as a brace rather than as the bracket that stood in for it, and `SVGBuilder` grows the anisotropic drawing surface that needed.

## The new builder surface

`stretchedText(…xScale:yScale:)` draws a run scaled independently on the two axes.

- `.outlines` — two factors on the `<use>` transform, which already carried one, so a stretched glyph still costs a single `<defs>` entry.
- `.fontFace` — a `<text>` carries one `font-size` and cannot be stretched at all, so the factors go on a group around it. `group(transform:)` is that primitive; it drops a group that ends up wrapping nothing, and nests.

An unstretched run takes neither path — it is written exactly as `text` writes it, which is what keeps every glyph the renderer already drew byte-identical.

## How far the arms thicken

The issue's sketch was a vertical-only stretch, on the reading that abcm2ps keeps the brace's horizontal weight. abcm2ps does, but from the other end: its brace path is drawn at *system* height and only ever compressed, while Bravura's is drawn 3.988 staff spaces tall — the proportions of a brace over one staff. Measured on the same two-staff tune, abcm2ps's brace is 0.115 wide over tall and a vertical-only Bravura brace 0.027, four times too thin to read as a brace.

So the brace is scaled uniformly until its arms are a staff space wide, and vertically alone after that: abcm2ps's weight at two and three staves, without a brace over five staves turning into a slab. The constant and the reasoning live in `BracketColumns.Clearance.braceMaxWidth`, next to the space reserved for it, so the column and the glyph standing in it cannot disagree.

The reserved column is the widest the brace can get, so systems of one plan region are indented alike whether the region's staves are far apart or close; a depth holding both kinds at once takes the wider of the two.

## Checks

- 855 tests pass. New `StaffBraceTests` (span geometry, the indent, the growth cap, `%%ceolkit:scale`, a brace nested in a bracket, and both rendering modes agreeing on position and scale) and `StretchedTextTests` (the builder surface itself).
- Output is byte-identical for the tunebook and for a nested-bracket tune, compared against a build of the parent commit.
- `--font-face` and outline output rasterise to identical brace ink bounds, and the 2-staff, 3-staff, nested, and half-scale renders were checked against `abcm2ps -g`.

Two existing #70 tests used `{…}` as a stand-in for a nested bracket; they now say `[[1 2] 3]` and `[1 [2 3]]`, those spans being braces on the page now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JASj9t8ca2nZSFNbct2NT3