### PR TITLE
Fix #74 — read V: stem= in the renderer

### DIFF
--- a/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
+++ b/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
@@ -63,7 +63,9 @@ public struct SVGRenderer: CeolKitRenderer {
         }()
 
         var tuneBlocks: [TuneBlock] = []
-        var stemDirection: StemDirection = .auto
+        // What the *document* asks for. A voice's own `V:` stem= outranks it; the emitter
+        // resolves the two per staff (issue #74).
+        var documentStemDirection: StemDirection = .auto
         var justifyLastSystem = effectiveConfig.justifyLastSystem
         // %%ceolkit:scale is tune-scoped but sticky: a preamble value governs every following
         // tune until a later tune header overrides it. %%ceolkit:gracenotespacing behaves the
@@ -74,7 +76,7 @@ public struct SVGRenderer: CeolKitRenderer {
         for tune in score.tunes {
             for scope in tune.directives {
                 switch scope.directive {
-                case .pipeFormat(true):     stemDirection = .down
+                case .pipeFormat(true):     documentStemDirection = .down
                 case .justifyLast(let on):  justifyLastSystem = on
                 case .scale(let factor):    scale = factor
                 case .graceNoteSpacing(let step): graceNoteSpacing = step
@@ -158,7 +160,8 @@ public struct SVGRenderer: CeolKitRenderer {
                                           keySignature: voiceKeys[index],
                                           meter: regionMeter,
                                           firstSystemLabel: firstLabels[index],
-                                          laterSystemLabel: laterLabels[index])
+                                          laterSystemLabel: laterLabels[index],
+                                          stemDirection: voice.properties.stemDirection)
                 }
                 // Space for the region's braces and brackets, reserved before anything is
                 // packed into the line.  It is added to the header widths rather than taken
@@ -230,7 +233,8 @@ public struct SVGRenderer: CeolKitRenderer {
                                         graceNoteSpacing: graceNoteSpacing))
         }
 
-        let emitter = SVGEmitter(config: effectiveConfig, metadata: metadata, stemDirection: stemDirection)
+        let emitter = SVGEmitter(config: effectiveConfig, metadata: metadata,
+                                 stemDirection: documentStemDirection)
         let layout = engine.layout(tuneBlocks)
         let finalLayout = attachFooters(layout, score: score, config: effectiveConfig)
         return try emitter.emit(finalLayout)
@@ -366,7 +370,7 @@ private extension SystemGroup {
             System(measures: $0.measures, isLastSystem: isLast, sourceForced: $0.sourceForced,
                    staveWasSplit: $0.staveWasSplit, clef: $0.clef,
                    keySignature: $0.keySignature, meter: $0.meter,
-                   voiceLabel: $0.voiceLabel)
+                   voiceLabel: $0.voiceLabel, stemDirection: $0.stemDirection)
         }, grouping: grouping)
     }
 }

