### PR TITLE
Fix #75 — tag every event with its voice through the layout passes

### DIFF
--- a/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
+++ b/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
@@ -133,7 +133,8 @@ public struct SVGRenderer: CeolKitRenderer {
                         for voiceIndex in printedVoices.indices {
                             columnsPerVoice[voiceIndex].append(
                                 sizer.size(stave.measures[voiceIndex][column],
-                                           unitNoteLength: voiceUnitLengths[voiceIndex]))
+                                           unitNoteLength: voiceUnitLengths[voiceIndex],
+                                           voiceIndex: voiceIndex))
                         }
                     }
                 }

--- a/Sources/CeolKitSVGRenderer/Layout/MeasureSizer.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/MeasureSizer.swift
@@ -24,7 +24,11 @@ public struct MeasureSizer: Sendable {
     ///   - measure: The measure to size.
     ///   - unitNoteLength: The voice's `L:` value (e.g. `Fraction(1, 8)` for eighth-note unit).
     ///     Used to convert `Note.duration` multipliers to an absolute quarter-note reference.
-    public func size(_ measure: Measure, unitNoteLength: Fraction) -> SizedMeasure {
+    ///   - voiceIndex: Which printed voice the measure belongs to.  Every event is tagged
+    ///     with it, so the passes below can tell the voices of a shared staff apart without
+    ///     the layout types growing a second dimension.
+    public func size(_ measure: Measure, unitNoteLength: Fraction,
+                     voiceIndex: Int = 0) -> SizedMeasure {
         // Quarter-note duration expressed in unit-note-length units.
         // e.g. unitNoteLength = 1/8 → quarterInUnits = 2.0
         let unl = Double(unitNoteLength.numerator) / Double(unitNoteLength.denominator)
@@ -63,7 +67,8 @@ public struct MeasureSizer: Sendable {
         let naturalWidth = x + rightPadding(for: measure)
 
         return SizedMeasure(measure: measure, naturalWidth: naturalWidth, eventOffsets: offsets,
-                            unitNoteLength: unitNoteLength, graceEventIndices: graceEventIndices)
+                            unitNoteLength: unitNoteLength, graceEventIndices: graceEventIndices,
+                            eventVoiceIndices: Array(repeating: voiceIndex, count: offsets.count))
     }
 
     // MARK: - Column width

--- a/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
@@ -17,19 +17,32 @@ public struct SizedMeasure: Sendable {
     /// following event.  The justifier keeps the gap within each such pair fixed so
     /// grace notes stay visually attached to their melody note when measures are stretched.
     public let graceEventIndices: Set<Int>
+    /// The voice each event came from, parallel to `eventOffsets`.
+    /// `eventVoiceIndices.count == eventOffsets.count`.
+    ///
+    /// An index into the *printed* voices of the plan region the measure belongs to — the
+    /// same numbering ``SystemGroup/staves`` is in.  A staff carrying one voice tags every
+    /// event with that staff's own index; a shared staff (§11.1 `( … )`) is what makes this
+    /// a per-event table rather than a property of the measure.
+    public let eventVoiceIndices: [Int]
 
     public init(
         measure: Measure,
         naturalWidth: Double,
         eventOffsets: [Double],
         unitNoteLength: Fraction = Fraction(numerator: 1, denominator: 8),
-        graceEventIndices: Set<Int> = []
+        graceEventIndices: Set<Int> = [],
+        eventVoiceIndices: [Int]? = nil
     ) {
         self.measure = measure
         self.naturalWidth = naturalWidth
         self.eventOffsets = eventOffsets
         self.unitNoteLength = unitNoteLength
         self.graceEventIndices = graceEventIndices
+        // Kept parallel by construction: a caller that says nothing about voices gets the
+        // single-voice answer rather than an array the rest of the pipeline has to test.
+        self.eventVoiceIndices = eventVoiceIndices
+            ?? Array(repeating: 0, count: eventOffsets.count)
     }
 }
 
@@ -265,6 +278,11 @@ public struct JustifiedMeasure: Sendable {
         self.finalWidth = finalWidth
         self.eventOffsets = eventOffsets
     }
+
+    /// The voice tags of ``SizedMeasure/eventVoiceIndices``, still parallel to
+    /// ``eventOffsets``.  Justification moves events along the line; it never adds, drops or
+    /// reorders one, so the sizer's table is as valid after it as before.
+    public var eventVoiceIndices: [Int] { source.eventVoiceIndices }
 }
 
 // MARK: - Pass 4 output
@@ -548,10 +566,15 @@ public struct ResolvedEvent: Sendable {
     /// Absolute position in page coordinates; y is at the top staff line.
     public let origin: Point
     public let kind: ResolvedEventKind
+    /// The voice this event was written by, carried through from
+    /// ``SizedMeasure/eventVoiceIndices``.  With one voice per staff every event on a staff
+    /// shares the staff's index; a shared staff is where they differ.
+    public let voiceIndex: Int
 
-    public init(origin: Point, kind: ResolvedEventKind) {
+    public init(origin: Point, kind: ResolvedEventKind, voiceIndex: Int = 0) {
         self.origin = origin
         self.kind = kind
+        self.voiceIndex = voiceIndex
     }
 }
 

--- a/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
@@ -470,12 +470,18 @@ public struct VerticalLayoutEngine: Sendable {
             let measureOrigin = Point(x: measureX, y: systemOrigin.y)
             let eventBaseY = systemOrigin.y + extraAbove
 
-            let events: [ResolvedEvent] = zip(jm.eventOffsets, jm.source.measure.events).map { offset, event in
-                ResolvedEvent(
-                    origin: Point(x: measureOrigin.x + offset, y: eventBaseY),
-                    kind: ResolvedEventKind(from: event)
-                )
-            }
+            let voices = jm.eventVoiceIndices
+            let events: [ResolvedEvent] = zip(jm.eventOffsets, jm.source.measure.events)
+                .enumerated().map { i, pair in
+                    let (offset, event) = pair
+                    return ResolvedEvent(
+                        origin: Point(x: measureOrigin.x + offset, y: eventBaseY),
+                        kind: ResolvedEventKind(from: event),
+                        // Parallel by construction, but a hand-built `SizedMeasure` in a test
+                        // can be short; fall back to the staff's own voice rather than trap.
+                        voiceIndex: i < voices.count ? voices[i] : 0
+                    )
+                }
 
             // A bar line between two measures belongs to both of them: the semantic
             // pass stores the same `BarLine` as the left measure's `closingBar` and

--- a/Tests/CeolKitSVGRendererTests/EventVoiceTagTests.swift
+++ b/Tests/CeolKitSVGRendererTests/EventVoiceTagTests.swift
@@ -1,0 +1,147 @@
+import Testing
+import CeolKitModel
+import CeolKitParser
+@testable import CeolKitSVGRenderer
+
+// MARK: - Helpers
+
+private let config   = SVGRenderConfig()
+private let metadata = try! BravuraMetadata.load()
+
+private let dummyRange = SourceRange(file: nil, byteOffset: 0, length: 0, line: 0, column: 0)
+private let dummyBar   = BarLine(kind: .single, source: dummyRange)
+
+private func parseMeasure(_ abc: String) -> Measure {
+    let tune = CeolKitParser().parse(abc, options: .default).score.tunes[0]
+    return tune.voices[0].staves[0].measures[0]
+}
+
+/// Issue #75: every event carries the voice it was written by, from the sizer through to
+/// the resolved layout.  Behaviour-neutral on its own — this is the seam the shared-staff
+/// work (§11.1 `( … )`) hangs on, and the goldens assert that nothing about the page moved.
+@Suite("Event Voice Tags")
+struct EventVoiceTagTests {
+
+    // MARK: - Pass 1
+
+    @Test("The sizer tags every event with the voice it sized for")
+    func sizerTagsEveryEvent() {
+        let measure = parseMeasure("X:1\nL:1/8\nK:C\nCDEF GABc|\n")
+        let sizer   = MeasureSizer(config: config, metadata: metadata)
+        let sized   = sizer.size(measure, unitNoteLength: Fraction(numerator: 1, denominator: 8),
+                                 voiceIndex: 3)
+
+        #expect(sized.eventVoiceIndices.count == sized.eventOffsets.count)
+        #expect(sized.eventVoiceIndices.allSatisfy { $0 == 3 })
+    }
+
+    @Test("A measure sized without a voice belongs to voice 0")
+    func sizerDefaultsToVoiceZero() {
+        let measure = parseMeasure("X:1\nL:1/8\nK:C\nCDEF|\n")
+        let sized   = MeasureSizer(config: config, metadata: metadata)
+            .size(measure, unitNoteLength: Fraction(numerator: 1, denominator: 8))
+        #expect(sized.eventVoiceIndices == [0, 0, 0, 0])
+    }
+
+    @Test("A hand-built SizedMeasure gets a table parallel to its offsets")
+    func handBuiltMeasureIsStillParallel() {
+        let sized = SizedMeasure(measure: Measure(openingBar: nil, events: [], closingBar: dummyBar,
+                                                  endingNumber: nil, source: dummyRange),
+                                 naturalWidth: 100, eventOffsets: [0, 10, 20])
+        #expect(sized.eventVoiceIndices == [0, 0, 0])
+    }
+
+    // MARK: - Pass 3
+
+    /// The tags have to come through justification intact, and specifically alongside the
+    /// grace pairing: `stretchOffsets` treats a grace event and its principal note as one
+    /// unit, so a measure with grace notes is the case where an index-keyed side table is
+    /// most likely to slip out of step with the offsets.
+    @Test("Justification moves the events and keeps their tags")
+    func justificationPreservesTags() {
+        let measure = parseMeasure("X:1\nL:1/8\nK:C\n{g}A B {ge}c d|\n")
+        let sized   = MeasureSizer(config: config, metadata: metadata)
+            .size(measure, unitNoteLength: Fraction(numerator: 1, denominator: 8), voiceIndex: 1)
+        #expect(!sized.graceEventIndices.isEmpty)
+
+        let system = System(measures: [sized], isLastSystem: false, sourceForced: false)
+        let justified = Justifier().justify([system], usableWidth: sized.naturalWidth * 2,
+                                            justifyLastSystem: true)
+        let jm = justified[0].measures[0]
+
+        #expect(jm.eventOffsets != sized.eventOffsets)   // it really did stretch
+        #expect(jm.eventOffsets.count == jm.eventVoiceIndices.count)
+        #expect(jm.eventVoiceIndices.allSatisfy { $0 == 1 })
+    }
+
+    // MARK: - Pass 4
+
+    @Test("Every resolved event carries a voice index")
+    func resolvedEventsCarryTheTag() {
+        let measure = parseMeasure("X:1\nL:1/8\nK:C\nCDEF GABc|\n")
+        let sized   = MeasureSizer(config: config, metadata: metadata)
+            .size(measure, unitNoteLength: Fraction(numerator: 1, denominator: 8), voiceIndex: 2)
+        let jm = JustifiedMeasure(source: sized, finalWidth: sized.naturalWidth,
+                                  eventOffsets: sized.eventOffsets)
+        let system = JustifiedSystem(measures: [jm], isLastSystem: true, sourceForced: false)
+        let layout = VerticalLayoutEngine(config: config, metadata: metadata).layout([system])
+
+        let events = layout.pages.flatMap(\.systems).flatMap(\.measures).flatMap(\.events)
+        #expect(events.count == sized.eventOffsets.count)
+        #expect(events.allSatisfy { $0.voiceIndex == 2 })
+    }
+
+    // MARK: - End to end
+
+    /// The renderer's own chain, run over a two-voice tune: each staff's events must come
+    /// out tagged with that staff's index and no other.
+    @Test("Each staff of a multi-voice system tags its events with its own voice")
+    func multiVoiceTunePipeline() throws {
+        let abc = """
+            X:1
+            T:Two Voices
+            M:4/4
+            L:1/8
+            K:D
+            V:M1
+            V:M2
+            [V:M1] abcd efga | bage dcBA |
+            [V:M2] ABcd efga | bage dcBA |
+            """
+        let tune = CeolKitParser().parse(abc, options: .default).score.tunes[0]
+        var diagnostics: [Diagnostic] = []
+        let voices = VoiceSelector.select(from: tune.voices, plan: nil, into: &diagnostics).voices
+        #expect(voices.count == 2)
+
+        let sizer  = MeasureSizer(config: config, metadata: metadata)
+        let staves = VoiceAligner.align(voices, into: &diagnostics)
+        var columnsPerVoice = [[SizedMeasure]](repeating: [], count: voices.count)
+        var breaks: [ScoreLineBreak?] = []
+        for stave in staves {
+            for column in 0..<stave.measureCount {
+                breaks.append(nil)
+                for v in voices.indices {
+                    columnsPerVoice[v].append(
+                        sizer.size(stave.measures[v][column],
+                                   unitNoteLength: tune.effectiveUnitNoteLength(for: voices[v]),
+                                   voiceIndex: v))
+                }
+            }
+        }
+
+        let lines = voices.indices.map { LineBreaker.VoiceLine(measures: columnsPerVoice[$0]) }
+        let groups = LineBreaker().breakIntoGroups(lines, breaks: breaks, usableWidth: 500)
+        let justified = Justifier().justifyGroups(groups, usableWidth: 500, justifyLastSystem: false)
+        let block  = TuneBlock(systemGroups: justified)
+        let layout = VerticalLayoutEngine(config: config, metadata: metadata).layout([block])
+
+        let staffSystems = layout.pages.flatMap(\.systems)
+        #expect(staffSystems.count == 2)
+        for system in staffSystems {
+            let group = try #require(system.staffGroup)
+            let events = system.measures.flatMap(\.events)
+            #expect(!events.isEmpty)
+            #expect(events.allSatisfy { $0.voiceIndex == group.index })
+        }
+    }
+}


### PR DESCRIPTION
Closes #75.

Every event now carries the voice it was written by, from the sizer through to the resolved layout. Behaviour-neutral — this is the seam the shared-staff work (§11.1 `( … )`) hangs on.

## Why a side table

`ResolvedSystem` is structurally single-voice: one `clef`, one `keySignature`, one `meter`, one `[ResolvedMeasure]`. Layering it to hold N voices would ripple through `LineBreaker`, `Justifier` and `VerticalLayoutEngine`. `SizedMeasure` already carries `graceEventIndices` as an index-keyed side table parallel to `eventOffsets`, so the voice tag follows that pattern and every layout type keeps its current shape.

## Changes

- **`Layout/ResolvedLayout.swift`**
  - `SizedMeasure.eventVoiceIndices: [Int]`, parallel to `eventOffsets`. The init takes `[Int]?` and fills zeros when omitted, so the table is parallel by construction and every existing call site still compiles.
  - `JustifiedMeasure.eventVoiceIndices` — a passthrough of `source.eventVoiceIndices`. Justification moves events but never adds, drops or reorders one, so the sizer's table is as valid after it as before.
  - `ResolvedEvent.voiceIndex: Int` (defaults to 0).
- **`Layout/MeasureSizer.swift`** — `size(_:unitNoteLength:voiceIndex:)` tags every offset it emits, including the grace/principal pair.
- **`Layout/VerticalLayoutEngine.swift`** — reads the tag when building each `ResolvedEvent`, falling back to 0 for a short table (hand-built `SizedMeasure`s in tests) rather than trapping.
- **`CeolKitSVGRenderer.swift`** — passes the loop's `voiceIndex` into the sizer.

`LineBreaker` and `Justifier` needed no change: the breaker slices `[SizedMeasure]` and the justifier keeps `source`, so the tags ride through both untouched.

## Tests

New `EventVoiceTagTests` (6 tests): the sizer tags what it is given, defaults to voice 0, hand-built measures stay parallel, tags survive justification on a measure with grace pairs (asserting the offsets actually moved — that is where an index-keyed table is most likely to slip), resolved events carry the tag, and a two-voice tune run through the renderer's own chain comes out with each staff's events tagged to that staff's index and no other.

Full suite: 905 tests pass, goldens and snapshots unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2oXH88dgkQdDwF2AWchgP