### PR TITLE
Fix #73 — space staves by the group they belong to

### DIFF
--- a/Sources/CeolKitSVGRenderer/Config/SVGRenderConfig.swift
+++ b/Sources/CeolKitSVGRenderer/Config/SVGRenderConfig.swift
@@ -6,13 +6,25 @@ public struct SVGRenderConfig: Sendable {
     public var staffSize: Double
     /// Vertical gap added between systems within a single tune.
     public var systemGap: Double
-    /// Vertical gap added between the staves *within* one system — the staff group a
-    /// multi-voice tune draws for each source line.
+    /// Vertical gap added between two staves of one system that no brace or bracket joins
+    /// — the staff group a multi-voice tune draws for each source line.
     ///
     /// Deliberately smaller than ``systemGap``: the staves of a system are read together,
     /// so they have to sit closer to each other than the system does to its neighbours,
     /// or the group stops reading as a unit.  Only tunes with more than one voice use it.
     public var staffGap: Double
+    /// Vertical gap added between two staves whose innermost brace or bracket is the same
+    /// one — the staves of a single part.
+    ///
+    /// Smaller again than ``staffGap``, and for the same reason one step further in: staves
+    /// under one span are read as a unit, and the spacing has to say so on its own.
+    /// `[{A B} C]` should read as "A and B belong together, C is alongside" without the
+    /// reader having to trace the brace to find out — so A–B is spaced with this and B–C,
+    /// which meets only at the bracket outside them both, with ``staffGap``.  See
+    /// ``BracketColumns/sharesInnermostSpan(_:_:)``.  A system with no plan has no spans at
+    /// all, so every boundary in it uses ``staffGap`` and the page is the one the renderer
+    /// drew before spans existed.
+    public var spanStaffGap: Double
     /// Vertical gap added after the last system of a tune, before the next tune's title block.
     public var tuneGap: Double
     public var justifyLastSystem: Bool
@@ -44,6 +56,7 @@ public struct SVGRenderConfig: Sendable {
         staffSize: Double = 6.0,
         systemGap: Double? = nil,
         staffGap: Double? = nil,
+        spanStaffGap: Double? = nil,
         tuneGap: Double? = nil,
         justifyLastSystem: Bool = false,
         straightFlags: Bool = false,
@@ -58,6 +71,7 @@ public struct SVGRenderConfig: Sendable {
         self.staffSize = staffSize
         self.systemGap = systemGap ?? staffSize * 4
         self.staffGap = staffGap ?? staffSize * 3
+        self.spanStaffGap = spanStaffGap ?? staffSize * 2
         self.tuneGap = tuneGap ?? staffSize * 16
         self.justifyLastSystem = justifyLastSystem
         self.straightFlags = straightFlags
@@ -77,6 +91,7 @@ public struct SVGRenderConfig: Sendable {
         copy.staffSize = staffSize * factor
         copy.systemGap = systemGap * factor
         copy.staffGap = staffGap * factor
+        copy.spanStaffGap = spanStaffGap * factor
         copy.tuneGap = tuneGap * factor
         return copy
     }

--- a/Sources/CeolKitSVGRenderer/Layout/BracketColumns.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/BracketColumns.swift
@@ -91,6 +91,30 @@ struct BracketColumns: Sendable {
         }
     }
 
+    /// Whether two staves sit inside the *same innermost* span — whether the boundary
+    /// between them is inside one part rather than between two.
+    ///
+    /// Not "is some span drawn over both": in `[{A B} C]` the bracket covers all three, so
+    /// that question answers yes everywhere and the tightening says nothing.  What
+    /// distinguishes A–B from B–C is that A and B bottom out in the same group while B and
+    /// C meet only further out, and it is the innermost span that a reader takes as the
+    /// part.  `[{1 2} {3 4}]` separates the two braced pairs by the same reasoning, and
+    /// `[1 2] 3` still tightens the bracketed pair, whose innermost span is the bracket.
+    ///
+    /// Asked here, of the spans that survived ``drawable(_:staffCount:)``, so the tightening
+    /// and the furniture always agree about what is joined to what.  A span the renderer
+    /// declined to draw tightens nothing: the reader would have no mark on the page to read
+    /// the closer spacing against.
+    func sharesInnermostSpan(_ upper: Int, _ lower: Int) -> Bool {
+        guard let inner = innermostSpan(over: upper) else { return false }
+        return inner == innermostSpan(over: lower)
+    }
+
+    /// The deepest drawn span covering `staff`, or `nil` where none does.
+    private func innermostSpan(over staff: Int) -> StaffGrouping.Span? {
+        spans.filter { $0.staves.contains(staff) }.max { $0.depth < $1.depth }
+    }
+
     /// Absolute x of the left edge of the spine drawn for a span at `depth`, given the x the
     /// staves start at.
     func spineX(depth: Int, staffLeftX: Double) -> Double {

--- a/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
@@ -137,7 +137,7 @@ public struct VerticalLayoutEngine: Sendable {
             y += block.titleBlockHeight
 
             for (gi, group) in groups.enumerated() {
-                let metrics = groupMetrics(of: group, staffSize: staffSize, staffGap: tuneConfig.staffGap)
+                let metrics = groupMetrics(of: group, config: tuneConfig)
 
                 // A group breaks to the next page whole: splitting it would separate staves
                 // that only mean anything read together.
@@ -154,7 +154,7 @@ public struct VerticalLayoutEngine: Sendable {
                 previousAbcLine = abcLine
                 pageSystems.append(contentsOf: resolveGroup(
                     group, metrics: metrics, topY: y, staffSize: staffSize,
-                    staffHeight: staffHeight, staffGap: tuneConfig.staffGap,
+                    staffHeight: staffHeight,
                     graceNoteSpacing: block.graceNoteSpacing, abcLine: abcLine))
 
                 let isLastInBlock = gi == groups.count - 1
@@ -186,11 +186,18 @@ public struct VerticalLayoutEngine: Sendable {
         /// Width of the widest clef + key + time signature run in the group.  Every staff
         /// starts its first measure there, so their bar lines can align.
         let startWidth: Double
+        /// The group's braces and brackets, and the indent they stand in.  Computed here
+        /// rather than where they are drawn because the spans decide the spacing as well as
+        /// the furniture: a staff a span reaches past is not drawn *and* not tightened.
+        let columns: BracketColumns
     }
 
-    private func groupMetrics(of group: JustifiedSystemGroup, staffSize: Double,
-                              staffGap: Double) -> GroupMetrics {
+    private func groupMetrics(of group: JustifiedSystemGroup,
+                              config: SVGRenderConfig) -> GroupMetrics {
+        let staffSize = config.staffSize
         let staffHeight = 4.0 * staffSize
+        let columns = BracketColumns(grouping: group.grouping, staffCount: group.staves.count,
+                                     metadata: metadata, staffSize: staffSize)
         var staves: [(extraAbove: Double, extraBelow: Double, staffTopOffset: Double)] = []
         staves.reserveCapacity(group.staves.count)
         var offset = 0.0
@@ -199,16 +206,19 @@ public struct VerticalLayoutEngine: Sendable {
             let (extraAbove, extraBelow) = verticalExtent(of: staff, staffSize: staffSize)
             staves.append((extraAbove, extraBelow, offset + extraAbove))
             offset += extraAbove + staffHeight + extraBelow
-            if i < group.staves.count - 1 { offset += staffGap }
+            if i < group.staves.count - 1 {
+                offset += columns.sharesInnermostSpan(i, i + 1) ? config.spanStaffGap : config.staffGap
+            }
             startWidth = max(startWidth, systemStartWidth(for: staff, staffSize: staffSize))
         }
-        return GroupMetrics(staves: staves, totalHeight: offset, startWidth: startWidth)
+        return GroupMetrics(staves: staves, totalHeight: offset, startWidth: startWidth,
+                            columns: columns)
     }
 
     /// Places every staff of one system, top to bottom, starting at `topY`.
     private func resolveGroup(_ group: JustifiedSystemGroup, metrics: GroupMetrics,
                               topY: Double, staffSize: Double, staffHeight: Double,
-                              staffGap: Double, graceNoteSpacing: Double,
+                              graceNoteSpacing: Double,
                               abcLine: Int) -> [ResolvedSystem] {
         // A group of one is an ordinary system: no membership, no group furniture, and the
         // same output the renderer produced before staff groups existed.
@@ -223,8 +233,7 @@ public struct VerticalLayoutEngine: Sendable {
         // zero and the page is the one the renderer drew before brackets existed.  The line
         // breaker was handed the same reservation, so the music still ends on the right
         // margin (see `BracketColumns`).
-        let columns = BracketColumns(grouping: group.grouping, staffCount: metrics.staves.count,
-                                     metadata: metadata, staffSize: staffSize)
+        let columns = metrics.columns
         let staffLeftX = config.margins.left + columns.indent
 
         // The plan's spans, placed: a span reaches from the top staff line of its first
@@ -296,8 +305,7 @@ public struct VerticalLayoutEngine: Sendable {
         let tuneConfig = config.scaled(by: block.scale)
         var h = block.titleBlockHeight
         for (i, group) in block.systemGroups.enumerated() {
-            h += groupMetrics(of: group, staffSize: tuneConfig.staffSize,
-                              staffGap: tuneConfig.staffGap).totalHeight
+            h += groupMetrics(of: group, config: tuneConfig).totalHeight
             if i < block.systemGroups.count - 1 { h += tuneConfig.systemGap }
         }
         return h

--- a/Tests/CeolKitSVGRendererTests/StaffSpacingTests.swift
+++ b/Tests/CeolKitSVGRendererTests/StaffSpacingTests.swift
@@ -1,0 +1,222 @@
+import Testing
+import CeolKitModel
+import CeolKitParser
+import CeolKitSVGGeometry
+@testable import CeolKitSVGRenderer
+
+/// Issue #73: staves joined by a brace or bracket sit closer together than staves that are
+/// merely adjacent in the same system, so `[{A B} C]` reads as "A and B belong together, C
+/// is alongside" from the spacing alone rather than only from the furniture.
+///
+/// The gaps are measured off the drawing rather than off the layout engine, because the
+/// spacing is only worth anything as ink on the page: what is asserted is the distance from
+/// one staff's bottom line to the next staff's top line, which is what a reader sees.
+@Suite("Staff Spacing")
+struct StaffSpacingTests {
+
+    private let config = SVGRenderConfig()
+    private let metadata = try! BravuraMetadata.load()
+
+    // MARK: - Rendering
+
+    private func render(_ abc: String, config: SVGRenderConfig? = nil)
+    -> (svg: String, staves: [SystemGeometry]) {
+        let score = CeolKitParser().parse(abc, options: .default).score
+        var diagnostics: [Diagnostic] = []
+        let svgs = try! SVGRenderer(config: config ?? self.config).render(score,
+                                                                         diagnostics: &diagnostics)
+        return (svgs.joined(), try! SVGGeometry.pages(from: svgs).flatMap(\.systems))
+    }
+
+    /// `n` voices, one line each, with `directive` above the `K:`.
+    ///
+    /// Every note sits between the staff lines, so no staff reserves room for ledger lines
+    /// and the space between two staves is exactly the gap the engine put there.
+    private func voices(_ count: Int, _ directive: String? = nil) -> String {
+        let heads = (1...count).map { "V:\($0)" }
+        let bodies = (1...count).map { "[V:\($0)] EFGA Bcde | fedc BAGF |" }
+        let header = ["X:1", "T:Spacing", "M:4/4", "L:1/8"] + (directive.map { [$0] } ?? []) + ["K:C"]
+        return (header + heads + bodies).joined(separator: "\n")
+    }
+
+    /// The vertical space between staff `i` and staff `i + 1`: bottom line to top line.
+    private func gaps(_ staves: [SystemGeometry]) -> [Double] {
+        zip(staves, staves.dropFirst()).map { $1.topY - $0.bottomY }
+    }
+
+    // MARK: - Grouped spacing
+
+    @Test("Within a span the staves sit closer than adjacent staves, which sit closer than systems")
+    func withinSpanIsTighterThanBetweenSpansIsTighterThanSystems() {
+        #expect(config.spanStaffGap < config.staffGap)
+        #expect(config.staffGap < config.systemGap)
+    }
+
+    @Test("`[{A B} C]`: the braced pair is tightened, the staff alongside it is not")
+    func spannedBoundaryTightensAndTheOtherDoesNot() {
+        let staves = render(voices(3, "%%score [{1 2} 3]")).staves
+        let measured = gaps(staves)
+        #expect(measured.count == 2)
+        #expect(abs(measured[0] - config.spanStaffGap) < 1e-6)
+        #expect(abs(measured[1] - config.staffGap) < 1e-6)
+    }
+
+    @Test("A bracket tightens what it covers exactly as a brace does")
+    func bracketTightensToo() {
+        let staves = render(voices(3, "%%score [1 2] 3")).staves
+        let measured = gaps(staves)
+        #expect(abs(measured[0] - config.spanStaffGap) < 1e-6)
+        #expect(abs(measured[1] - config.staffGap) < 1e-6)
+    }
+
+    @Test("A plan grouping every staff tightens every boundary")
+    func oneSpanOverAllStavesTightensAllOfThem() {
+        let measured = gaps(render(voices(3, "%%score {1 2 3}")).staves)
+        #expect(measured.allSatisfy { abs($0 - config.spanStaffGap) < 1e-6 })
+    }
+
+    @Test("Two braced pairs under one bracket are tight inside and apart from each other")
+    func siblingSpansAreSeparatedFromEachOther() {
+        let measured = gaps(render(voices(4, "%%score [{1 2} {3 4}]")).staves)
+        #expect(measured.count == 3)
+        #expect(abs(measured[0] - config.spanStaffGap) < 1e-6)
+        // The boundary between the two pairs meets only at the bracket outside them both.
+        #expect(abs(measured[1] - config.staffGap) < 1e-6)
+        #expect(abs(measured[2] - config.spanStaffGap) < 1e-6)
+    }
+
+    // MARK: - The ungrouped page is unchanged
+
+    @Test("A multi-voice tune with no plan is spaced exactly as it was before spans existed")
+    func ungroupedMultiVoiceIsUnchanged() {
+        let measured = gaps(render(voices(3)).staves)
+        #expect(measured.count == 2)
+        #expect(measured.allSatisfy { abs($0 - config.staffGap) < 1e-6 })
+    }
+
+    @Test("A plan that only orders the voices groups nothing, and tightens nothing")
+    func aPlanWithNoSpansTightensNothing() {
+        let measured = gaps(render(voices(3, "%%score 1 2 3")).staves)
+        #expect(measured.allSatisfy { abs($0 - config.staffGap) < 1e-6 })
+    }
+
+    // MARK: - Scale
+
+    @Test("Halving the tune halves the gaps, and the furniture with them")
+    func scalingTakesTheGapsAndTheFurnitureTogether() throws {
+        let (svg, staves) = render(voices(2, "%%score {1 2}\n%%ceolkit:scale 0.5"),
+                                   config: {
+                                       var pinned = config
+                                       pinned.textRendering = .fontFace
+                                       return pinned
+                                   }())
+        // The music is half size…
+        #expect(abs(staves[0].staffLineGap - config.staffSize / 2) < 1e-6)
+        // …and so is the space between the braced staves.
+        #expect(abs(gaps(staves)[0] - config.spanStaffGap / 2) < 1e-6)
+
+        // The brace still reaches from the first staff's top line to the last's bottom one,
+        // which is the whole of what the tightened gap changed.
+        let brace = try #require(braces(in: svg).first)
+        let natural = try #require(metadata.glyphBBoxes["brace"])
+        #expect(abs(brace.y - staves[1].bottomY) < 1e-3)
+        #expect(abs(brace.y - natural.height * staves[0].staffLineGap * brace.yScale
+                    - staves[0].topY) < 1e-3)
+    }
+
+    // MARK: - Furniture over an uneven group
+
+    @Test("A brace over a staff with ledger lines below still lands on its bottom staff line")
+    func braceTerminatesOnTheStaffLinesNotShortOfThem() throws {
+        var pinned = config
+        pinned.textRendering = .fontFace
+        // The lower staff runs an octave and a half below the staff, so its band is much
+        // taller than the staff it draws.  The brace's foot belongs on the staff line all
+        // the same — the span is measured from the staves, not from the bands.
+        let abc = """
+            X:1
+            T:Deep
+            M:4/4
+            L:1/8
+            %%score {1 2}
+            K:C
+            V:1
+            V:2
+            [V:1] EFGA Bcde | fedc BAGF |
+            [V:2] C,D,E,F, G,A,B,C | C,D,E,F, G,A,B,C |
+            """
+        let score = CeolKitParser().parse(abc, options: .default).score
+        var diagnostics: [Diagnostic] = []
+        let svgs = try SVGRenderer(config: pinned).render(score, diagnostics: &diagnostics)
+        let staves = try SVGGeometry.pages(from: svgs).flatMap(\.systems)
+        let brace = try #require(braces(in: svgs.joined()).first)
+        let natural = try #require(metadata.glyphBBoxes["brace"])
+
+        #expect(abs(brace.y - staves[1].bottomY) < 1e-3)
+        #expect(abs(brace.y - natural.height * config.staffSize * brace.yScale
+                    - staves[0].topY) < 1e-3)
+        // …and the ledger lines really are down there, below the foot it stopped at, so the
+        // test is measuring the case it says it is.
+        #expect(lowestInk(in: svgs.joined()) > staves[1].bottomY + config.staffSize)
+        // The group's own spacing is untouched by an extent that grows below it.
+        #expect(abs(gaps(staves)[0] - config.spanStaffGap) < 1e-6)
+    }
+
+    // MARK: - Which boundaries count as joined
+
+    @Test("Only a span that is actually drawn tightens the staves it covers")
+    func anUndrawnSpanTightensNothing() {
+        let brace = StaffGrouping.Span(bracket: .brace, staves: 0...1, depth: 0)
+        let joined = BracketColumns(grouping: StaffGrouping(spans: [brace], barlineJoins: []),
+                                    staffCount: 3, metadata: metadata, staffSize: 6)
+        #expect(joined.sharesInnermostSpan(0, 1))
+        #expect(!joined.sharesInnermostSpan(1, 2))
+
+        // A span reaching past the staves the system actually has is dropped rather than
+        // clamped, so it groups nothing — and must tighten nothing either, or the page
+        // would show a closer pair with no mark saying why.
+        let overreaching = StaffGrouping.Span(bracket: .brace, staves: 0...3, depth: 0)
+        let dropped = BracketColumns(grouping: StaffGrouping(spans: [overreaching],
+                                                            barlineJoins: []),
+                                     staffCount: 3, metadata: metadata, staffSize: 6)
+        #expect(!dropped.sharesInnermostSpan(0, 1))
+
+        // A span over a single staff has no furniture and no boundary of its own.
+        let single = StaffGrouping.Span(bracket: .bracket, staves: 1...1, depth: 0)
+        let alone = BracketColumns(grouping: StaffGrouping(spans: [single], barlineJoins: []),
+                                   staffCount: 3, metadata: metadata, staffSize: 6)
+        #expect(!alone.sharesInnermostSpan(0, 1))
+        #expect(!alone.sharesInnermostSpan(1, 2))
+    }
+
+    // MARK: - Helpers
+
+    /// The brace as it reaches the page in `.fontFace`: a group carrying the placement and
+    /// the two stretch factors, around a `<text>` drawn at the origin.
+    private struct DrawnBrace {
+        let x: Double, y: Double, xScale: Double, yScale: Double
+    }
+
+    /// The lowest y any horizontal rule reaches in the drawing — with these tunes, the
+    /// bottom ledger line of the deepest note.
+    private func lowestInk(in svg: String) -> Double {
+        svg.matches(of: /<line x1="[-0-9.]+" y1="([-0-9.]+)" x2="[-0-9.]+" y2="([-0-9.]+)"/)
+            .compactMap { match in
+                guard let y1 = Double(match.1), let y2 = Double(match.2),
+                      abs(y1 - y2) < 1e-9 else { return nil }
+                return y1
+            }
+            .max() ?? 0
+    }
+
+    private func braces(in svg: String) -> [DrawnBrace] {
+        let brace = String(SMuFLGlyph.brace.character)
+        return svg.matches(of: /<g transform="translate\(([-0-9.]+) ([-0-9.]+)\) scale\(([-0-9.]+) ([-0-9.]+)\)">\s*<text [^>]*>(.)<\/text>/)
+            .compactMap { match in
+                guard String(match.5) == brace,
+                      let x = Double(match.1), let y = Double(match.2),
+                      let sx = Double(match.3), let sy = Double(match.4) else { return nil }
+                return DrawnBrace(x: x, y: y, xScale: sx, yScale: sy)
+            }
+    }
+}


### PR DESCRIPTION
Closes #73.

A single `staffGap` between every pair of staves in a system says nothing about which of them are a part and which are merely neighbours. This adds `spanStaffGap` — smaller again — and chooses between the two per boundary.

## The predicate

*Same innermost span*, not *some span covers both*. The looser question fails the issue's own example: in `[{A B} C]` the bracket covers all three, so everything tightens and the spacing conveys nothing. A and B bottom out in the same brace; B and C meet only at the bracket outside them both.

That generalises correctly:

| plan | boundaries |
|---|---|
| `[{A B} C]` | A–B tight, B–C loose |
| `[{1 2} {3 4}]` | each pair tight, the two pairs apart |
| `[1 2] 3` | 1–2 tight (innermost span is the bracket), 2–3 loose |
| no plan | every boundary `staffGap`, exactly as before |

`BracketColumns` answers it, over the spans that survived `drawable`, so a span the renderer declined to draw tightens nothing — the reader would have no mark on the page to read the closer spacing against. It moves up to `groupMetrics`, which now builds it once for both the spacing and the furniture instead of `resolveGroup` building a second copy.

## Furniture height

Already derived from the resolved span rather than a config constant (#70, #72) — `StaffGroup.Span` carries `topY`/`bottomY` off the staff offsets the engine computed. No code change was needed; the tests here pin it, including a group whose lower staff runs an octave and a half below its staff, where the brace foot still lands on the bottom staff line.

## Acceptance

- [x] Within-span gap (12) < between-span gap (18) < `systemGap` (24)
- [x] A brace over a staff with ledger lines below still terminates on the staff lines
- [x] `%%ceolkit:scale 0.5` halves the gaps and the furniture together (`scaled(by:)` scales the new gap alongside the old)
- [x] Ungrouped multi-voice spacing unchanged

865 tests pass. Rendered `[{1 2} 3] [4 5]` and read the page back: braced pair tightest, third staff alongside, second bracket group at the wider gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JASj9t8ca2nZSFNbct2NT3