--- a/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
@@ -45,13 +45,23 @@ private struct SlurAnchor {
 struct SVGEmitter: Sendable {
     let config: SVGRenderConfig
     let metadata: BravuraMetadata
+    /// What `%%ceolkit:pipeformat` asked of the whole document.  A voice that states its own
+    /// `V:` `stem=` overrides it (issue #74), so this is the fallback rather than the answer
+    /// — see ``configured(for:)``.
+    let documentStemDirection: StemDirection
+    /// The direction in force for the system being emitted: the voice's own where it stated
+    /// one, ``documentStemDirection`` where it did not.  `.auto` leaves the choice to the
+    /// note's staff position, which is the ordinary engraving rule.
     let stemDirection: StemDirection
     let accidentalMetrics: AccidentalMetrics
 
-    init(config: SVGRenderConfig, metadata: BravuraMetadata, stemDirection: StemDirection = .auto) {
+    init(config: SVGRenderConfig, metadata: BravuraMetadata,
+         stemDirection: StemDirection = .auto,
+         systemStemDirection: StemDirection? = nil) {
         self.config = config
         self.metadata = metadata
-        self.stemDirection = stemDirection
+        self.documentStemDirection = stemDirection
+        self.stemDirection = systemStemDirection ?? stemDirection
         self.accidentalMetrics = AccidentalMetrics(config: config, metadata: metadata)
     }
 
@@ -114,13 +124,25 @@ struct SVGEmitter: Sendable {
     /// threading a size argument through the whole emission tree.  `graceNoteSpacing` rides
     /// along for a different reason: the sizer reserved this system's grace groups with it,
     /// and a group drawn at any other step would not fill the space it was given.
+    ///
+    /// Stem direction is resolved here too, and for the same reason: it varies per staff,
+    /// and threading it down to `emitStem` through every note, chord, tuplet and beam group
+    /// would touch the whole emission tree to say one thing.  The voice's `V:` `stem=` beats
+    /// `%%ceolkit:pipeformat`, which beats the note's own staff position (issue #74).
+    ///
+    /// Always called on the page-level emitter, whose ``stemDirection`` is still the
+    /// document's — resolving from ``documentStemDirection`` rather than from
+    /// ``stemDirection`` keeps that from mattering.
     private func configured(for system: ResolvedSystem) -> SVGEmitter {
+        let systemStem = system.stemDirection != .auto ? system.stemDirection : documentStemDirection
         guard system.staffSize != config.staffSize
-                || system.graceNoteSpacing != config.graceNoteSpacing else { return self }
+                || system.graceNoteSpacing != config.graceNoteSpacing
+                || systemStem != stemDirection else { return self }
         var systemConfig = config
         systemConfig.staffSize = system.staffSize
         systemConfig.graceNoteSpacing = system.graceNoteSpacing
-        return SVGEmitter(config: systemConfig, metadata: metadata, stemDirection: stemDirection)
+        return SVGEmitter(config: systemConfig, metadata: metadata,
+                          stemDirection: documentStemDirection, systemStemDirection: systemStem)
     }
 
     // MARK: - Scroll-sync metadata

--- a/Sources/CeolKitSVGRenderer/Layout/Justifier.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/Justifier.swift
@@ -116,7 +116,7 @@ public struct Justifier: Sendable {
             return JustifiedSystem(measures: measures, isLastSystem: staff.isLastSystem,
                                    sourceForced: staff.sourceForced, clef: staff.clef,
                                    keySignature: staff.keySignature, meter: staff.meter,
-                                   voiceLabel: staff.voiceLabel)
+                                   voiceLabel: staff.voiceLabel, stemDirection: staff.stemDirection)
         }
         return JustifiedSystemGroup(staves: staves, grouping: group.grouping)
     }

--- a/Sources/CeolKitSVGRenderer/Layout/LineBreaker.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/LineBreaker.swift
@@ -70,16 +70,21 @@ public struct LineBreaker: Sendable {
         /// has none, and deliberately not defaulted to ``firstSystemLabel``: a voice named
         /// once and never again is what the spec asks for and what abcm2ps prints.
         public let laterSystemLabel: String?
+        /// The voice's `V:` `stem=`, stamped on every system it appears on — unlike the
+        /// label, it does not change between the first system and the rest.
+        public let stemDirection: StemDirection
 
         public init(measures: [SizedMeasure], clef: ClefSpec = ClefSpec(clef: .treble, octaveShift: 0),
                     keySignature: KeySignature? = nil, meter: Meter? = nil,
-                    firstSystemLabel: String? = nil, laterSystemLabel: String? = nil) {
+                    firstSystemLabel: String? = nil, laterSystemLabel: String? = nil,
+                    stemDirection: StemDirection = .auto) {
             self.measures = measures
             self.clef = clef
             self.keySignature = keySignature
             self.meter = meter
             self.firstSystemLabel = firstSystemLabel
             self.laterSystemLabel = laterSystemLabel
+            self.stemDirection = stemDirection
         }
     }
 
@@ -145,7 +150,8 @@ public struct LineBreaker: Sendable {
                         clef: voice.clef,
                         keySignature: voice.keySignature,
                         meter: isFirstOfTune ? voice.meter : nil,
-                        voiceLabel: isFirstOfTune ? voice.firstSystemLabel : voice.laterSystemLabel
+                        voiceLabel: isFirstOfTune ? voice.firstSystemLabel : voice.laterSystemLabel,
+                        stemDirection: voice.stemDirection
                     )
                 }, grouping: grouping))
             }
