### PR TITLE
Fix #57 — print the V: voice names in a gutter left of the system

### DIFF
--- a/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
+++ b/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
@@ -35,9 +35,18 @@ public struct SVGRenderer: CeolKitRenderer {
         // File-preamble directives are promoted to the first tune by the parser.
         let effectiveConfig = applyingScoreDirectives(score)
 
+        // The face voice labels are measured in, read once and only when a voice has a label
+        // to measure: parsing the bundled faces is the most expensive thing this renderer
+        // does, and a score that names no voice needs none of it.  `nil` where the resource
+        // could not be read — `VoiceLabelGutter` estimates from there, on both sides of the
+        // reservation, so the labels still land in the space kept for them.
+        let labelFont = score.tunes.contains(where: \.hasVoiceLabels)
+            ? OutlineFontSet.textFace() : nil
+
         let breaker   = LineBreaker(overflowTolerance: effectiveConfig.lineOverflowTolerance)
         let justifier = Justifier(maxStretch: effectiveConfig.maxSystemStretch)
-        let engine    = VerticalLayoutEngine(config: effectiveConfig, metadata: metadata)
+        let engine    = VerticalLayoutEngine(config: effectiveConfig, metadata: metadata,
+                                             labelFont: labelFont)
 
         let usableWidth = effectiveConfig.pageSize.width - effectiveConfig.margins.left - effectiveConfig.margins.right
 
@@ -134,11 +143,22 @@ public struct SVGRenderer: CeolKitRenderer {
                 let isOpeningRegion = groups.isEmpty
                 let regionMeter = isOpeningRegion ? tune.meter : nil
 
+                // §4.1: `name=` labels the voice on the first system it appears on and
+                // `sname=` on every later one.  A region after the opening one is not the
+                // first system of anything — the voice has already been named — so it takes
+                // the subname throughout, exactly as a line break within a region does.
+                let firstLabels = printedVoices.map {
+                    isOpeningRegion ? $0.properties.name : $0.properties.subname
+                }
+                let laterLabels = printedVoices.map(\.properties.subname)
+
                 let voiceLines = printedVoices.enumerated().map { index, voice in
                     LineBreaker.VoiceLine(measures: columnsPerVoice[index],
                                           clef: voice.properties.clef,
                                           keySignature: voiceKeys[index],
-                                          meter: regionMeter)
+                                          meter: regionMeter,
+                                          firstSystemLabel: firstLabels[index],
+                                          laterSystemLabel: laterLabels[index])
                 }
                 // Space for the region's braces and brackets, reserved before anything is
                 // packed into the line.  It is added to the header widths rather than taken
@@ -150,16 +170,26 @@ public struct SVGRenderer: CeolKitRenderer {
                                             metadata: metadata,
                                             staffSize: tuneConfig.staffSize).indent
 
+                // Space for the voice names, outside the furniture.  Two widths, because the
+                // labels differ: the first system carries the full names and later ones the
+                // subnames, so a voice named "Soprano" with `snm="S"` indents its opening
+                // system further than the rest — which is what an engraver draws, and what
+                // the separate first/later header widths below already express.
+                let openingGutter = VoiceLabelGutter(labels: firstLabels, font: labelFont,
+                                                     staffSize: tuneConfig.staffSize).width
+                let laterGutter = VoiceLabelGutter(labels: laterLabels, font: labelFont,
+                                                   staffSize: tuneConfig.staffSize).width
+
                 // Header widths differ between the first system (has time sig) and later
                 // ones, and are the max across the group: the staves of a system have to
                 // start at the same x even when one voice's clef or key signature is wider.
-                let openingHeaderW = indent + printedVoices.indices.reduce(0.0) { widest, index in
+                let openingHeaderW = indent + openingGutter + printedVoices.indices.reduce(0.0) { widest, index in
                     max(widest, systemHeaderWidth(clef: printedVoices[index].properties.clef,
                                                   keySignature: voiceKeys[index],
                                                   meter: regionMeter, metadata: metadata,
                                                   staffSize: tuneConfig.staffSize))
                 }
-                let laterHeaderW = indent + printedVoices.indices.reduce(0.0) { widest, index in
+                let laterHeaderW = indent + laterGutter + printedVoices.indices.reduce(0.0) { widest, index in
                     max(widest, systemHeaderWidth(clef: printedVoices[index].properties.clef,
                                                   keySignature: voiceKeys[index],
                                                   meter: nil, metadata: metadata,
@@ -316,6 +346,16 @@ public struct SVGRenderer: CeolKitRenderer {
     }
 }
 
+// MARK: - Voice labels
+
+private extension Tune {
+    /// Whether any voice of this tune prints a name in the left gutter — which is what
+    /// decides whether the renderer has to read a text face at all.
+    var hasVoiceLabels: Bool {
+        voices.contains { $0.properties.name != nil || $0.properties.subname != nil }
+    }
+}
+
 // MARK: - Plan regions
 
 private extension SystemGroup {
@@ -325,7 +365,8 @@ private extension SystemGroup {
         return SystemGroup(staves: staves.map {
             System(measures: $0.measures, isLastSystem: isLast, sourceForced: $0.sourceForced,
                    staveWasSplit: $0.staveWasSplit, clef: $0.clef,
-                   keySignature: $0.keySignature, meter: $0.meter)
+                   keySignature: $0.keySignature, meter: $0.meter,
+                   voiceLabel: $0.voiceLabel)
         }, grouping: grouping)
     }
 }

--- a/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
@@ -184,6 +184,7 @@ struct SVGEmitter: Sendable {
                              builder: inout SVGBuilder) {
         emitStaffLines(system, builder: &builder)
         emitStaffGroupConnector(system, builder: &builder)
+        emitVoiceLabel(system, builder: &builder)
         emitClef(system, builder: &builder)
         if let keySig = system.keySignature {
             emitKeySignature(keySig, system: system, builder: &builder)
@@ -226,6 +227,30 @@ struct SVGEmitter: Sendable {
                                 kind: .slur, builder: &builder)
             }
         }
+    }
+
+    /// The voice's `V:` `name=` / `sname=`, standing in the gutter left of the system
+    /// (ABC v2.2 §4.1).
+    ///
+    /// Right-aligned against the gutter's right edge rather than measured out from the
+    /// staff, so the labels of a system line up with each other whatever their lengths, and
+    /// optically centred on the staff — the middle staff line, plus half a cap height, which
+    /// puts the letterforms' centre on it rather than their baseline.
+    ///
+    /// Drawn through the same `builder.text` path as the title block, so it takes whichever
+    /// of `<text>` and outlines the document is in.  A bare `<text>` would vanish in every
+    /// non-browser rasteriser, which is the default here.
+    private func emitVoiceLabel(_ system: ResolvedSystem, builder: inout SVGBuilder) {
+        guard let label = system.voiceLabel else { return }
+        let topY = system.origin.y + system.staffOrigin
+        builder.text(
+            label.text,
+            x: label.x,
+            y: topY + VoiceLabelGutter.baselineOffset(staffSize: config.staffSize),
+            fontFamily: "Libertinus Serif",
+            fontSize: VoiceLabelGutter.fontSize(staffSize: config.staffSize),
+            textAnchor: "end"
+        )
     }
 
     private func emitStaffLines(_ system: ResolvedSystem, builder: inout SVGBuilder) {

--- a/Sources/CeolKitSVGRenderer/Font/OpenTypeFont.swift
+++ b/Sources/CeolKitSVGRenderer/Font/OpenTypeFont.swift
@@ -271,4 +271,15 @@ struct OpenTypeFont: Sendable {
     func outline(forGlyph glyph: Int) throws -> GlyphPath {
         try charstrings.outline(forGlyph: glyph)
     }
+
+    /// How wide `text` is drawn at `fontSize`, in points.
+    ///
+    /// Summed nominal advances, one glyph per Unicode scalar, which is exactly what
+    /// ``SVGBuilder`` lays a run out with — so a caller reserving space from this measure
+    /// and the emitter drawing into it cannot disagree.  An unencoded scalar falls back to
+    /// glyph 0, whose `.notdef` box is what gets drawn for it.
+    func width(of text: String, fontSize: Double) -> Double {
+        let units = text.unicodeScalars.reduce(0.0) { $0 + advance(forGlyph: glyphID(for: $1) ?? 0) }
+        return units * fontSize / unitsPerEm
+    }
 }

--- a/Sources/CeolKitSVGRenderer/Font/OutlineFontSet.swift
+++ b/Sources/CeolKitSVGRenderer/Font/OutlineFontSet.swift
@@ -48,6 +48,16 @@ struct OutlineFontSet: Sendable {
         return .success(OutlineFontSet(fonts: fonts))
     }()
 
+    /// The face every run of ordinary text is set in — titles, footers, voice labels.
+    ///
+    /// `nil` where the bundled resource could not be read.  Layout asks for it to measure
+    /// text it has to reserve space for, and has to keep working without it: a score that
+    /// engraves with an estimated gutter is worth more than one that refuses to render.
+    static func textFace() -> OpenTypeFont? {
+        try? shared().resolve(family: CeolKitFonts.Face.libertinusSerifRegular.familyName,
+                              italic: false)?.font
+    }
+
     /// The face the emitter's `font-family` / `font-style` pair names, or `nil` for a
     /// family this renderer does not bundle.
     func resolve(family: String, italic: Bool) -> (key: FaceKey, font: OpenTypeFont)? {

--- a/Sources/CeolKitSVGRenderer/Layout/Justifier.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/Justifier.swift
@@ -115,7 +115,8 @@ public struct Justifier: Sendable {
             }
             return JustifiedSystem(measures: measures, isLastSystem: staff.isLastSystem,
                                    sourceForced: staff.sourceForced, clef: staff.clef,
-                                   keySignature: staff.keySignature, meter: staff.meter)
+                                   keySignature: staff.keySignature, meter: staff.meter,
+                                   voiceLabel: staff.voiceLabel)
         }
         return JustifiedSystemGroup(staves: staves, grouping: group.grouping)
     }

--- a/Sources/CeolKitSVGRenderer/Layout/LineBreaker.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/LineBreaker.swift
@@ -64,13 +64,22 @@ public struct LineBreaker: Sendable {
         public let keySignature: KeySignature?
         /// Stamped on the voice's first system only.
         public let meter: Meter?
+        /// What the voice is called on the first system it appears on — its `V:` `name=`.
+        public let firstSystemLabel: String?
+        /// What it is called on every system after that — its `sname=`.  Nil where the voice
+        /// has none, and deliberately not defaulted to ``firstSystemLabel``: a voice named
+        /// once and never again is what the spec asks for and what abcm2ps prints.
+        public let laterSystemLabel: String?
 
         public init(measures: [SizedMeasure], clef: ClefSpec = ClefSpec(clef: .treble, octaveShift: 0),
-                    keySignature: KeySignature? = nil, meter: Meter? = nil) {
+                    keySignature: KeySignature? = nil, meter: Meter? = nil,
+                    firstSystemLabel: String? = nil, laterSystemLabel: String? = nil) {
             self.measures = measures
             self.clef = clef
             self.keySignature = keySignature
             self.meter = meter
+            self.firstSystemLabel = firstSystemLabel
+            self.laterSystemLabel = laterSystemLabel
         }
     }
 
@@ -135,7 +144,8 @@ public struct LineBreaker: Sendable {
                         staveWasSplit: ranges.count > 1,
                         clef: voice.clef,
                         keySignature: voice.keySignature,
-                        meter: isFirstOfTune ? voice.meter : nil
+                        meter: isFirstOfTune ? voice.meter : nil,
+                        voiceLabel: isFirstOfTune ? voice.firstSystemLabel : voice.laterSystemLabel
                     )
                 }, grouping: grouping))
             }
