### PR TITLE
Fix #71 — Canzonetta (§14.4) end-to-end conformance fixture

### DIFF
--- a/Sources/CeolKitParser/Lexer/LineClassifier.swift
+++ b/Sources/CeolKitParser/Lexer/LineClassifier.swift
@@ -7,26 +7,48 @@ struct LineClassifier {
     func classify() -> [LogicalLine] {
         var result: [LogicalLine] = []
         var mode = ParserMode.preamble
-        var pendingContinuation: (text: String, source: SourceRange)? = nil
+        // A music line ended in `\`.  `text` is what has been gathered so far and `source`
+        // where it started; `deferred` holds the lines that fell between it and its
+        // continuation, which are emitted once the music line is whole again.
+        var pendingContinuation: (text: String, source: SourceRange, deferred: [LogicalLine])? = nil
 
         for (lineNumber, text, _) in source.lines() {
             let str = String(text)
             let lineSource = source.range(line: lineNumber, column: 1, length: text.utf8.count)
-
-            // Continuation: this line is a raw extension of the previous music line.
-            if var cont = pendingContinuation {
-                if str.hasSuffix("\\") {
-                    cont.text += String(str.dropLast())
-                    pendingContinuation = cont
-                } else {
-                    cont.text += str
-                    result.append(.musicLine(text: cont.text, source: cont.source))
-                    pendingContinuation = nil
-                }
-                continue
-            }
-
             let line = classifyLine(str, source: lineSource, mode: mode)
+
+            // §2.2: a backslash continues a music line *through* information fields,
+            // comments and stylesheet directives — only the next line of music code joins
+            // it.  Anything else is set aside and emitted after the music line it
+            // interrupted, so a `w:` still lands on the line it belongs to.  Comments are
+            // dropped, as they are everywhere else.
+            if var cont = pendingContinuation {
+                switch line {
+                case .musicLine(let t, _):
+                    if t.hasSuffix("\\") {
+                        cont.text += String(t.dropLast())
+                        pendingContinuation = cont
+                    } else {
+                        cont.text += t
+                        result.append(.musicLine(text: cont.text, source: cont.source))
+                        result += cont.deferred
+                        pendingContinuation = nil
+                    }
+                    continue
+                case .comment:
+                    continue
+                case .empty:
+                    // Illegal per §6.1.1 — a backslash must not precede an empty line.
+                    // Flush what there is rather than swallow the rest of the tune.
+                    result.append(.musicLine(text: cont.text, source: cont.source))
+                    result += cont.deferred
+                    pendingContinuation = nil
+                default:
+                    cont.deferred.append(line)
+                    pendingContinuation = cont
+                    continue
+                }
+            }
 
             // Update state machine
             switch line {
@@ -45,7 +67,7 @@ struct LineClassifier {
 
             // Start continuation tracking for music lines ending with backslash.
             if case .musicLine(let t, let s) = line, t.hasSuffix("\\") {
-                pendingContinuation = (text: String(t.dropLast()), source: s)
+                pendingContinuation = (text: String(t.dropLast()), source: s, deferred: [])
                 continue
             }
 
@@ -55,6 +77,7 @@ struct LineClassifier {
         // Flush dangling continuation.
         if let cont = pendingContinuation {
             result.append(.musicLine(text: cont.text, source: cont.source))
+            result += cont.deferred
         }
 
         return result

--- a/Sources/CeolKitParser/Lexer/MusicLexer.swift
+++ b/Sources/CeolKitParser/Lexer/MusicLexer.swift
@@ -24,6 +24,19 @@ struct MusicLexer {
             let token = scan(leading: ch)
             let length = max(1, localOffset - startOffset)
             result.append((token, makeRange(at: startOffset, length: length)))
+
+            // §4.9: a bar line may be followed straight away by the numbers of the variant
+            // ending it opens — `|1`, `:|2`, `||1,2`.  Scanned here rather than inside each
+            // bar-line scanner so that every kind of bar line spells it the same way, and
+            // so that the number is an *extra* token: `|1` is a bar line and an ending, and
+            // dropping the bar merges the ending into the measure before it.
+            if token.isBarLine, current?.isNumber == true {
+                let numberStart = localOffset
+                let numbers = scanEndingNumber()
+                result.append((numbers,
+                               makeRange(at: numberStart,
+                                         length: max(1, localOffset - numberStart))))
+            }
         }
         return result
     }
@@ -155,7 +168,6 @@ struct MusicLexer {
         case "]": advance(); return .barFinal
         case "|": advance(); return .barDouble
         case ":": advance(); return .barRepeatStart
-        case let d? where d.isNumber: return scanEndingNumber()
         default: return .barSingle
         }
     }

--- a/Sources/CeolKitParser/Lexer/Token.swift
+++ b/Sources/CeolKitParser/Lexer/Token.swift
@@ -71,3 +71,17 @@ enum Token {
     // Unknown
     case unknown(Character)
 }
+
+extension Token {
+    /// Whether this token is one of the bar lines.  Used by the lexer to decide that a
+    /// digit standing right after it opens a variant ending rather than starting a note.
+    var isBarLine: Bool {
+        switch self {
+        case .barSingle, .barDouble, .barFinal, .barSectionStart, .barRepeatStart,
+             .barRepeatEnd, .barRepeatBoth, .barSectionRepeatStart, .barRepeatEndSection:
+            true
+        default:
+            false
+        }
+    }
+}

--- a/Tests/CeolKitParserTests/Conformance/BarLineTests.swift
+++ b/Tests/CeolKitParserTests/Conformance/BarLineTests.swift
@@ -103,6 +103,31 @@ struct BarLineTests {
         #expect(ending1 != nil)
     }
 
+    /// `|1` is a bar line *and* an ending number.  The lexer used to read the digit in
+    /// place of the bar, which merged the measure before the ending into the ending itself
+    /// and lost one bar from every repeat written this way — §14.4 among them.
+    @Test("|1 closes the measure before the ending as well as opening it")
+    func endingNumberDoesNotSwallowItsBarLine() {
+        let result = parse(barTune("CDEF|GABC|1CDEF:|2GABC|]"))
+        let measures = result.score.firstTune?.singleVoiceMeasures ?? []
+        #expect(measures.count == 4)
+        #expect(measures.count(where: { $0.endingNumber != nil }) == 2)
+        // The bar that the ending number followed keeps its own closing bar line.
+        guard measures.count == 4 else { return }
+        #expect(measures[1].closingBar.kind == .single)
+        #expect(measures[1].endingNumber == nil)
+        #expect(measures[2].endingNumber?.contains(1) == true)
+    }
+
+    @Test("|1,2 and |1-3 keep their bar line and their whole list")
+    func endingListsKeepTheirBarLine() {
+        for (body, expected) in [("CDEF|1,2 GABC|]", [1, 2]), ("CDEF|1-3 GABC|]", [1, 2, 3])] {
+            let measures = parse(barTune(body)).score.firstTune?.singleVoiceMeasures ?? []
+            #expect(measures.count == 2, "\(body) gave \(measures.count) measures")
+            #expect(measures.last?.endingNumber == expected)
+        }
+    }
+
     @Test("Measures without ending numbers have nil endingNumber")
     func noEndingNumber() {
         let result = parse(barTune("CDEF|GABC|"))

--- a/Tests/CeolKitParserTests/Conformance/LineContinuationTests.swift
+++ b/Tests/CeolKitParserTests/Conformance/LineContinuationTests.swift
@@ -1,0 +1,72 @@
+// Backslash continuation of music code lines. ABC §2.2 and §6.1.1.
+import Testing
+import CeolKitModel
+import CeolKitParser
+
+private func contTune(_ body: String) -> String {
+    "X:1\nT:Test\nM:4/4\nL:1/4\nK:C\n\(body)"
+}
+
+/// §2.2: "The backslash effectively acts as a continuation character for music code lines
+/// … In particular it can continue music code lines through information fields, comments
+/// and stylesheet directives."
+///
+/// The lines it reaches through are not part of the music.  They used to be pasted into it
+/// verbatim, which turned a `w:` lyric line into a bar's worth of invented notes — §14.4
+/// Canzonetta is written this way and came out with a system of nonsense.
+@Suite("Line continuation (§2.2)")
+struct LineContinuationTests {
+
+    private func staves(_ body: String) -> [Staff] {
+        parse(contTune(body)).score.firstTune?.firstVoice?.staves ?? []
+    }
+
+    @Test("A trailing backslash joins the next music line into the same stave")
+    func backslashJoinsTwoMusicLines() {
+        let joined = staves("CDEF|\\\nGABC|")
+        #expect(joined.count == 1)
+        #expect(joined.first?.measures.count == 2)
+        // …and without it, two staves, which is what makes the score line-break.
+        #expect(staves("CDEF|\nGABC|").count == 2)
+    }
+
+    @Test("The continuation reaches through a w: lyric line")
+    func continuationReachesThroughLyrics() {
+        let result = parse(contTune("CDEF|\\\nw: la la la la\nGABC|"))
+        #expect(result.score.warningDiagnostics.isEmpty,
+                "Unexpected: \(result.score.warningDiagnostics.map(\.message))")
+        let staves = result.score.firstTune?.firstVoice?.staves ?? []
+        #expect(staves.count == 1)
+        #expect(staves.first?.measures.count == 2)
+        // The lyric lands on the line it was written under, not on invented notes.
+        let notes = staves.flatMap(\.measures).flatMap(\.noteEvents)
+        #expect(notes.count == 8)
+        #expect(notes.prefix(4).allSatisfy { $0.lyric != nil })
+    }
+
+    @Test("The continuation reaches through comments and stylesheet directives")
+    func continuationReachesThroughCommentsAndDirectives() {
+        // §2.2's own example, transposed to 4/4 so the meter change is visible.
+        let result = parse(contTune("CDEF|\\\n%%pagenumber 3\n%a comment\nGABC|"))
+        #expect(result.score.warningDiagnostics.isEmpty,
+                "Unexpected: \(result.score.warningDiagnostics.map(\.message))")
+        let staves = result.score.firstTune?.firstVoice?.staves ?? []
+        #expect(staves.count == 1)
+        #expect(staves.first?.measures.count == 2)
+    }
+
+    @Test("A backslash before an empty line still yields its music")
+    func danglingBackslashBeforeEmptyLine() {
+        // Illegal per §6.1.1, so this is the recovery path: the half-line already written
+        // becomes a stave of its own rather than swallowing the rest of the file.
+        let joined = staves("CDEF|\\\n\nGABC|")
+        #expect(joined.first?.measures.count == 1)
+    }
+
+    @Test("A backslash on the last line of a tune still yields its music")
+    func danglingBackslashAtEndOfInput() {
+        let joined = staves("CDEF|\\")
+        #expect(joined.count == 1)
+        #expect(joined.first?.measures.count == 1)
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/CanzonettaConformanceTests.swift
+++ b/Tests/CeolKitSVGRendererTests/CanzonettaConformanceTests.swift
@@ -1,0 +1,238 @@
+//
+//  CanzonettaConformanceTests.swift
+//  CeolKitSVGRendererTests
+//
+//  §14.4 Canzonetta.abc, rendered.  The parser side of the same source is asserted in
+//  `CeolKitParserTests/Conformance/CanzonettaTests.swift`; this is the engraved shape.
+//
+
+import Testing
+import SnapshotTesting
+import CeolKitModel
+import CeolKitParser
+import CeolKitSVGGeometry
+@testable import CeolKitSVGRenderer
+
+/// §14.4 Canzonetta.abc — the first spec example that reaches the renderer whole:
+/// `%%score [1 2 3]`, three named voices, one bracket, no shared staves.
+///
+/// Asserted through `CeolKitSVGGeometry`, which reads the emitted SVG rather than the
+/// layout engine's own beliefs, so a system that *thinks* it is aligned and one that is
+/// drawn aligned are told apart.
+///
+/// The tune carries `w:` lyric lines that CeolKit does not draw yet (issue #82), so
+/// nothing here asserts on lyrics — only on the staves, their bar lines and their bracket.
+@Suite("§14.4 Canzonetta.abc — rendering")
+struct CanzonettaConformanceTests {
+
+    private let config = SVGRenderConfig()
+
+    /// One vertical stroke of the emitted drawing.  Read straight out of the SVG, because
+    /// `CeolKitSVGGeometry` reports staves and bar lines and a bracket is deliberately
+    /// neither — the same reading `StaffBracketTests` does.
+    private struct Stroke {
+        let x: Double, y1: Double, y2: Double
+    }
+
+    private func render() throws -> (svg: String, staves: [SystemGeometry], diagnostics: [Diagnostic]) {
+        let result = CeolKitParser().parse(canzonettaABC, options: .default)
+        var diagnostics = result.score.diagnostics
+        let pages = try SVGRenderer(config: config).render(result.score, diagnostics: &diagnostics)
+        // One page: the whole point of the fixture is that the three systems land together.
+        #expect(pages.count == 1)
+        let geometry = try SVGGeometry.pages(from: pages)
+        return (pages.joined(), geometry.flatMap(\.systems), diagnostics)
+    }
+
+    /// The brackets: the vertical strokes that open flush with some staff's top line and
+    /// stand left of that staff.  Nothing else in the drawing does both — the rule joining
+    /// a system's staves at the left edge is drawn *at* `left`, not before it — and the
+    /// test cannot simply take the leftmost staff edge as the threshold, because the
+    /// opening system is indented further than the rest by its longer voice names.
+    private func bracketSpines(in svg: String, staves: [SystemGeometry]) -> [Stroke] {
+        svg.matches(of: /<line x1="([-0-9.]+)" y1="([-0-9.]+)" x2="([-0-9.]+)" y2="([-0-9.]+)"/)
+            .compactMap { match in
+                guard let x1 = Double(match.1), let y1 = Double(match.2),
+                      let x2 = Double(match.3), let y2 = Double(match.4),
+                      abs(x1 - x2) < 1e-9 else { return nil }
+                let stroke = Stroke(x: x1, y1: min(y1, y2), y2: max(y1, y2))
+                guard let opened = staves.first(where: { abs($0.topY - stroke.y1) < 1e-3 }),
+                      stroke.x < opened.left - 1e-9 else { return nil }
+                return stroke
+            }
+            .sorted { $0.y1 < $1.y1 }
+    }
+
+    /// The staves each bracket spans, top to bottom — the tune's systems, recovered from
+    /// what was drawn rather than assumed from the voice count.
+    private func systems(staves: [SystemGeometry], brackets: [Stroke]) -> [[SystemGeometry]] {
+        brackets.map { bracket in
+            staves.filter { $0.topY >= bracket.y1 - 0.5 && $0.bottomY <= bracket.y2 + 0.5 }
+        }
+    }
+
+    // MARK: - Diagnostics
+
+    @Test("§14.4 renders without a single warning or error")
+    func rendersClean() throws {
+        // Everything above `info` — the unsupported abcm2ps page-layout directives the tune
+        // opens with are reported at `info` and are not a failure to parse it.
+        let complaints = try render().diagnostics.filter { $0.severity != .info }
+        #expect(complaints.isEmpty,
+                "Unexpected diagnostics: \(complaints.map { "line \($0.source.line): \($0.message)" })")
+    }
+
+    // MARK: - Systems
+
+    @Test("Three systems of three staves, and every staff belongs to one")
+    func threeStavesPerSystem() throws {
+        let (svg, staves, _) = try render()
+        let brackets = bracketSpines(in: svg, staves: staves)
+        #expect(brackets.count == 3)
+        let systems = systems(staves: staves, brackets: brackets)
+        #expect(systems.map(\.count) == [3, 3, 3])
+        // No staff drawn outside a system, and none counted twice.
+        #expect(systems.reduce(0) { $0 + $1.count } == staves.count)
+        #expect(staves.count == 9)
+    }
+
+    @Test("The staves of a system share one x-span")
+    func stavesOfASystemShareAnXSpan() throws {
+        let (svg, staves, _) = try render()
+        for system in systems(staves: staves, brackets: bracketSpines(in: svg, staves: staves)) {
+            #expect(Set(system.map(\.left)).count == 1)
+            #expect(Set(system.map(\.right)).count == 1)
+        }
+    }
+
+    @Test("Bar lines are aligned across all three staves of a system")
+    func barLinesAlignAcrossTheSystem() throws {
+        let (svg, staves, _) = try render()
+        for (index, system) in systems(staves: staves,
+                                       brackets: bracketSpines(in: svg, staves: staves)).enumerated() {
+            guard let top = system.first else { Issue.record("System \(index) has no staves"); return }
+            #expect(!top.barlineXs.isEmpty)
+            for staff in system.dropFirst() {
+                #expect(staff.barlineXs.count == top.barlineXs.count,
+                        "System \(index): \(staff.barlineXs.count) bar lines against \(top.barlineXs.count)")
+                for (x, expected) in zip(staff.barlineXs, top.barlineXs) {
+                    #expect(abs(x - expected) < 0.5,
+                            "System \(index): bar line at \(x) against \(expected)")
+                }
+            }
+        }
+    }
+
+    @Test("Each system carries one bracket, spanning all three of its staves")
+    func oneBracketPerSystemSpanningIt() throws {
+        let (svg, staves, _) = try render()
+        let brackets = bracketSpines(in: svg, staves: staves)
+        let systems = systems(staves: staves, brackets: brackets)
+        for (bracket, system) in zip(brackets, systems) {
+            guard let first = system.first, let last = system.last else {
+                Issue.record("A bracket spans no staves")
+                return
+            }
+            // Top staff line of the first staff to bottom staff line of the last.
+            #expect(abs(bracket.y1 - first.topY) < 1e-3)
+            #expect(abs(bracket.y2 - last.bottomY) < 1e-3)
+            // Standing in the indent reserved for it: left of the staves, inside the margin.
+            #expect(bracket.x < first.left)
+            #expect(bracket.x >= config.margins.left)
+        }
+    }
+
+    @Test("The abcLine anchors run down the page")
+    func abcLineAnchorsAreMonotonic() throws {
+        let result = CeolKitParser().parse(canzonettaABC, options: .default)
+        var diagnostics: [Diagnostic] = []
+        let pages = try SVGRenderer(config: config).render(result.score, diagnostics: &diagnostics)
+        for page in try SVGGeometry.pages(from: pages) {
+            let lines = page.systems.compactMap(\.abcLine)
+            #expect(lines.count == page.systems.count, "Some system carries no anchor")
+            #expect(lines == lines.sorted(), "Anchors out of order: \(lines)")
+        }
+    }
+
+    // MARK: - Snapshot
+
+    @Test("The engraved page does not drift")
+    func pageMatchesSnapshot() throws {
+        // Outline data replaced for the reason `IntegrationTests` gives: this snapshot is
+        // about structure and placement, and a few thousand curve coordinates would bury
+        // it.  The outlines are checked against Bravura's own boxes in `OpenTypeFontTests`.
+        let sanitized = try render().svg.replacing(
+            /(<path id="[^"]+" d=")[^"]+"/,
+            with: { "\($0.output.1)<OUTLINE>\"" }
+        )
+        assertSnapshot(of: sanitized, as: .lines)
+    }
+}
+
+/// §14.4 of the ABC v2.2 standard, verbatim.  The backslashes are escaped for Swift: the
+/// music line ends `|\` and the `w:` after it ends `que-sto\`.
+private let canzonettaABC = """
+%abc-2.1
+%%pagewidth      21cm
+%%pageheight     29.7cm
+%%topspace       0.5cm
+%%topmargin      1cm
+%%botmargin      0cm
+%%leftmargin     1cm
+%%rightmargin    1cm
+%%titlespace     0cm
+%%titlefont      Times-Bold 32
+%%subtitlefont   Times-Bold 24
+%%composerfont   Times 16
+%%vocalfont      Times-Roman 14
+%%staffsep       60pt
+%%sysstaffsep    20pt
+%%musicspace     1cm
+%%vocalspace     5pt
+%%measurenb      0
+%%barsperstaff   5
+%%scale          0.7
+X: 1
+T: Canzonetta a tre voci
+C: Claudio Monteverdi (1567-1643)
+M: C
+L: 1/4
+Q: "Andante mosso" 1/4 = 110
+%%score [1 2 3]
+V: 1 clef=treble name="Soprano" sname="A"
+V: 2 clef=treble name="Alto"    sname="T"
+V: 3 clef=bass   name="Tenor"   sname="B" octave=-2
+%%MIDI program 1 75
+%%MIDI program 2 75
+%%MIDI program 3 75
+K: Eb
+% 1 - 4
+[V: 1] |:z4  |z4  |f2ec         |_ddcc        |
+w: Son que-sti~i cre-spi cri-ni~e
+w: Que-sti son gli~oc-chi che mi-
+[V: 2] |:c2BG|AAGc|(F/G/A/B/)c=A|B2AA         |
+w: Son que-sti~i cre-spi cri-ni~e que - - - - sto~il vi-so e
+w: Que-sti son~gli oc-chi che mi-ran - - - - do fi-so mi-
+[V: 3] |:z4  |f2ec|_ddcf        |(B/c/_d/e/)ff|
+w: Son que-sti~i cre-spi cri-ni~e que - - - - sto~il
+w: Que-sti son~gli oc-chi che mi-ran - - - - do
+% 5 - 9
+[V: 1] cAB2     |cAAA |c3B|G2!fermata!Gz ::e4|
+w: que-sto~il vi-so ond' io ri-man-go~uc-ci-so. Deh,
+w: ran-do fi-so, tut-to re-stai con-qui-so.
+[V: 2] AAG2     |AFFF |A3F|=E2!fermata!Ez::c4|
+w: que-sto~il vi-so ond' io ri-man-go~uc-ci-so. Deh,
+w: ran-do fi-so tut-to re-stai con-qui-so.
+[V: 3] (ag/f/e2)|A_ddd|A3B|c2!fermata!cz ::A4|
+w: vi - - - so ond' io ti-man-go~uc-ci-so. Deh,
+w: fi - - - so tut-to re-stai con-qui-so.
+% 10 - 15
+[V: 1] f_dec |B2c2|zAGF  |\\
+w: dim-me-lo ben mi-o, che que-sto\\
+=EFG2          |1F2z2:|2F8|]
+w: sol de-si-o_.
+[V: 2] ABGA  |G2AA|GF=EF |(GF3/2=E//D//E)|1F2z2:|2F8|]
+w: dim-me-lo ben mi-o, che que-sto sol de-si - - - - o_.
+[V: 3] _dBc>d|e2AF|=EFc_d|c4             |1F2z2:|2F8|]
+w: dim-me-lo ben mi-o, che que-sto sol de-si-o_.
+"""

--- a/Tests/CeolKitSVGRendererTests/__Snapshots__/CanzonettaConformanceTests/pageMatchesSnapshot.1.txt
+++ b/Tests/CeolKitSVGRendererTests/__Snapshots__/CanzonettaConformanceTests/pageMatchesSnapshot.1.txt
@@ -1,0 +1,606 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 612 792" width="612" height="792">
+  <defs>
+    <path id="libertinusSerif-g36" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g66" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g79" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g91" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g80" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g70" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g85" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g83" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g87" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g68" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g74" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g36" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g77" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g66" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g86" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g69" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g74" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g80" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g46" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g79" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g85" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g70" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g87" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g83" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g9" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g18" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g22" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g23" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g24" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g14" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g21" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g20" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g10" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g34" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g69" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g78" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g84" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g2261" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g30" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g18" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g17" d="<OUTLINE>"/>
+    <path id="bravura-g18" d="<OUTLINE>"/>
+    <path id="bravura-g19" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g52" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g81" d="<OUTLINE>"/>
+    <path id="bravura-g74" d="<OUTLINE>"/>
+    <path id="bravura-g535" d="<OUTLINE>"/>
+    <path id="bravura-g132" d="<OUTLINE>"/>
+    <path id="bravura-g64" d="<OUTLINE>"/>
+    <path id="bravura-g994" d="<OUTLINE>"/>
+    <path id="bravura-g157" d="<OUTLINE>"/>
+    <path id="bravura-g158" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g77" d="<OUTLINE>"/>
+    <path id="bravura-g536" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g53" d="<OUTLINE>"/>
+    <path id="bravura-g92" d="<OUTLINE>"/>
+    <path id="bravura-g459" d="<OUTLINE>"/>
+    <path id="bravura-g968" d="<OUTLINE>"/>
+    <path id="bravura-g996" d="<OUTLINE>"/>
+    <path id="bravura-g156" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g35" d="<OUTLINE>"/>
+    <path id="bravura-g995" d="<OUTLINE>"/>
+    <path id="bravura-g518" d="<OUTLINE>"/>
+  </defs>
+  <!-- ceolkit-meta: {"page": 1, "anchors": [{"abcLine": 36, "y": 87}, {"abcLine": 36, "y": 135}, {"abcLine": 36, "y": 183}, {"abcLine": 46, "y": 243}, {"abcLine": 46, "y": 291}, {"abcLine": 46, "y": 339}, {"abcLine": 56, "y": 405}, {"abcLine": 56, "y": 453}, {"abcLine": 56, "y": 501}]} -->
+  <use href="#libertinusSerif-g36" xlink:href="#libertinusSerif-g36" transform="translate(227.763 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g66" xlink:href="#libertinusSerif-g66" transform="translate(239.391 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g79" xlink:href="#libertinusSerif-g79" transform="translate(247.617 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g91" xlink:href="#libertinusSerif-g91" transform="translate(257.373 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g80" xlink:href="#libertinusSerif-g80" transform="translate(265.005 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g79" xlink:href="#libertinusSerif-g79" transform="translate(274.077 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g70" xlink:href="#libertinusSerif-g70" transform="translate(283.833 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g85" xlink:href="#libertinusSerif-g85" transform="translate(291.879 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g85" xlink:href="#libertinusSerif-g85" transform="translate(297.567 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g66" xlink:href="#libertinusSerif-g66" transform="translate(303.255 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g66" xlink:href="#libertinusSerif-g66" transform="translate(315.981 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g85" xlink:href="#libertinusSerif-g85" transform="translate(328.707 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g83" xlink:href="#libertinusSerif-g83" transform="translate(334.395 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g70" xlink:href="#libertinusSerif-g70" transform="translate(341.091 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g87" xlink:href="#libertinusSerif-g87" transform="translate(353.637 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g80" xlink:href="#libertinusSerif-g80" transform="translate(362.583 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g68" xlink:href="#libertinusSerif-g68" transform="translate(371.655 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g74" xlink:href="#libertinusSerif-g74" transform="translate(379.359 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerifItalic-g36" xlink:href="#libertinusSerifItalic-g36" transform="translate(425.064 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g77" xlink:href="#libertinusSerifItalic-g77" transform="translate(432.456 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g66" xlink:href="#libertinusSerifItalic-g66" transform="translate(435.648 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g86" xlink:href="#libertinusSerifItalic-g86" transform="translate(441.48 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g69" xlink:href="#libertinusSerifItalic-g69" transform="translate(447.732 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g74" xlink:href="#libertinusSerifItalic-g74" transform="translate(453.6 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g80" xlink:href="#libertinusSerifItalic-g80" transform="translate(456.912 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g46" xlink:href="#libertinusSerifItalic-g46" transform="translate(465.276 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g80" xlink:href="#libertinusSerifItalic-g80" transform="translate(474.924 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g79" xlink:href="#libertinusSerifItalic-g79" transform="translate(480.288 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g85" xlink:href="#libertinusSerifItalic-g85" transform="translate(486.504 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g70" xlink:href="#libertinusSerifItalic-g70" transform="translate(490.188 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g87" xlink:href="#libertinusSerifItalic-g87" transform="translate(495 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g70" xlink:href="#libertinusSerifItalic-g70" transform="translate(500.664 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g83" xlink:href="#libertinusSerifItalic-g83" transform="translate(505.476 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g69" xlink:href="#libertinusSerifItalic-g69" transform="translate(509.76 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g74" xlink:href="#libertinusSerifItalic-g74" transform="translate(515.628 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g9" xlink:href="#libertinusSerifItalic-g9" transform="translate(521.94 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g18" xlink:href="#libertinusSerifItalic-g18" transform="translate(525.612 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g22" xlink:href="#libertinusSerifItalic-g22" transform="translate(530.94 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g23" xlink:href="#libertinusSerifItalic-g23" transform="translate(536.268 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g24" xlink:href="#libertinusSerifItalic-g24" transform="translate(541.596 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g14" xlink:href="#libertinusSerifItalic-g14" transform="translate(546.924 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g18" xlink:href="#libertinusSerifItalic-g18" transform="translate(550.92 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g23" xlink:href="#libertinusSerifItalic-g23" transform="translate(556.248 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g21" xlink:href="#libertinusSerifItalic-g21" transform="translate(561.576 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g20" xlink:href="#libertinusSerifItalic-g20" transform="translate(566.916 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g10" xlink:href="#libertinusSerifItalic-g10" transform="translate(572.244 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g34" xlink:href="#libertinusSerif-g34" transform="translate(36 77.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g79" xlink:href="#libertinusSerif-g79" transform="translate(44.34 77.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g69" xlink:href="#libertinusSerif-g69" transform="translate(50.844 77.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g66" xlink:href="#libertinusSerif-g66" transform="translate(56.916 77.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g79" xlink:href="#libertinusSerif-g79" transform="translate(62.4 77.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g85" xlink:href="#libertinusSerif-g85" transform="translate(68.904 77.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g70" xlink:href="#libertinusSerif-g70" transform="translate(72.696 77.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g78" xlink:href="#libertinusSerif-g78" transform="translate(81.06 77.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g80" xlink:href="#libertinusSerif-g80" transform="translate(90.54 77.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g84" xlink:href="#libertinusSerif-g84" transform="translate(96.588 77.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g84" xlink:href="#libertinusSerif-g84" transform="translate(101.268 77.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g80" xlink:href="#libertinusSerif-g80" transform="translate(105.948 77.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g2261" xlink:href="#libertinusSerif-g2261" transform="translate(114.996 77.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g30" xlink:href="#libertinusSerif-g30" transform="translate(122.796 77.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g18" xlink:href="#libertinusSerif-g18" transform="translate(132.396 77.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g18" xlink:href="#libertinusSerif-g18" transform="translate(137.976 77.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g17" xlink:href="#libertinusSerif-g17" transform="translate(143.556 77.25) scale(0.012 -0.012)"/>
+  <line x1="96.252" y1="87" x2="576" y2="87" stroke="black" stroke-width="0.78"/>
+  <line x1="96.252" y1="93" x2="576" y2="93" stroke="black" stroke-width="0.78"/>
+  <line x1="96.252" y1="99" x2="576" y2="99" stroke="black" stroke-width="0.78"/>
+  <line x1="96.252" y1="105" x2="576" y2="105" stroke="black" stroke-width="0.78"/>
+  <line x1="96.252" y1="111" x2="576" y2="111" stroke="black" stroke-width="0.78"/>
+  <line x1="96.252" y1="87" x2="96.252" y2="207" stroke="black" stroke-width="0.78"/>
+  <line x1="84.096" y1="87" x2="84.096" y2="207" stroke="black" stroke-width="3"/>
+  <use href="#bravura-g18" xlink:href="#bravura-g18" transform="translate(82.596 87) scale(0.024 -0.024)"/>
+  <use href="#bravura-g19" xlink:href="#bravura-g19" transform="translate(82.596 207) scale(0.024 -0.024)"/>
+  <use href="#libertinusSerif-g52" xlink:href="#libertinusSerif-g52" transform="translate(36 102.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g80" xlink:href="#libertinusSerif-g80" transform="translate(41.82 102.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g81" xlink:href="#libertinusSerif-g81" transform="translate(47.868 102.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g83" xlink:href="#libertinusSerif-g83" transform="translate(54.096 102.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g66" xlink:href="#libertinusSerif-g66" transform="translate(58.56 102.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g79" xlink:href="#libertinusSerif-g79" transform="translate(64.044 102.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g80" xlink:href="#libertinusSerif-g80" transform="translate(70.548 102.948) scale(0.012 -0.012)"/>
+  <use href="#bravura-g74" xlink:href="#bravura-g74" transform="translate(97.752 105) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(115.356 99) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(121.932 90) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(128.508 102) scale(0.024 -0.024)"/>
+  <use href="#bravura-g132" xlink:href="#bravura-g132" transform="translate(138.084 99) scale(0.024 -0.024)"/>
+  <line x1="159.192" y1="87" x2="159.192" y2="111" stroke="black" stroke-width="0.96"/>
+  <line x1="163.992" y1="87" x2="163.992" y2="111" stroke="black" stroke-width="3"/>
+  <use href="#bravura-g64" xlink:href="#bravura-g64" transform="translate(164.952 102) scale(0.024 -0.024)"/>
+  <use href="#bravura-g64" xlink:href="#bravura-g64" transform="translate(164.952 96) scale(0.024 -0.024)"/>
+  <line x1="252.594" y1="87" x2="252.594" y2="111" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g994" xlink:href="#bravura-g994" transform="translate(174.432 93) scale(0.024 -0.024)"/>
+  <line x1="344.212" y1="87" x2="344.212" y2="111" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g994" xlink:href="#bravura-g994" transform="translate(259.674 93) scale(0.024 -0.024)"/>
+  <line x1="459.008" y1="87" x2="459.008" y2="111" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(351.292 87) scale(0.024 -0.024)"/>
+  <line x1="351.292" y1="87" x2="351.292" y2="108" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(392.865 90) scale(0.024 -0.024)"/>
+  <line x1="392.865" y1="90" x2="392.865" y2="111" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(422.262 96) scale(0.024 -0.024)"/>
+  <line x1="422.262" y1="96" x2="422.262" y2="117" stroke="black" stroke-width="0.72"/>
+  <line x1="576" y1="87" x2="576" y2="111" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(466.088 93) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(459.944 93) scale(0.024 -0.024)"/>
+  <line x1="466.088" y1="93" x2="466.088" y2="114" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(500.987 93) scale(0.024 -0.024)"/>
+  <line x1="500.987" y1="93" x2="500.987" y2="114" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(524.068 96) scale(0.024 -0.024)"/>
+  <line x1="524.068" y1="96" x2="524.068" y2="117" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(547.149 96) scale(0.024 -0.024)"/>
+  <line x1="547.149" y1="96" x2="547.149" y2="117" stroke="black" stroke-width="0.72"/>
+  <line x1="96.252" y1="135" x2="576" y2="135" stroke="black" stroke-width="0.78"/>
+  <line x1="96.252" y1="141" x2="576" y2="141" stroke="black" stroke-width="0.78"/>
+  <line x1="96.252" y1="147" x2="576" y2="147" stroke="black" stroke-width="0.78"/>
+  <line x1="96.252" y1="153" x2="576" y2="153" stroke="black" stroke-width="0.78"/>
+  <line x1="96.252" y1="159" x2="576" y2="159" stroke="black" stroke-width="0.78"/>
+  <use href="#libertinusSerif-g34" xlink:href="#libertinusSerif-g34" transform="translate(55.248 150.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g77" xlink:href="#libertinusSerif-g77" transform="translate(63.588 150.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g85" xlink:href="#libertinusSerif-g85" transform="translate(66.756 150.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g80" xlink:href="#libertinusSerif-g80" transform="translate(70.548 150.948) scale(0.012 -0.012)"/>
+  <use href="#bravura-g74" xlink:href="#bravura-g74" transform="translate(97.752 153) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(115.356 147) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(121.932 138) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(128.508 150) scale(0.024 -0.024)"/>
+  <use href="#bravura-g132" xlink:href="#bravura-g132" transform="translate(138.084 147) scale(0.024 -0.024)"/>
+  <line x1="159.192" y1="135" x2="159.192" y2="159" stroke="black" stroke-width="0.96"/>
+  <line x1="163.992" y1="135" x2="163.992" y2="159" stroke="black" stroke-width="3"/>
+  <use href="#bravura-g64" xlink:href="#bravura-g64" transform="translate(164.952 150) scale(0.024 -0.024)"/>
+  <use href="#bravura-g64" xlink:href="#bravura-g64" transform="translate(164.952 144) scale(0.024 -0.024)"/>
+  <line x1="252.594" y1="135" x2="252.594" y2="159" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(174.432 144) scale(0.024 -0.024)"/>
+  <line x1="174.432" y1="144" x2="174.432" y2="165" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(204.599 147) scale(0.024 -0.024)"/>
+  <line x1="211.679" y1="126" x2="211.679" y2="147" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(225.93 153) scale(0.024 -0.024)"/>
+  <line x1="233.01" y1="132" x2="233.01" y2="153" stroke="black" stroke-width="0.72"/>
+  <line x1="344.212" y1="135" x2="344.212" y2="159" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(259.674 150) scale(0.024 -0.024)"/>
+  <line x1="266.754" y1="129" x2="266.754" y2="150" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(279.565 150) scale(0.024 -0.024)"/>
+  <line x1="286.645" y1="129" x2="286.645" y2="150" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(299.457 153) scale(0.024 -0.024)"/>
+  <line x1="306.537" y1="132" x2="306.537" y2="153" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(319.348 144) scale(0.024 -0.024)"/>
+  <line x1="319.348" y1="144" x2="319.348" y2="165" stroke="black" stroke-width="0.72"/>
+  <line x1="459.008" y1="135" x2="459.008" y2="159" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(351.292 156) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(365.205 153) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(379.118 150) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(393.032 147) scale(0.024 -0.024)"/>
+  <line x1="358.372" y1="126" x2="358.372" y2="156" stroke="black" stroke-width="0.72"/>
+  <line x1="372.285" y1="126" x2="372.285" y2="153" stroke="black" stroke-width="0.72"/>
+  <line x1="386.198" y1="126" x2="386.198" y2="150" stroke="black" stroke-width="0.72"/>
+  <line x1="400.112" y1="126" x2="400.112" y2="147" stroke="black" stroke-width="0.72"/>
+  <line x1="358.372" y1="126" x2="400.112" y2="126" stroke="black" stroke-width="3"/>
+  <path d="M 358.372 162.3 C 369.925 167.28 381.478 158.28 393.032 153.3 L 393.032 152.7 C 381.478 156.72 369.925 165.72 358.372 161.7 Z" fill="black" stroke="none"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(406.945 144) scale(0.024 -0.024)"/>
+  <line x1="406.945" y1="144" x2="406.945" y2="165" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(426.621 150) scale(0.024 -0.024)"/>
+  <use href="#bravura-g536" xlink:href="#bravura-g536" transform="translate(421.869 150) scale(0.024 -0.024)"/>
+  <line x1="433.701" y1="129" x2="433.701" y2="150" stroke="black" stroke-width="0.72"/>
+  <line x1="576" y1="135" x2="576" y2="159" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(466.088 147) scale(0.024 -0.024)"/>
+  <line x1="473.168" y1="126" x2="473.168" y2="147" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(508.509 150) scale(0.024 -0.024)"/>
+  <line x1="515.589" y1="129" x2="515.589" y2="150" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(538.505 150) scale(0.024 -0.024)"/>
+  <line x1="545.585" y1="129" x2="545.585" y2="150" stroke="black" stroke-width="0.72"/>
+  <line x1="96.252" y1="183" x2="576" y2="183" stroke="black" stroke-width="0.78"/>
+  <line x1="96.252" y1="189" x2="576" y2="189" stroke="black" stroke-width="0.78"/>
+  <line x1="96.252" y1="195" x2="576" y2="195" stroke="black" stroke-width="0.78"/>
+  <line x1="96.252" y1="201" x2="576" y2="201" stroke="black" stroke-width="0.78"/>
+  <line x1="96.252" y1="207" x2="576" y2="207" stroke="black" stroke-width="0.78"/>
+  <use href="#libertinusSerif-g53" xlink:href="#libertinusSerif-g53" transform="translate(47.052 198.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g70" xlink:href="#libertinusSerif-g70" transform="translate(54.216 198.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g79" xlink:href="#libertinusSerif-g79" transform="translate(59.58 198.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g80" xlink:href="#libertinusSerif-g80" transform="translate(66.084 198.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g83" xlink:href="#libertinusSerif-g83" transform="translate(72.132 198.948) scale(0.012 -0.012)"/>
+  <use href="#bravura-g92" xlink:href="#bravura-g92" transform="translate(97.752 189) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(115.788 195) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(122.364 186) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(128.94 198) scale(0.024 -0.024)"/>
+  <use href="#bravura-g132" xlink:href="#bravura-g132" transform="translate(138.516 195) scale(0.024 -0.024)"/>
+  <line x1="159.192" y1="183" x2="159.192" y2="207" stroke="black" stroke-width="0.96"/>
+  <line x1="163.992" y1="183" x2="163.992" y2="207" stroke="black" stroke-width="3"/>
+  <use href="#bravura-g64" xlink:href="#bravura-g64" transform="translate(164.952 198) scale(0.024 -0.024)"/>
+  <use href="#bravura-g64" xlink:href="#bravura-g64" transform="translate(164.952 192) scale(0.024 -0.024)"/>
+  <line x1="252.594" y1="183" x2="252.594" y2="207" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g994" xlink:href="#bravura-g994" transform="translate(174.432 189) scale(0.024 -0.024)"/>
+  <line x1="344.212" y1="183" x2="344.212" y2="207" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(259.674 183) scale(0.024 -0.024)"/>
+  <line x1="259.674" y1="183" x2="259.674" y2="204" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(292.302 186) scale(0.024 -0.024)"/>
+  <line x1="292.302" y1="186" x2="292.302" y2="207" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(315.373 192) scale(0.024 -0.024)"/>
+  <line x1="315.373" y1="192" x2="315.373" y2="213" stroke="black" stroke-width="0.72"/>
+  <line x1="459.008" y1="183" x2="459.008" y2="207" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(351.292 189) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(345.148 189) scale(0.024 -0.024)"/>
+  <line x1="351.292" y1="189" x2="351.292" y2="210" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(385.493 189) scale(0.024 -0.024)"/>
+  <line x1="385.493" y1="189" x2="385.493" y2="210" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(408.113 192) scale(0.024 -0.024)"/>
+  <line x1="408.113" y1="192" x2="408.113" y2="213" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(430.733 183) scale(0.024 -0.024)"/>
+  <line x1="430.733" y1="183" x2="430.733" y2="204" stroke="black" stroke-width="0.72"/>
+  <line x1="576" y1="183" x2="576" y2="207" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(466.088 195) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(479.99 192) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(493.893 189) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(487.749 189) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(517.861 186) scale(0.024 -0.024)"/>
+  <line x1="473.168" y1="174" x2="473.168" y2="195" stroke="black" stroke-width="0.72"/>
+  <line x1="479.99" y1="174" x2="479.99" y2="192" stroke="black" stroke-width="0.72"/>
+  <line x1="493.893" y1="174" x2="493.893" y2="189" stroke="black" stroke-width="0.72"/>
+  <line x1="517.861" y1="174" x2="517.861" y2="186" stroke="black" stroke-width="0.72"/>
+  <line x1="473.168" y1="174" x2="517.861" y2="174" stroke="black" stroke-width="3"/>
+  <path d="M 473.168 201.3 C 488.066 206.28 502.963 197.28 517.861 192.3 L 517.861 191.7 C 502.963 195.72 488.066 204.72 473.168 200.7 Z" fill="black" stroke="none"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(531.763 183) scale(0.024 -0.024)"/>
+  <line x1="531.763" y1="183" x2="531.763" y2="204" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(551.424 183) scale(0.024 -0.024)"/>
+  <line x1="551.424" y1="183" x2="551.424" y2="204" stroke="black" stroke-width="0.72"/>
+  <line x1="63.996" y1="243" x2="576" y2="243" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="249" x2="576" y2="249" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="255" x2="576" y2="255" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="261" x2="576" y2="261" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="267" x2="576" y2="267" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="243" x2="63.996" y2="369" stroke="black" stroke-width="0.78"/>
+  <line x1="51.84" y1="243" x2="51.84" y2="369" stroke="black" stroke-width="3"/>
+  <use href="#bravura-g18" xlink:href="#bravura-g18" transform="translate(50.34 243) scale(0.024 -0.024)"/>
+  <use href="#bravura-g19" xlink:href="#bravura-g19" transform="translate(50.34 369) scale(0.024 -0.024)"/>
+  <use href="#libertinusSerif-g34" xlink:href="#libertinusSerif-g34" transform="translate(36 258.948) scale(0.012 -0.012)"/>
+  <use href="#bravura-g74" xlink:href="#bravura-g74" transform="translate(65.496 261) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(83.1 255) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(89.676 246) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(96.252 258) scale(0.024 -0.024)"/>
+  <line x1="208.428" y1="243" x2="208.428" y2="267" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(117.42 252) scale(0.024 -0.024)"/>
+  <line x1="117.42" y1="252" x2="117.42" y2="273" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(142.257 258) scale(0.024 -0.024)"/>
+  <line x1="149.337" y1="237" x2="149.337" y2="258" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(167.094 255) scale(0.024 -0.024)"/>
+  <line x1="174.174" y1="234" x2="174.174" y2="255" stroke="black" stroke-width="0.72"/>
+  <line x1="320.879" y1="243" x2="320.879" y2="267" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(215.508 252) scale(0.024 -0.024)"/>
+  <line x1="215.508" y1="252" x2="215.508" y2="273" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(240.301 258) scale(0.024 -0.024)"/>
+  <line x1="247.381" y1="237" x2="247.381" y2="258" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(265.095 258) scale(0.024 -0.024)"/>
+  <line x1="272.175" y1="237" x2="272.175" y2="258" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(289.888 258) scale(0.024 -0.024)"/>
+  <line x1="296.968" y1="237" x2="296.968" y2="258" stroke="black" stroke-width="0.72"/>
+  <line x1="395.931" y1="243" x2="395.931" y2="267" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(327.959 252) scale(0.024 -0.024)"/>
+  <use href="#bravura-g459" xlink:href="#bravura-g459" transform="translate(336.455 252) scale(0.024 -0.024)"/>
+  <line x1="327.959" y1="252" x2="327.959" y2="273" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(367.439 255) scale(0.024 -0.024)"/>
+  <line x1="374.519" y1="234" x2="374.519" y2="255" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g64" xlink:href="#bravura-g64" transform="translate(493.881 258) scale(0.024 -0.024)"/>
+  <use href="#bravura-g64" xlink:href="#bravura-g64" transform="translate(493.881 252) scale(0.024 -0.024)"/>
+  <line x1="497.241" y1="243" x2="497.241" y2="267" stroke="black" stroke-width="0.96"/>
+  <line x1="502.041" y1="243" x2="502.041" y2="267" stroke="black" stroke-width="3"/>
+  <use href="#bravura-g64" xlink:href="#bravura-g64" transform="translate(503.001 258) scale(0.024 -0.024)"/>
+  <use href="#bravura-g64" xlink:href="#bravura-g64" transform="translate(503.001 252) scale(0.024 -0.024)"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(403.011 261) scale(0.024 -0.024)"/>
+  <line x1="410.091" y1="240" x2="410.091" y2="261" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(437.471 261) scale(0.024 -0.024)"/>
+  <use href="#bravura-g968" xlink:href="#bravura-g968" transform="translate(433.715 237) scale(0.024 -0.024)"/>
+  <line x1="444.551" y1="240" x2="444.551" y2="261" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g996" xlink:href="#bravura-g996" transform="translate(461.837 255) scale(0.024 -0.024)"/>
+  <line x1="576" y1="243" x2="576" y2="267" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g156" xlink:href="#bravura-g156" transform="translate(517.281 246) scale(0.024 -0.024)"/>
+  <line x1="63.996" y1="291" x2="576" y2="291" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="297" x2="576" y2="297" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="303" x2="576" y2="303" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="309" x2="576" y2="309" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="315" x2="576" y2="315" stroke="black" stroke-width="0.78"/>
+  <use href="#libertinusSerif-g53" xlink:href="#libertinusSerif-g53" transform="translate(37.176 306.948) scale(0.012 -0.012)"/>
+  <use href="#bravura-g74" xlink:href="#bravura-g74" transform="translate(65.496 309) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(83.1 303) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(89.676 294) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(96.252 306) scale(0.024 -0.024)"/>
+  <line x1="208.428" y1="291" x2="208.428" y2="315" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(117.42 306) scale(0.024 -0.024)"/>
+  <line x1="124.5" y1="285" x2="124.5" y2="306" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(142.257 306) scale(0.024 -0.024)"/>
+  <line x1="149.337" y1="285" x2="149.337" y2="306" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(167.094 309) scale(0.024 -0.024)"/>
+  <line x1="174.174" y1="288" x2="174.174" y2="309" stroke="black" stroke-width="0.72"/>
+  <line x1="320.879" y1="291" x2="320.879" y2="315" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(215.508 306) scale(0.024 -0.024)"/>
+  <line x1="222.588" y1="285" x2="222.588" y2="306" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(240.301 312) scale(0.024 -0.024)"/>
+  <line x1="247.381" y1="291" x2="247.381" y2="312" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(265.095 312) scale(0.024 -0.024)"/>
+  <line x1="272.175" y1="291" x2="272.175" y2="312" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(289.888 312) scale(0.024 -0.024)"/>
+  <line x1="296.968" y1="291" x2="296.968" y2="312" stroke="black" stroke-width="0.72"/>
+  <line x1="395.931" y1="291" x2="395.931" y2="315" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(327.959 306) scale(0.024 -0.024)"/>
+  <use href="#bravura-g459" xlink:href="#bravura-g459" transform="translate(336.455 306) scale(0.024 -0.024)"/>
+  <line x1="335.039" y1="285" x2="335.039" y2="306" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(367.439 312) scale(0.024 -0.024)"/>
+  <line x1="374.519" y1="291" x2="374.519" y2="312" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g64" xlink:href="#bravura-g64" transform="translate(493.881 306) scale(0.024 -0.024)"/>
+  <use href="#bravura-g64" xlink:href="#bravura-g64" transform="translate(493.881 300) scale(0.024 -0.024)"/>
+  <line x1="497.241" y1="291" x2="497.241" y2="315" stroke="black" stroke-width="0.96"/>
+  <line x1="502.041" y1="291" x2="502.041" y2="315" stroke="black" stroke-width="3"/>
+  <use href="#bravura-g64" xlink:href="#bravura-g64" transform="translate(503.001 306) scale(0.024 -0.024)"/>
+  <use href="#bravura-g64" xlink:href="#bravura-g64" transform="translate(503.001 300) scale(0.024 -0.024)"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(403.011 315) scale(0.024 -0.024)"/>
+  <use href="#bravura-g536" xlink:href="#bravura-g536" transform="translate(398.259 315) scale(0.024 -0.024)"/>
+  <line x1="410.091" y1="294" x2="410.091" y2="315" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(443.203 315) scale(0.024 -0.024)"/>
+  <use href="#bravura-g968" xlink:href="#bravura-g968" transform="translate(439.447 285) scale(0.024 -0.024)"/>
+  <line x1="450.283" y1="294" x2="450.283" y2="315" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g996" xlink:href="#bravura-g996" transform="translate(465.406 303) scale(0.024 -0.024)"/>
+  <line x1="576" y1="291" x2="576" y2="315" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g156" xlink:href="#bravura-g156" transform="translate(517.281 300) scale(0.024 -0.024)"/>
+  <line x1="63.996" y1="345" x2="576" y2="345" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="351" x2="576" y2="351" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="357" x2="576" y2="357" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="363" x2="576" y2="363" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="369" x2="576" y2="369" stroke="black" stroke-width="0.78"/>
+  <use href="#libertinusSerif-g35" xlink:href="#libertinusSerif-g35" transform="translate(37.284 360.948) scale(0.012 -0.012)"/>
+  <use href="#bravura-g92" xlink:href="#bravura-g92" transform="translate(65.496 351) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(83.532 357) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(90.108 348) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(96.684 360) scale(0.024 -0.024)"/>
+  <line x1="208.428" y1="345" x2="208.428" y2="369" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(117.42 339) scale(0.024 -0.024)"/>
+  <line x1="117.42" y1="339" x2="117.42" y2="360" stroke="black" stroke-width="0.72"/>
+  <line x1="115.02" y1="339" x2="126.9" y2="339" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(139.735 342) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(155.513 345) scale(0.024 -0.024)"/>
+  <line x1="139.735" y1="342" x2="139.735" y2="366" stroke="black" stroke-width="0.72"/>
+  <line x1="155.513" y1="345" x2="155.513" y2="366" stroke="black" stroke-width="0.72"/>
+  <line x1="139.735" y1="366" x2="155.513" y2="366" stroke="black" stroke-width="3"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(171.292 348) scale(0.024 -0.024)"/>
+  <line x1="171.292" y1="348" x2="171.292" y2="369" stroke="black" stroke-width="0.72"/>
+  <path d="M 124.5 333.3 C 140.097 329.28 155.695 338.28 171.292 342.3 L 171.292 341.7 C 155.695 336.72 140.097 327.72 124.5 332.7 Z" fill="black" stroke="none"/>
+  <line x1="320.879" y1="345" x2="320.879" y2="369" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(215.508 360) scale(0.024 -0.024)"/>
+  <line x1="222.588" y1="339" x2="222.588" y2="360" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(237.636 351) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(231.492 351) scale(0.024 -0.024)"/>
+  <line x1="237.636" y1="351" x2="237.636" y2="372" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(271.092 351) scale(0.024 -0.024)"/>
+  <line x1="271.092" y1="351" x2="271.092" y2="372" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(293.22 351) scale(0.024 -0.024)"/>
+  <line x1="293.22" y1="351" x2="293.22" y2="372" stroke="black" stroke-width="0.72"/>
+  <line x1="395.931" y1="345" x2="395.931" y2="369" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(327.959 360) scale(0.024 -0.024)"/>
+  <use href="#bravura-g459" xlink:href="#bravura-g459" transform="translate(336.455 360) scale(0.024 -0.024)"/>
+  <line x1="335.039" y1="339" x2="335.039" y2="360" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(367.439 357) scale(0.024 -0.024)"/>
+  <line x1="374.519" y1="336" x2="374.519" y2="357" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g64" xlink:href="#bravura-g64" transform="translate(493.881 360) scale(0.024 -0.024)"/>
+  <use href="#bravura-g64" xlink:href="#bravura-g64" transform="translate(493.881 354) scale(0.024 -0.024)"/>
+  <line x1="497.241" y1="345" x2="497.241" y2="369" stroke="black" stroke-width="0.96"/>
+  <line x1="502.041" y1="345" x2="502.041" y2="369" stroke="black" stroke-width="3"/>
+  <use href="#bravura-g64" xlink:href="#bravura-g64" transform="translate(503.001 360) scale(0.024 -0.024)"/>
+  <use href="#bravura-g64" xlink:href="#bravura-g64" transform="translate(503.001 354) scale(0.024 -0.024)"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(403.011 354) scale(0.024 -0.024)"/>
+  <line x1="403.011" y1="354" x2="403.011" y2="375" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(437.471 354) scale(0.024 -0.024)"/>
+  <use href="#bravura-g968" xlink:href="#bravura-g968" transform="translate(433.715 339) scale(0.024 -0.024)"/>
+  <line x1="437.471" y1="354" x2="437.471" y2="375" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g996" xlink:href="#bravura-g996" transform="translate(461.837 357) scale(0.024 -0.024)"/>
+  <line x1="576" y1="345" x2="576" y2="369" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g156" xlink:href="#bravura-g156" transform="translate(517.281 360) scale(0.024 -0.024)"/>
+  <line x1="63.996" y1="405" x2="462.994" y2="405" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="411" x2="462.994" y2="411" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="417" x2="462.994" y2="417" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="423" x2="462.994" y2="423" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="429" x2="462.994" y2="429" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="405" x2="63.996" y2="525" stroke="black" stroke-width="0.78"/>
+  <line x1="51.84" y1="405" x2="51.84" y2="525" stroke="black" stroke-width="3"/>
+  <use href="#bravura-g18" xlink:href="#bravura-g18" transform="translate(50.34 405) scale(0.024 -0.024)"/>
+  <use href="#bravura-g19" xlink:href="#bravura-g19" transform="translate(50.34 525) scale(0.024 -0.024)"/>
+  <use href="#libertinusSerif-g34" xlink:href="#libertinusSerif-g34" transform="translate(36 420.948) scale(0.012 -0.012)"/>
+  <use href="#bravura-g74" xlink:href="#bravura-g74" transform="translate(65.496 423) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(83.1 417) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(89.676 408) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(96.252 420) scale(0.024 -0.024)"/>
+  <line x1="174.564" y1="405" x2="174.564" y2="429" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(117.42 405) scale(0.024 -0.024)"/>
+  <line x1="117.42" y1="405" x2="117.42" y2="426" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(129.42 411) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(123.276 411) scale(0.024 -0.024)"/>
+  <line x1="129.42" y1="411" x2="129.42" y2="432" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(147.564 408) scale(0.024 -0.024)"/>
+  <line x1="147.564" y1="408" x2="147.564" y2="429" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(159.564 414) scale(0.024 -0.024)"/>
+  <line x1="159.564" y1="414" x2="159.564" y2="435" stroke="black" stroke-width="0.72"/>
+  <line x1="225.615" y1="405" x2="225.615" y2="429" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(181.644 417) scale(0.024 -0.024)"/>
+  <line x1="188.724" y1="396" x2="188.724" y2="417" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(201.844 414) scale(0.024 -0.024)"/>
+  <line x1="201.844" y1="414" x2="201.844" y2="435" stroke="black" stroke-width="0.72"/>
+  <line x1="294.591" y1="405" x2="294.591" y2="429" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g996" xlink:href="#bravura-g996" transform="translate(232.695 417) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(247.258 420) scale(0.024 -0.024)"/>
+  <line x1="254.338" y1="399" x2="254.338" y2="420" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(261.822 423) scale(0.024 -0.024)"/>
+  <line x1="268.902" y1="402" x2="268.902" y2="423" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(276.386 426) scale(0.024 -0.024)"/>
+  <line x1="283.466" y1="405" x2="283.466" y2="426" stroke="black" stroke-width="0.72"/>
+  <line x1="365.352" y1="405" x2="365.352" y2="429" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(301.671 429) scale(0.024 -0.024)"/>
+  <use href="#bravura-g536" xlink:href="#bravura-g536" transform="translate(296.919 429) scale(0.024 -0.024)"/>
+  <line x1="308.751" y1="408" x2="308.751" y2="429" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(323.566 426) scale(0.024 -0.024)"/>
+  <line x1="330.646" y1="405" x2="330.646" y2="426" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(339.25 423) scale(0.024 -0.024)"/>
+  <line x1="346.33" y1="402" x2="346.33" y2="423" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g64" xlink:href="#bravura-g64" transform="translate(406.013 420) scale(0.024 -0.024)"/>
+  <use href="#bravura-g64" xlink:href="#bravura-g64" transform="translate(406.013 414) scale(0.024 -0.024)"/>
+  <line x1="409.373" y1="405" x2="409.373" y2="429" stroke="black" stroke-width="0.96"/>
+  <line x1="414.173" y1="405" x2="414.173" y2="429" stroke="black" stroke-width="3"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(372.432 426) scale(0.024 -0.024)"/>
+  <line x1="379.512" y1="405" x2="379.512" y2="426" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g995" xlink:href="#bravura-g995" transform="translate(389.402 417) scale(0.024 -0.024)"/>
+  <line x1="458.194" y1="405" x2="458.194" y2="429" stroke="black" stroke-width="0.96"/>
+  <line x1="462.994" y1="405" x2="462.994" y2="429" stroke="black" stroke-width="3"/>
+  <use href="#bravura-g156" xlink:href="#bravura-g156" transform="translate(421.253 426) scale(0.024 -0.024)"/>
+  <line x1="63.996" y1="453" x2="462.994" y2="453" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="459" x2="462.994" y2="459" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="465" x2="462.994" y2="465" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="471" x2="462.994" y2="471" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="477" x2="462.994" y2="477" stroke="black" stroke-width="0.78"/>
+  <use href="#libertinusSerif-g53" xlink:href="#libertinusSerif-g53" transform="translate(37.176 468.948) scale(0.012 -0.012)"/>
+  <use href="#bravura-g74" xlink:href="#bravura-g74" transform="translate(65.496 471) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(83.1 465) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(89.676 456) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(96.252 468) scale(0.024 -0.024)"/>
+  <line x1="174.564" y1="453" x2="174.564" y2="477" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(117.42 468) scale(0.024 -0.024)"/>
+  <line x1="124.5" y1="447" x2="124.5" y2="468" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(130.866 465) scale(0.024 -0.024)"/>
+  <line x1="137.946" y1="444" x2="137.946" y2="465" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(144.311 471) scale(0.024 -0.024)"/>
+  <line x1="151.391" y1="450" x2="151.391" y2="471" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(157.757 468) scale(0.024 -0.024)"/>
+  <line x1="164.837" y1="447" x2="164.837" y2="468" stroke="black" stroke-width="0.72"/>
+  <line x1="225.615" y1="453" x2="225.615" y2="477" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(181.644 471) scale(0.024 -0.024)"/>
+  <line x1="188.724" y1="450" x2="188.724" y2="471" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(198.615 468) scale(0.024 -0.024)"/>
+  <line x1="205.695" y1="447" x2="205.695" y2="468" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(210.615 468) scale(0.024 -0.024)"/>
+  <line x1="217.695" y1="447" x2="217.695" y2="468" stroke="black" stroke-width="0.72"/>
+  <line x1="294.591" y1="453" x2="294.591" y2="477" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(232.695 471) scale(0.024 -0.024)"/>
+  <line x1="239.775" y1="450" x2="239.775" y2="471" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(246.017 474) scale(0.024 -0.024)"/>
+  <line x1="253.097" y1="453" x2="253.097" y2="474" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(259.339 477) scale(0.024 -0.024)"/>
+  <use href="#bravura-g536" xlink:href="#bravura-g536" transform="translate(254.587 477) scale(0.024 -0.024)"/>
+  <line x1="266.419" y1="456" x2="266.419" y2="477" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(277.938 474) scale(0.024 -0.024)"/>
+  <line x1="285.018" y1="453" x2="285.018" y2="474" stroke="black" stroke-width="0.72"/>
+  <line x1="365.352" y1="453" x2="365.352" y2="477" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(301.671 471) scale(0.024 -0.024)"/>
+  <line x1="308.751" y1="450" x2="308.751" y2="471" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(313.671 474) scale(0.024 -0.024)"/>
+  <use href="#bravura-g459" xlink:href="#bravura-g459" transform="translate(322.167 474) scale(0.024 -0.024)"/>
+  <line x1="320.751" y1="453" x2="320.751" y2="474" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(328.368 477) scale(0.024 -0.024)"/>
+  <use href="#bravura-g536" xlink:href="#bravura-g536" transform="translate(323.616 477) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(341.736 480) scale(0.024 -0.024)"/>
+  <line x1="335.448" y1="456" x2="335.448" y2="477" stroke="black" stroke-width="0.72"/>
+  <line x1="348.816" y1="456" x2="348.816" y2="480" stroke="black" stroke-width="0.72"/>
+  <line x1="335.448" y1="456" x2="348.816" y2="456" stroke="black" stroke-width="3"/>
+  <line x1="335.448" y1="460.5" x2="348.816" y2="460.5" stroke="black" stroke-width="3"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(350.352 477) scale(0.024 -0.024)"/>
+  <line x1="357.432" y1="456" x2="357.432" y2="477" stroke="black" stroke-width="0.72"/>
+  <path d="M 308.751 477.3 C 322.618 482.28 336.485 488.28 350.352 483.3 L 350.352 482.7 C 336.485 486.72 322.618 480.72 308.751 476.7 Z" fill="black" stroke="none"/>
+  <use href="#bravura-g64" xlink:href="#bravura-g64" transform="translate(406.013 468) scale(0.024 -0.024)"/>
+  <use href="#bravura-g64" xlink:href="#bravura-g64" transform="translate(406.013 462) scale(0.024 -0.024)"/>
+  <line x1="409.373" y1="453" x2="409.373" y2="477" stroke="black" stroke-width="0.96"/>
+  <line x1="414.173" y1="453" x2="414.173" y2="477" stroke="black" stroke-width="3"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(372.432 474) scale(0.024 -0.024)"/>
+  <line x1="379.512" y1="453" x2="379.512" y2="474" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g995" xlink:href="#bravura-g995" transform="translate(389.402 465) scale(0.024 -0.024)"/>
+  <line x1="458.194" y1="453" x2="458.194" y2="477" stroke="black" stroke-width="0.96"/>
+  <line x1="462.994" y1="453" x2="462.994" y2="477" stroke="black" stroke-width="3"/>
+  <use href="#bravura-g156" xlink:href="#bravura-g156" transform="translate(421.253 474) scale(0.024 -0.024)"/>
+  <line x1="63.996" y1="501" x2="462.994" y2="501" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="507" x2="462.994" y2="507" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="513" x2="462.994" y2="513" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="519" x2="462.994" y2="519" stroke="black" stroke-width="0.78"/>
+  <line x1="63.996" y1="525" x2="462.994" y2="525" stroke="black" stroke-width="0.78"/>
+  <use href="#libertinusSerif-g35" xlink:href="#libertinusSerif-g35" transform="translate(37.284 516.948) scale(0.012 -0.012)"/>
+  <use href="#bravura-g92" xlink:href="#bravura-g92" transform="translate(65.496 507) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(83.532 513) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(90.108 504) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(96.684 516) scale(0.024 -0.024)"/>
+  <line x1="174.564" y1="501" x2="174.564" y2="525" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(117.42 507) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(111.276 507) scale(0.024 -0.024)"/>
+  <line x1="117.42" y1="507" x2="117.42" y2="528" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(135.827 513) scale(0.024 -0.024)"/>
+  <line x1="142.907" y1="492" x2="142.907" y2="513" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(148.002 510) scale(0.024 -0.024)"/>
+  <use href="#bravura-g459" xlink:href="#bravura-g459" transform="translate(156.498 510) scale(0.024 -0.024)"/>
+  <line x1="148.002" y1="510" x2="148.002" y2="531" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(162.912 507) scale(0.024 -0.024)"/>
+  <line x1="162.912" y1="507" x2="162.912" y2="528" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g518" xlink:href="#bravura-g518" transform="translate(162.912 528) scale(0.024 -0.024)"/>
+  <line x1="225.615" y1="501" x2="225.615" y2="525" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(181.644 504) scale(0.024 -0.024)"/>
+  <line x1="181.644" y1="504" x2="181.644" y2="525" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(198.615 516) scale(0.024 -0.024)"/>
+  <line x1="205.695" y1="495" x2="205.695" y2="516" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(210.615 522) scale(0.024 -0.024)"/>
+  <line x1="217.695" y1="501" x2="217.695" y2="522" stroke="black" stroke-width="0.72"/>
+  <line x1="294.591" y1="501" x2="294.591" y2="525" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(232.695 525) scale(0.024 -0.024)"/>
+  <use href="#bravura-g536" xlink:href="#bravura-g536" transform="translate(227.943 525) scale(0.024 -0.024)"/>
+  <line x1="239.775" y1="504" x2="239.775" y2="525" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(249.447 522) scale(0.024 -0.024)"/>
+  <line x1="256.527" y1="501" x2="256.527" y2="522" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(261.447 510) scale(0.024 -0.024)"/>
+  <line x1="261.447" y1="510" x2="261.447" y2="531" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(273.447 507) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(267.303 507) scale(0.024 -0.024)"/>
+  <line x1="273.447" y1="507" x2="273.447" y2="528" stroke="black" stroke-width="0.72"/>
+  <line x1="365.352" y1="501" x2="365.352" y2="525" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g156" xlink:href="#bravura-g156" transform="translate(301.671 510) scale(0.024 -0.024)"/>
+  <use href="#bravura-g64" xlink:href="#bravura-g64" transform="translate(406.013 516) scale(0.024 -0.024)"/>
+  <use href="#bravura-g64" xlink:href="#bravura-g64" transform="translate(406.013 510) scale(0.024 -0.024)"/>
+  <line x1="409.373" y1="501" x2="409.373" y2="525" stroke="black" stroke-width="0.96"/>
+  <line x1="414.173" y1="501" x2="414.173" y2="525" stroke="black" stroke-width="3"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(372.432 522) scale(0.024 -0.024)"/>
+  <line x1="379.512" y1="501" x2="379.512" y2="522" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g995" xlink:href="#bravura-g995" transform="translate(389.402 513) scale(0.024 -0.024)"/>
+  <line x1="458.194" y1="501" x2="458.194" y2="525" stroke="black" stroke-width="0.96"/>
+  <line x1="462.994" y1="501" x2="462.994" y2="525" stroke="black" stroke-width="3"/>
+  <use href="#bravura-g156" xlink:href="#bravura-g156" transform="translate(421.253 522) scale(0.024 -0.024)"/>
+</svg>


### PR DESCRIPTION
Adds the §14.4 Canzonetta example as a rendering fixture, asserted through `CeolKitSVGGeometry` so what was *drawn* is checked rather than what the layout engine believed: three staves per system sharing an x-span, bar lines aligned across all three, one bracket at the left edge, and monotonic `abcLine` anchors. Snapshot included, with outline `d=` attributes sanitised so the diff stays about structure.

Rendering the tune whole turned up two parser bugs the parser-side fixture had not reached.

### §2.2 line continuation

A trailing backslash continues a music line *through* information fields, comments and stylesheet directives — but `LineClassifier` pasted every intervening line into the music verbatim, which turned Canzonetta's `w:` lyric lines into a bar's worth of invented notes.

Now only the next line of *music* joins the continuation. Anything else is deferred and emitted after the joined line, and comments are dropped as they are everywhere else. An empty line after a backslash is illegal per §6.1.1, so the pending line is flushed rather than swallowing the rest of the tune.

That the deferred fields land *after* the joined line rather than at the break is #107, left as-is here.

### §4.9 variant endings

`|1` is a bar line **and** an ending number, but `scanBarLine` read the digit in place of the bar — merging the measure before the ending into the ending itself and losing one bar from every repeat written that way, §14.4 among them.

The ending number is now scanned as an extra token after any bar line (`Token.isBarLine`), so `|1`, `:|2` and `||1,2` all spell it the same way.

### Not covered

Lyrics are still not drawn (#82), so nothing here asserts on them.

## Testing

`swift test` — 893 tests in 66 suites, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)