@@ -157,7 +163,7 @@ public struct LineBreaker: Sendable {
                 System(measures: staff.measures, isLastSystem: true,
                        sourceForced: staff.sourceForced, staveWasSplit: staff.staveWasSplit,
                        clef: staff.clef, keySignature: staff.keySignature, meter: staff.meter,
-                       voiceLabel: staff.voiceLabel)
+                       voiceLabel: staff.voiceLabel, stemDirection: staff.stemDirection)
             }, grouping: last.grouping))
         }
 

--- a/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
@@ -54,6 +54,9 @@ public struct System: Sendable {
     /// (ABC v2.2 §4.1).  A voice with a name but no subname is therefore labelled once and
     /// then not again, which is what abcm2ps does.
     public let voiceLabel: String?
+    /// What this voice asked for with `V:` `stem=` (§4.1, issue #74).  `.auto` — the
+    /// overwhelmingly common case — means it asked for nothing and the document decides.
+    public let stemDirection: StemDirection
 
     public init(
         measures: [SizedMeasure],
@@ -63,7 +66,8 @@ public struct System: Sendable {
         clef: ClefSpec = ClefSpec(clef: .treble, octaveShift: 0),
         keySignature: KeySignature? = nil,
         meter: Meter? = nil,
-        voiceLabel: String? = nil
+        voiceLabel: String? = nil,
+        stemDirection: StemDirection = .auto
     ) {
         self.measures = measures
         self.isLastSystem = isLastSystem
@@ -73,6 +77,7 @@ public struct System: Sendable {
         self.keySignature = keySignature
         self.meter = meter
         self.voiceLabel = voiceLabel
+        self.stemDirection = stemDirection
     }
 }
 
@@ -220,6 +225,9 @@ public struct JustifiedSystem: Sendable {
     /// Carried through from ``System/voiceLabel`` — justification moves x positions, never
     /// what a staff is called.
     public let voiceLabel: String?
+    /// Carried through from ``System/stemDirection`` — justification moves x positions,
+    /// never which way a voice's stems point.
+    public let stemDirection: StemDirection
 
     public init(
         measures: [JustifiedMeasure],
@@ -228,7 +236,8 @@ public struct JustifiedSystem: Sendable {
         clef: ClefSpec = ClefSpec(clef: .treble, octaveShift: 0),
         keySignature: KeySignature? = nil,
         meter: Meter? = nil,
-        voiceLabel: String? = nil
+        voiceLabel: String? = nil,
+        stemDirection: StemDirection = .auto
     ) {
         self.measures = measures
         self.isLastSystem = isLastSystem
@@ -237,6 +246,7 @@ public struct JustifiedSystem: Sendable {
         self.keySignature = keySignature
         self.meter = meter
         self.voiceLabel = voiceLabel
+        self.stemDirection = stemDirection
     }
 }
 
@@ -449,6 +459,10 @@ public struct ResolvedSystem: Sendable {
     /// voice has nothing to print on this system, which is every voice of every tune that
     /// names none.
     public let voiceLabel: VoiceLabel?
+    /// What this staff's voice asked for with `V:` `stem=`.  A voice that states a
+    /// direction overrides `%%ceolkit:pipeformat`; `.auto` leaves the choice to the
+    /// document, and failing that to the note's own staff position.
+    public let stemDirection: StemDirection
 
     public init(
         origin: Point,
@@ -465,7 +479,8 @@ public struct ResolvedSystem: Sendable {
         meter: Meter? = nil,
         abcLine: Int = 1,
         staffGroup: StaffGroup? = nil,
-        voiceLabel: VoiceLabel? = nil
+        voiceLabel: VoiceLabel? = nil,
+        stemDirection: StemDirection = .auto
     ) {
         self.origin = origin
         self.measures = measures
@@ -482,6 +497,7 @@ public struct ResolvedSystem: Sendable {
         self.abcLine = abcLine
         self.staffGroup = staffGroup
         self.voiceLabel = voiceLabel
+        self.stemDirection = stemDirection
     }
 }
 

--- a/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
@@ -308,7 +308,8 @@ public struct VerticalLayoutEngine: Sendable {
                 meter: staff.meter,
                 abcLine: abcLine,
                 staffGroup: membership,
-                voiceLabel: staff.voiceLabel.map { VoiceLabel(text: $0, x: labelRightX) }
+                voiceLabel: staff.voiceLabel.map { VoiceLabel(text: $0, x: labelRightX) },
+                stemDirection: staff.stemDirection
             )
         }
     }

--- a/Tests/CeolKitSVGRendererTests/StemDirectionTests.swift
+++ b/Tests/CeolKitSVGRendererTests/StemDirectionTests.swift
@@ -1,0 +1,175 @@
+import Testing
+import CeolKitModel
+import CeolKitParser
+@testable import CeolKitSVGRenderer
+
+/// Issue #74: a voice's `V:` `stem=up|down` decides which way its stems point, outranking
+/// the document-wide `%%ceolkit:pipeformat` and the note's own staff position.
+///
+/// End to end — source in, SVG out — because the point of the issue was that the value was
+/// parsed and then never reached the drawing.  Asserting on `VoiceProperties` would have
+/// passed before the fix.
+///
+/// Direction is read out of the emitted document rather than out of the layout: a stem is
+/// drawn from its notehead, so the end that coincides with a notehead's y is the notehead
+/// end, and the stem points away from it.
+@Suite("Stem direction (V: stem=)")
+struct StemDirectionTests {
+
+    /// One drawn stem, with the direction recovered from where its notehead sits.
+    private struct Stem {
+        let x: Double
+        let noteheadY: Double
+        let tipY: Double
+        var isUp: Bool { tipY < noteheadY }
+    }
+
+    /// Every stem in `svg`, paired with the notehead it grows from.
+    ///
+    /// Stems are the `<line>`s at Bravura's stem thickness — thinner than every staff line
+    /// and bar line in the document, which is what ``BravuraMetadataTests`` pins.  Noteheads
+    /// are the Bravura `<text>` runs, so the renderer is driven in `.fontFace` mode to keep
+    /// them readable as text.
+    private func stems(in svg: String, staffSize: Double, metadata: BravuraMetadata) -> [Stem] {
+        let stemWidth = metadata.engravingDefaults.stemThickness * staffSize
+        let noteheads = svg.matches(
+            of: /<text x="([-0-9.]+)" y="([-0-9.]+)" font-family="Bravura"[^>]*>(.)<\/text>/
+        ).compactMap { match -> (x: Double, y: Double)? in
+            let heads: Set<Character> = [SMuFLGlyph.noteheadBlack.character,
+                                         SMuFLGlyph.noteheadHalf.character,
+                                         SMuFLGlyph.noteheadWhole.character]
+            guard let x = Double(match.1), let y = Double(match.2),
+                  let ch = String(match.3).first, heads.contains(ch) else { return nil }
+            return (x, y)
+        }
+
+        return svg.matches(
+            of: /<line x1="([-0-9.]+)" y1="([-0-9.]+)" x2="([-0-9.]+)" y2="([-0-9.]+)" stroke="black" stroke-width="([-0-9.]+)"\/>/
+        ).compactMap { match -> Stem? in
+            guard let x = Double(match.1), let y1 = Double(match.2),
+                  let y2 = Double(match.4), let width = Double(match.5),
+                  abs(width - stemWidth) < 0.01, y1 != y2 else { return nil }
+            // The notehead end is whichever end a notehead is drawn at.  A stem is attached
+            // to the right of its notehead when it points up and to the left when it points
+            // down, so the x match has to allow a notehead's width either way.
+            let touches: (Double) -> Bool = { end in
+                noteheads.contains { abs($0.y - end) < 0.01 && abs($0.x - x) < 4 * staffSize }
+            }
+            if touches(y2) { return Stem(x: x, noteheadY: y2, tipY: y1) }
+            if touches(y1) { return Stem(x: x, noteheadY: y1, tipY: y2) }
+            return nil
+        }
+    }
+
+    /// Renders `abc` and returns the stems of each staff, top staff first.
+    ///
+    /// Bucketed by the staff the notehead falls nearest, so a two-voice tune's staves can be
+    /// asserted against each other — the whole point of "other voices unaffected".
+    private func stemsPerStaff(_ abc: String, staffCount: Int) throws -> [[Stem]] {
+        let metadata = try BravuraMetadata.load()
+        let config = SVGRenderConfig()
+        let score = CeolKitParser().parse(abc, options: .default).score
+        var diagnostics: [Diagnostic] = []
+        let svg = try textProbeRenderer(config).render(score, diagnostics: &diagnostics).joined()
+        let all = stems(in: svg, staffSize: config.staffSize, metadata: metadata)
+        // Staves are far enough apart vertically that sorting the noteheads into `staffCount`
+        // clusters by y is unambiguous: every stem of a staff is nearer its own staff's notes
+        // than the next staff's.
+        let sorted = all.sorted { $0.noteheadY < $1.noteheadY }
+        guard staffCount > 1, !sorted.isEmpty else { return [sorted.sorted { $0.x < $1.x }] }
+        let perStaff = sorted.count / staffCount
+        return (0..<staffCount).map { staff in
+            Array(sorted[(staff * perStaff)..<((staff + 1) * perStaff)]).sorted { $0.x < $1.x }
+        }
+    }
+
+    /// Two voices over the same four notes, so any difference between the staves is the
+    /// `V:` attributes and nothing else.
+    private func twoVoices(_ first: String, _ second: String = "",
+                           directive: String = "", notes: String = "c d e f") -> String {
+        ([
+            "X:1", "T:Stems", "M:4/4", "L:1/4", directive, "K:C",
+            "V:1 \(first)", "V:2 \(second)",
+            "[V:1] \(notes) |", "[V:2] \(notes) |"
+        ] as [String]).filter { !$0.isEmpty }.joined(separator: "\n") + "\n"
+    }
+
+    // MARK: - The voice's own stem=
+
+    @Test("stem=up forces every stem up regardless of pitch, and leaves other voices alone")
+    func stemUpForcesUpAndIsVoiceLocal() throws {
+        // c d e f sit above the middle line, where the pitch rule stems down — which is what
+        // voice 2 does.  Every assertion here is a flip away from the untouched control.
+        let staves = try stemsPerStaff(twoVoices("stem=up"), staffCount: 2)
+        try #require(staves.count == 2)
+        try #require(staves[0].count == 4)
+        try #require(staves[1].count == 4)
+        #expect(staves[0].allSatisfy { $0.isUp })
+        #expect(staves[1].allSatisfy { !$0.isUp })
+    }
+
+    @Test("stem=down forces every stem down regardless of pitch")
+    func stemDownForcesDown() throws {
+        // C D E F sit below the middle line, where the pitch rule stems *up* — so voice 2 is
+        // the control that says the forced staff is not simply agreeing with the default.
+        let staves = try stemsPerStaff(twoVoices("stem=down", notes: "C D E F"), staffCount: 2)
+        try #require(staves.count == 2)
+        try #require(staves[0].count == 4)
+        try #require(staves[1].count == 4)
+        #expect(staves[0].allSatisfy { !$0.isUp })
+        #expect(staves[1].allSatisfy { $0.isUp })
+    }
+
+    // MARK: - Against the document
+
+    @Test("%%ceolkit:pipeformat true still stems a voice that asks for nothing down")
+    func pipeFormatStillGoverns() throws {
+        // Low notes, which the pitch rule would stem up — so the directive is doing the work.
+        let staves = try stemsPerStaff(twoVoices("", directive: "%%ceolkit:pipeformat true",
+                                                 notes: "C D E F"),
+                                       staffCount: 2)
+        try #require(staves.flatMap { $0 }.count == 8)
+        #expect(staves.flatMap { $0 }.allSatisfy { !$0.isUp })
+    }
+
+    @Test("A voice with stem=up under pipeformat gets up stems — the voice wins")
+    func voiceOutranksPipeFormat() throws {
+        // Low notes again: voice 2 is stemmed down by the directive against the pitch rule,
+        // so both staves differ from what they would draw on their own and from each other.
+        let staves = try stemsPerStaff(twoVoices("stem=up", directive: "%%ceolkit:pipeformat true",
+                                                 notes: "C D E F"),
+                                       staffCount: 2)
+        try #require(staves.count == 2)
+        try #require(staves[0].count == 4)
+        try #require(staves[1].count == 4)
+        #expect(staves[0].allSatisfy { $0.isUp })
+        #expect(staves[1].allSatisfy { !$0.isUp })
+    }
+
+    /// One voice, so the stems come back in written order with nothing to bucket.
+    private func oneVoice(_ notes: String) -> String {
+        "X:1\nT:Stems\nM:4/4\nL:1/4\nK:C\n\(notes) |\n"
+    }
+
+    // MARK: - Nobody asks
+
+    @Test("With neither, the note's own staff position still decides")
+    func autoFallsBackToPitch() throws {
+        let staves = try stemsPerStaff(oneVoice("C D E F G a b c'"), staffCount: 1)
+        let stems = try #require(staves.first)
+        try #require(stems.count == 8)
+        // At or below the middle line up, above it down — C4…G4 against A5…C6.  The rule the
+        // emitter has always applied, left untouched by the fix.
+        #expect(stems.prefix(5).allSatisfy { $0.isUp })
+        #expect(stems.suffix(3).allSatisfy { !$0.isUp })
+    }
+
+    @Test("An explicit stem=auto draws exactly what stating nothing draws")
+    func explicitAutoIsNotADifference() throws {
+        let score = { (abc: String) in CeolKitParser().parse(abc, options: .default).score }
+        var diagnostics: [Diagnostic] = []
+        let bare = try textProbeRenderer().render(score(twoVoices("")), diagnostics: &diagnostics)
+        let auto = try textProbeRenderer().render(score(twoVoices("stem=auto")), diagnostics: &diagnostics)
+        #expect(bare == auto)
+    }
+}


### PR DESCRIPTION
`VoiceProperties.stemDirection` was parsed from `V: … stem=up|down` and merged per voice, and then nothing ever read it. The emitter held **one** direction for the whole document, set at `init` from `%%ceolkit:pipeformat`, and `emitStem` resolved it per *pitch*. Dead plumbing.

## What changed

Stem direction is now carried per voice through the layout, alongside the clef, key signature and voice label that already travel that way:

`LineBreaker.VoiceLine` → `System` → `JustifiedSystem` → `ResolvedSystem`

and resolved per staff in `SVGEmitter.configured(for:)` — the same hook `staffSize` and `graceNoteSpacing` use, and for the same reason: threading a direction down to `emitStem` through every note, chord, tuplet and beam group would touch the whole emission tree to say one thing.

Precedence is **the voice's own `stem=` → `%%ceolkit:pipeformat` → the note's staff position**. The emitter keeps `documentStemDirection` separately from the `stemDirection` in force, so a voice that states nothing falls back to the document rather than to whatever the previous staff asked for.

## Acceptance

| Criterion | Test |
|---|---|
| `V:1 stem=up` forces every stem up in that voice, other voices unaffected | `stemUpForcesUpAndIsVoiceLocal` |
| `%%ceolkit:pipeformat true` still forces stems down where no voice overrides | `pipeFormatStillGoverns` |
| A voice with `stem=up` under `pipeformat` gets up stems — the voice wins | `voiceOutranksPipeFormat` |
| Tunes with neither are byte-identical | existing snapshot suites, unchanged |

Plus `stemDownForcesDown` and `autoFallsBackToPitch` for the other two arms.

The new suite reads direction back out of the emitted SVG rather than out of the layout — a stem is drawn from its notehead, so the end coinciding with a notehead's `y` is the notehead end and the stem points away from it. Asserting on `VoiceProperties` would have passed before this change.

Each test's notes are chosen so the assertion is a genuine flip from what the pitch rule alone would draw; reverting the one-line wiring in the driver fails three of the six.

## Not touched

`%%ceolkit:pipeformat false` still does not reset the document direction once an earlier tune has turned it on. Pre-existing and orthogonal — left alone to keep this about the plumbing.

Unblocks #77 (opposed stems on a shared staff), where direction has to come from voice identity rather than pitch.

## Testing

`swift test` — 885 tests in 65 suites, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)