@@ -146,7 +156,8 @@ public struct LineBreaker: Sendable {
             groups.append(SystemGroup(staves: last.staves.map { staff in
                 System(measures: staff.measures, isLastSystem: true,
                        sourceForced: staff.sourceForced, staveWasSplit: staff.staveWasSplit,
-                       clef: staff.clef, keySignature: staff.keySignature, meter: staff.meter)
+                       clef: staff.clef, keySignature: staff.keySignature, meter: staff.meter,
+                       voiceLabel: staff.voiceLabel)
             }, grouping: last.grouping))
         }
 

--- a/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
@@ -49,6 +49,11 @@ public struct System: Sendable {
     public let keySignature: KeySignature?
     /// Non-nil only on the first system of a tune; time signatures do not repeat at line breaks.
     public let meter: Meter?
+    /// What this voice prints in the left gutter of *this* system: its `V:` `name=` on the
+    /// tune's first system, its `sname=` on every later one, and `nil` where it has none
+    /// (ABC v2.2 §4.1).  A voice with a name but no subname is therefore labelled once and
+    /// then not again, which is what abcm2ps does.
+    public let voiceLabel: String?
 
     public init(
         measures: [SizedMeasure],
@@ -57,7 +62,8 @@ public struct System: Sendable {
         staveWasSplit: Bool = false,
         clef: ClefSpec = ClefSpec(clef: .treble, octaveShift: 0),
         keySignature: KeySignature? = nil,
-        meter: Meter? = nil
+        meter: Meter? = nil,
+        voiceLabel: String? = nil
     ) {
         self.measures = measures
         self.isLastSystem = isLastSystem
@@ -66,6 +72,7 @@ public struct System: Sendable {
         self.clef = clef
         self.keySignature = keySignature
         self.meter = meter
+        self.voiceLabel = voiceLabel
     }
 }
 
@@ -210,6 +217,9 @@ public struct JustifiedSystem: Sendable {
     public let keySignature: KeySignature?
     /// Non-nil only on the first system of a tune; time signatures do not repeat at line breaks.
     public let meter: Meter?
+    /// Carried through from ``System/voiceLabel`` — justification moves x positions, never
+    /// what a staff is called.
+    public let voiceLabel: String?
 
     public init(
         measures: [JustifiedMeasure],
@@ -217,7 +227,8 @@ public struct JustifiedSystem: Sendable {
         sourceForced: Bool,
         clef: ClefSpec = ClefSpec(clef: .treble, octaveShift: 0),
         keySignature: KeySignature? = nil,
-        meter: Meter? = nil
+        meter: Meter? = nil,
+        voiceLabel: String? = nil
     ) {
         self.measures = measures
         self.isLastSystem = isLastSystem
@@ -225,6 +236,7 @@ public struct JustifiedSystem: Sendable {
         self.clef = clef
         self.keySignature = keySignature
         self.meter = meter
+        self.voiceLabel = voiceLabel
     }
 }
 
@@ -383,6 +395,24 @@ public struct StaffGroup: Sendable {
     public var isGroupLeader: Bool { index == 0 }
 }
 
+/// A voice's `V:` `name=` / `sname=`, placed on the page.
+///
+/// The text and its x arrive together because the x is not derived from the staff: it is
+/// the right edge of the gutter ``VoiceLabelGutter`` reserved for the *system*, which is
+/// as far left as the widest label in it reaches.  Every staff of a system shares that
+/// edge, so the labels right-align with each other rather than each ending where its own
+/// staff begins.
+public struct VoiceLabel: Sendable {
+    public let text: String
+    /// Absolute x the label is right-aligned against.
+    public let x: Double
+
+    public init(text: String, x: Double) {
+        self.text = text
+        self.x = x
+    }
+}
+
 public struct ResolvedSystem: Sendable {
     public let origin: Point
     public let measures: [ResolvedMeasure]
@@ -415,6 +445,10 @@ public struct ResolvedSystem: Sendable {
     public let abcLine: Int
     /// Non-nil when this staff is one of several in a system; see ``StaffGroup``.
     public let staffGroup: StaffGroup?
+    /// The voice name drawn in this system's left gutter, already placed.  `nil` where the
+    /// voice has nothing to print on this system, which is every voice of every tune that
+    /// names none.
+    public let voiceLabel: VoiceLabel?
 
     public init(
         origin: Point,
@@ -430,7 +464,8 @@ public struct ResolvedSystem: Sendable {
         keySignature: KeySignature? = nil,
         meter: Meter? = nil,
         abcLine: Int = 1,
-        staffGroup: StaffGroup? = nil
+        staffGroup: StaffGroup? = nil,
+        voiceLabel: VoiceLabel? = nil
     ) {
         self.origin = origin
         self.measures = measures
@@ -446,6 +481,7 @@ public struct ResolvedSystem: Sendable {
         self.meter = meter
         self.abcLine = abcLine
         self.staffGroup = staffGroup
+        self.voiceLabel = voiceLabel
     }
 }
 

--- a/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
@@ -9,10 +9,19 @@ import CeolKitModel
 public struct VerticalLayoutEngine: Sendable {
     private let config: SVGRenderConfig
     private let metadata: BravuraMetadata
+    /// The text face voice labels are measured in, or `nil` where none was supplied or it
+    /// could not be read.  ``VoiceLabelGutter`` falls back to an estimate, and the caller
+    /// that reserved the gutter took the same fallback, so the two still agree.
+    private let labelFont: OpenTypeFont?
 
     public init(config: SVGRenderConfig, metadata: BravuraMetadata) {
+        self.init(config: config, metadata: metadata, labelFont: nil)
+    }
+
+    init(config: SVGRenderConfig, metadata: BravuraMetadata, labelFont: OpenTypeFont?) {
         self.config = config
         self.metadata = metadata
+        self.labelFont = labelFont
     }
 
     /// Converts justified systems into a fully positioned layout.
@@ -190,6 +199,9 @@ public struct VerticalLayoutEngine: Sendable {
         /// rather than where they are drawn because the spans decide the spacing as well as
         /// the furniture: a staff a span reaches past is not drawn *and* not tightened.
         let columns: BracketColumns
+        /// The space this system's voice labels stand in, left of the braces and brackets.
+        /// Empty on every system whose voices print no name.
+        let labels: VoiceLabelGutter
     }
 
     private func groupMetrics(of group: JustifiedSystemGroup,
@@ -212,7 +224,9 @@ public struct VerticalLayoutEngine: Sendable {
             startWidth = max(startWidth, systemStartWidth(for: staff, staffSize: staffSize))
         }
         return GroupMetrics(staves: staves, totalHeight: offset, startWidth: startWidth,
-                            columns: columns)
+                            columns: columns,
+                            labels: VoiceLabelGutter(labels: group.staves.map(\.voiceLabel),
+                                                     font: labelFont, staffSize: staffSize))
     }
 
     /// Places every staff of one system, top to bottom, starting at `topY`.
@@ -228,13 +242,15 @@ public struct VerticalLayoutEngine: Sendable {
         let last = metrics.staves[metrics.staves.count - 1]
         let groupBottomY = topY + last.staffTopOffset + staffHeight
 
-        // The staves start right of the margin by whatever the group's braces and brackets
-        // need, and nowhere else: with no plan, or a plan that groups nothing, the indent is
-        // zero and the page is the one the renderer drew before brackets existed.  The line
+        // The staves start right of the margin by whatever the group's voice labels and its
+        // braces and brackets need, in that order — the labels stand outside the furniture,
+        // or they would be printed over it — and nowhere else: a tune with neither reserves
+        // nothing and lands on the page the renderer drew before either existed.  The line
         // breaker was handed the same reservation, so the music still ends on the right
-        // margin (see `BracketColumns`).
+        // margin (see `VoiceLabelGutter` and `BracketColumns`).
         let columns = metrics.columns
-        let staffLeftX = config.margins.left + columns.indent
+        let staffLeftX = config.margins.left + metrics.labels.width + columns.indent
+        let labelRightX = metrics.labels.rightEdgeX(from: config.margins.left)
 
         // The plan's spans, placed: a span reaches from the top staff line of its first
         // staff to the bottom staff line of its last, standing in the column its depth was
@@ -291,7 +307,8 @@ public struct VerticalLayoutEngine: Sendable {
                 keySignature: staff.keySignature,
                 meter: staff.meter,
                 abcLine: abcLine,
-                staffGroup: membership
+                staffGroup: membership,
+                voiceLabel: staff.voiceLabel.map { VoiceLabel(text: $0, x: labelRightX) }
             )
         }
     }

--- a/Sources/CeolKitSVGRenderer/Layout/VoiceLabelGutter.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VoiceLabelGutter.swift
@@ -1,0 +1,74 @@
+/// The column of space to the left of a system's staves that its voice labels stand in,
+/// and where their right edge falls (ABC v2.2 §4.1: `V:` `name=` and `sname=`).
+///
+/// Written as one calculation for the same reason ``BracketColumns`` is: the width reserved
+/// here is subtracted from the music twice over — the line breaker packs into what is left
+/// and the justifier stretches into it — while the layout engine spends it by moving the
+/// staves right and the emitter draws into what that vacates.  Everything the four of them
+/// need to agree about is stated here once.
+///
+/// The gutter stands *outside* the bracket columns, so a system with both draws its labels,
+/// then its braces and brackets, then its staves.  Anything else would print the label over
+/// the furniture.
+///
+/// A system whose voices carry no label reserves nothing and shifts nothing, which is what
+/// keeps every existing single-voice page byte-identical.
+struct VoiceLabelGutter: Sendable {
+
+    /// Space between the widest label and whatever stands to its right — the outermost
+    /// bracket column, or the staff itself — in staff spaces.
+    private static let clearance = 1.0
+
+    /// Label size as a multiple of the staff space.
+    ///
+    /// abcm2ps sets its `%%voicefont` at 13pt against a 24pt staff; this is the same
+    /// proportion rounded to something a reader of the code can hold onto.  A
+    /// `%%voicefont`-style directive can override it later without moving anything else.
+    private static let fontSizeRatio = 2.0
+
+    /// Advance assumed per character when the text face could not be read.  Only ever
+    /// reached on a broken resource, and both the reservation and the drawing take the
+    /// same path, so the labels still land in the space kept for them.
+    private static let fallbackAdvanceRatio = 0.5
+
+    /// Total space reserved left of everything else.  Zero when no voice has a label.
+    let width: Double
+
+    private let staffSize: Double
+
+    /// - Parameters:
+    ///   - labels: one entry per staff of the system, top to bottom; `nil` where that
+    ///     staff's voice prints no label on this system.
+    ///   - font: the text face, or `nil` where it could not be read.
+    init(labels: [String?], font: OpenTypeFont?, staffSize: Double) {
+        self.staffSize = staffSize
+        let widest = labels.compactMap { $0 }.filter { !$0.isEmpty }.reduce(0.0) { widest, label in
+            max(widest, Self.width(of: label, font: font, staffSize: staffSize))
+        }
+        width = widest > 0 ? widest + Self.clearance * staffSize : 0
+    }
+
+    /// Absolute x the labels are right-aligned against, given the x the gutter starts at.
+    ///
+    /// The clearance is the gutter's right-hand part, so the labels end short of it and
+    /// nothing they are drawn against has to know how wide they were.
+    func rightEdgeX(from leftX: Double) -> Double {
+        leftX + width - Self.clearance * staffSize
+    }
+
+    /// The size labels are set at, at the given staff size.
+    static func fontSize(staffSize: Double) -> Double { fontSizeRatio * staffSize }
+
+    /// How far below the top staff line a label's baseline sits, so that the label is
+    /// optically centred on the staff: the staff's own middle, plus half a cap height to
+    /// bring the letterforms' centre onto it rather than their baseline.
+    static func baselineOffset(staffSize: Double) -> Double {
+        2 * staffSize + fontSize(staffSize: staffSize) * LibertinusSerifMetrics.capHeightRatio / 2
+    }
+
+    private static func width(of label: String, font: OpenTypeFont?, staffSize: Double) -> Double {
+        let size = fontSize(staffSize: staffSize)
+        guard let font else { return Double(label.count) * size * fallbackAdvanceRatio }
+        return font.width(of: label, fontSize: size)
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/VoiceLabelTests.swift
+++ b/Tests/CeolKitSVGRendererTests/VoiceLabelTests.swift
@@ -1,0 +1,235 @@
+import Testing
+import CeolKitModel
+import CeolKitParser
+import CeolKitSVGGeometry
+@testable import CeolKitSVGRenderer
+
+/// Issue #57: a `V:` `name=` is printed left of the tune's first system and `sname=` left of
+/// every later one, and the space they stand in is reserved before the music is broken into
+/// lines (ABC v2.2 §4.1).
+///
+/// End to end — source in, SVG out — for the same reason ``StaffBracketTests`` is: the label
+/// and the gutter only mean anything together.  The reservation is right when the label lands
+/// inside the page margin and the music still reaches the right one.
+@Suite("Voice Labels")
+struct VoiceLabelTests {
+
+    private let config = SVGRenderConfig()
+
+    /// One run of text in the emitted drawing.
+    private struct Label {
+        let text: String, x: Double, y: Double, fontSize: Double, anchor: String
+    }
+
+    private func render(_ abc: String, config: SVGRenderConfig? = nil)
+    -> (svg: String, staves: [SystemGeometry]) {
+        // `.both` so the strings stay in the document as `<text>` alongside the outlines the
+        // renderer actually paints: the geometry asserted here is the outlines', which are
+        // laid out from the same origin and anchor.
+        var effective = config ?? self.config
+        effective.textRendering = .both
+        let score = CeolKitParser().parse(abc, options: .default).score
+        var diagnostics: [Diagnostic] = []
+        let svgs = try! SVGRenderer(config: effective).render(score, diagnostics: &diagnostics)
+        return (svgs.joined(), try! SVGGeometry.pages(from: svgs).flatMap(\.systems))
+    }
+
+    private func texts(in svg: String) -> [Label] {
+        svg.matches(of: /<text x="([-0-9.]+)" y="([-0-9.]+)" font-family="[^"]*" font-size="([-0-9.]+)"([^>]*)>([^<]*)<\/text>/)
+            .compactMap { match in
+                guard let x = Double(match.1), let y = Double(match.2),
+                      let size = Double(match.3) else { return nil }
+                let anchor = String(match.4).firstMatch(of: /text-anchor="([a-z]+)"/)
+                    .map { String($0.1) } ?? "start"
+                return Label(text: String(match.5), x: x, y: y, fontSize: size, anchor: anchor)
+            }
+    }
+
+    /// The label standing in `staff`'s own gutter, or `nil` where it has none.
+    ///
+    /// Matched against the staff it names rather than against a page-wide left edge: a tune
+    /// whose voices have names but no subnames indents its first system and nothing else,
+    /// so the first system's labels sit to the *right* of where later staves begin.
+    private func gutterLabel(_ svg: String, staff: SystemGeometry) -> Label? {
+        texts(in: svg).first { $0.anchor == "end" && $0.x < staff.left
+                               && $0.y > staff.topY && $0.y < staff.bottomY }
+    }
+
+    /// The gutter labels of `staves`, in staff order, skipping the staves that have none.
+    private func gutterLabels(_ svg: String, staves: [SystemGeometry]) -> [Label] {
+        staves.compactMap { gutterLabel(svg, staff: $0) }
+    }
+
+    /// Two voices with the given `V:` attributes, two source lines of two bars each — so the
+    /// tune has a first system and a later one.
+    private func twoVoices(_ first: String, _ second: String, directive: String = "") -> String {
+        ([
+            "X:1", "T:Two Voices", "M:4/4", "L:1/8", directive, "K:D",
+            "V:1 \(first)", "V:2 \(second)",
+            "[V:1] abcd efga | bage dcBA |",
+            "[V:2] ABcd efga | bage dcBA |",
+            "[V:1] abcd efga | bage dcBA |",
+            "[V:2] ABcd efga | bage dcBA |",
+        ] as [String]).filter { !$0.isEmpty }.joined(separator: "\n")
+    }
+
+    private let named = #"name="Soprano" sname="S""#
+    private let alto  = #"name="Alto" sname="A""#
+
+    // MARK: - What gets printed
+
+    @Test("name= labels the first system and sname= every later one")
+    func namesThenSubnames() {
+        let (svg, staves) = render(twoVoices(named, alto))
+        #expect(staves.count == 4)
+        let labels = gutterLabels(svg, staves: staves)
+        #expect(labels.map(\.text) == ["Soprano", "Alto", "S", "A"])
+    }
+
+    @Test("A voice with a name but no sname is labelled once and then not again")
+    func subnameDoesNotFallBackToTheName() {
+        let (svg, staves) = render(twoVoices(#"name="Soprano""#, #"name="Alto""#))
+        #expect(gutterLabels(svg, staves: staves).map(\.text) == ["Soprano", "Alto"])
+    }
+
+    @Test("A voice with sname= but no name= is unlabelled until its second system")
+    func subnameAloneLabelsOnlyLaterSystems() {
+        let (svg, staves) = render(twoVoices(#"sname="S""#, #"sname="A""#))
+        #expect(gutterLabels(svg, staves: staves).map(\.text) == ["S", "A"])
+    }
+
+    @Test("A tune that names no voice draws no gutter text at all")
+    func unnamedVoicesDrawNothing() {
+        let (svg, staves) = render(twoVoices("", ""))
+        #expect(gutterLabels(svg, staves: staves).isEmpty)
+    }
+
+    // MARK: - Placement
+
+    @Test("The labels of one system right-align on a common edge")
+    func labelsShareTheirRightEdge() {
+        let (svg, staves) = render(twoVoices(named, alto))
+        let labels = gutterLabels(svg, staves: staves)
+        #expect(labels[0].x == labels[1].x)
+        #expect(labels[2].x == labels[3].x)
+        // The subnames are shorter, so their system indents less and their edge sits left of
+        // the first system's — the labels are what the gutter is measured from.
+        #expect(labels[2].x < labels[0].x)
+    }
+
+    @Test("Each label is centred on the staff it names")
+    func labelsAreCentredOnTheirStaff() {
+        let (svg, staves) = render(twoVoices(named, alto))
+        let labels = gutterLabels(svg, staves: staves)
+        for (label, staff) in zip(labels, staves) {
+            let expected = staff.topY
+                + VoiceLabelGutter.baselineOffset(staffSize: staff.staffLineGap)
+            #expect(abs(label.y - expected) < 1e-6)
+            // Inside the staff, which is the point of centring it there.
+            #expect(label.y > staff.topY && label.y < staff.bottomY)
+        }
+    }
+
+    @Test("The label is set at the voice-label size, which scales with the music")
+    func labelFontSizeScalesWithTheStaff() {
+        let (svg, staves) = render(twoVoices(named, alto))
+        let label = gutterLabels(svg, staves: staves)[0]
+        #expect(abs(label.fontSize
+                    - VoiceLabelGutter.fontSize(staffSize: staves[0].staffLineGap)) < 1e-6)
+    }
+
+    // MARK: - Reservation
+
+    @Test("A labelled system starts right of the margin, and an unlabelled one does not")
+    func labelsIndentTheStaves() {
+        let plain = render(twoVoices("", "")).staves
+        let labelled = render(twoVoices(named, alto)).staves
+
+        #expect(plain.allSatisfy { $0.left == config.margins.left })
+        #expect(labelled.allSatisfy { $0.left > config.margins.left })
+        // Both staves of a system start at the same x: the gutter belongs to the system, not
+        // to the staff with the longest name.
+        #expect(labelled[0].left == labelled[1].left)
+        #expect(labelled[2].left == labelled[3].left)
+        // …and the later system, carrying only subnames, indents less than the first.
+        #expect(labelled[2].left < labelled[0].left)
+    }
+
+    @Test("No label crosses the left margin")
+    func nothingCrossesTheLeftMargin() {
+        let (svg, staves) = render(twoVoices(named, alto))
+        // Right-aligned runs, so subtract the width the emitter laid them out at.
+        let font = OutlineFontSet.textFace()
+        for label in gutterLabels(svg, staves: staves) {
+            let width = font?.width(of: label.text, fontSize: label.fontSize) ?? 0
+            #expect(label.x - width >= config.margins.left - 1e-6)
+        }
+    }
+
+    @Test("The music still ends on the right margin: the gutter came out of the line")
+    func gutterIsTakenOutOfTheLine() {
+        var config = config
+        config.justifyLastSystem = true
+        let rightMargin = config.pageSize.width - config.margins.right
+        for abc in [twoVoices("", ""), twoVoices(named, alto)] {
+            let staves = render(abc, config: config).staves
+            #expect(staves.allSatisfy { abs($0.right - rightMargin) < 0.5 })
+        }
+    }
+
+    @Test("The gutter scales with the music")
+    func gutterScalesWithTheTune() {
+        let full = render(twoVoices(named, alto)).staves
+        let half = render(twoVoices(named, alto, directive: "%%ceolkit:scale 0.5")).staves
+        let fullIndent = full[0].left - config.margins.left
+        let halfIndent = half[0].left - config.margins.left
+        #expect(abs(halfIndent - fullIndent / 2) < 1e-6)
+    }
+
+    // MARK: - Alongside the brackets
+
+    @Test("The labels stand outside the bracket, which stands outside the staves")
+    func labelsStandLeftOfTheBracket() throws {
+        let (svg, staves) = render(twoVoices(named, alto, directive: "%%score [1 2]"))
+        let label = try #require(gutterLabels(svg, staves: staves).first)
+
+        // The bracket spine over the first system: the one vertical stroke left of its
+        // staves that starts on its top staff line.  Anchored to that system because the
+        // later one, carrying only subnames, indents less and so stands further left.
+        let spineX = svg.matches(of: /<line x1="([-0-9.]+)" y1="([-0-9.]+)" x2="([-0-9.]+)"/)
+            .compactMap { match -> Double? in
+                guard let x1 = Double(match.1), let y1 = Double(match.2),
+                      let x2 = Double(match.3),
+                      abs(x1 - x2) < 1e-9, x1 < staves[0].left,
+                      abs(y1 - staves[0].topY) < 1e-3 else { return nil }
+                return x1
+            }.min()
+        let spine = try #require(spineX)
+        #expect(label.x < spine)
+        #expect(spine < staves[0].left)
+    }
+
+    @Test("Adding a bracket to a labelled tune indents it further, not the same")
+    func bracketAndGutterAreBothReserved() {
+        let labelled = render(twoVoices(named, alto)).staves
+        let both = render(twoVoices(named, alto, directive: "%%score [1 2]")).staves
+        #expect(both[0].left > labelled[0].left)
+    }
+
+    // MARK: - Outline rendering
+
+    @Test("The label reaches the page as geometry, not as a bare <text>")
+    func labelIsDrawnAsOutlines() throws {
+        // The renderer's own default, which is what every non-browser rasteriser needs.
+        let score = CeolKitParser().parse(twoVoices(named, alto), options: .default).score
+        var diagnostics: [Diagnostic] = []
+        let svg = try SVGRenderer(config: config).render(score, diagnostics: &diagnostics).joined()
+        let staves = try SVGGeometry.pages(from: [svg]).flatMap(\.systems)
+
+        #expect(!svg.contains("<text"))
+        let inGutter = svg.matches(of: /<use [^>]*transform="translate\(([-0-9.]+)\s/)
+            .compactMap { Double($0.1) }
+            .filter { $0 < staves[0].left }
+        #expect(!inGutter.isEmpty)
+    }
+}


### PR DESCRIPTION
Closes #57.

`name=` and `snm=` were parsed, merged across continuation `V:` lines and stored, and then read by nothing. They now reach the page: `name=` left of the tune's first system, `snm=` left of every later one, right-aligned on a common edge and centred on the staff they name.

## One deviation from the issue's sketch

The issue proposes `indent = max(bracketWidth, labelGutterWidth)`. That collides — with `%%score [{1 2} {3 4}]` and a name like `Tenore II`, the brace and the label would occupy the same column and be printed one over the other. The gutter therefore stands *outside* the furniture and the indent is `labels + furniture`. abcm2ps sums them for the same reason (`set_indent` adds a bracket allowance to the name width).

## What it does

- `name=` on the first system, `snm=` on every later one. A voice with `name=` but no `snm=` is labelled once and then not again — no fallback to the full name, matching abcm2ps.
- Labels right-align on a common edge across the staves of a system, and sit on the staff's middle line plus half a cap height.
- The first system indents further than the rest when the subnames are shorter. That falls out of the first/later header-width split the line breaker already had.
- A plan region after the opening one takes subnames throughout: a `%%score` part-way through a tune does not re-introduce the voices.
- A voice with neither attribute reserves nothing and shifts nothing. Unlabelled tunes are byte-identical, which is why the existing 865 tests pass without a golden edit.

## Shape

`VoiceLabelGutter` states the reservation, its right edge, the label size (`2 × staffSize`) and the centring baseline — the shape `BracketColumns` already has, for the reason its own comment gives. Four callers spend the same number: the breaker packs into what is left of the line, the justifier stretches into it, `VerticalLayoutEngine` moves the staves right by it, and the emitter draws into what that vacates.

Measuring needed a string width, which no face wrapper offered. `OpenTypeFont.width(of:fontSize:)` sums nominal advances one glyph per scalar, exactly as `SVGBuilder` lays a run out, so what is reserved and what is drawn cannot drift. The face is read only when a tune actually names a voice; where the resource cannot be read at all, both sides take the same estimate and the labels still land in the space kept for them.

Emission goes through the same `builder.text` path as the title block, so it takes whichever of `<text>` and outlines the document is in — a bare `<text>` would vanish in every non-browser rasteriser, which is the default here.

## Tests

14 new in `VoiceLabelTests`, end to end for the reason `StaffBracketTests` is — the label and the gutter only mean anything together. They cover which label prints on which system, the shared right edge, centring, the indent and its absence, the music still ending on the right margin, scaling with `%%ceolkit:scale`, the ordering against a bracket, and that the label reaches the page as geometry rather than a bare `<text>`.

Full suite: 879 tests, 64 suites, passing.

## Unblocks

- #71 — Canzonetta (§14.4), which names all three voices.
- #83 — Zocharti Loch (§7), which names all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JASj9t8ca2nZSFNbct2NT3