### PR TITLE
Fix #76 — merge shared-staff voices onto a common onset grid

### DIFF
--- a/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
+++ b/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
@@ -124,21 +124,36 @@ public struct SVGRenderer: CeolKitRenderer {
                 // source line-break, so the last column of every non-final stave forces a
                 // system break.  The region's own final stave needs none — the region ends
                 // there, and the next one starts a new system anyway.
+                //
+                // §11.1 `( … )`: a staff may carry more than one voice, and those are merged
+                // onto a common onset grid here — before sizing, because interleaved onsets
+                // need more columns than either voice alone and neither the breaker's nor
+                // the justifier's `max` across staves can invent one.
+                let voicesByStaff = selection.voicesByStaff
                 var breaks: [ScoreLineBreak?] = []
-                var columnsPerVoice = [[SizedMeasure]](repeating: [], count: printedVoices.count)
+                var columnsPerStaff = [[SizedMeasure]](repeating: [], count: voicesByStaff.count)
                 for (si, stave) in alignedStaves.enumerated() {
                     let isLastStave = si == alignedStaves.count - 1
                     for column in 0..<stave.measureCount {
                         breaks.append(!isLastStave && column == stave.measureCount - 1 ? .hard : nil)
-                        for voiceIndex in printedVoices.indices {
-                            columnsPerVoice[voiceIndex].append(
-                                sizer.size(stave.measures[voiceIndex][column],
-                                           unitNoteLength: voiceUnitLengths[voiceIndex],
-                                           voiceIndex: voiceIndex))
+                        for (staffIndex, members) in voicesByStaff.enumerated() {
+                            columnsPerStaff[staffIndex].append(
+                                sizer.size(sharedStaff: members.enumerated().map { position, voice in
+                                    MeasureSizer.SharedVoice(
+                                        measure: stave.measures[voice][column],
+                                        unitNoteLength: voiceUnitLengths[voice],
+                                        voiceIndex: position,
+                                        isPadding: stave.isPadding(voice: voice, column: column))
+                                }))
                         }
                     }
                 }
                 guard !breaks.isEmpty else { continue }
+
+                // Everything below draws one staff at a time, and a shared staff draws the
+                // clef, key and name of the voice written at the top of it — as an engraver
+                // does, and as `V:` order decides.
+                let staffLead = voicesByStaff.map { $0[0] }
 
                 // A time signature is drawn once, on the tune's very first system.  A later
                 // region opens a fresh set of staves, but it is still the same tune, and a
@@ -150,19 +165,20 @@ public struct SVGRenderer: CeolKitRenderer {
                 // `sname=` on every later one.  A region after the opening one is not the
                 // first system of anything — the voice has already been named — so it takes
                 // the subname throughout, exactly as a line break within a region does.
-                let firstLabels = printedVoices.map {
-                    isOpeningRegion ? $0.properties.name : $0.properties.subname
+                let firstLabels = staffLead.map {
+                    isOpeningRegion ? printedVoices[$0].properties.name
+                                    : printedVoices[$0].properties.subname
                 }
-                let laterLabels = printedVoices.map(\.properties.subname)
+                let laterLabels = staffLead.map { printedVoices[$0].properties.subname }
 
-                let voiceLines = printedVoices.enumerated().map { index, voice in
-                    LineBreaker.VoiceLine(measures: columnsPerVoice[index],
-                                          clef: voice.properties.clef,
-                                          keySignature: voiceKeys[index],
+                let voiceLines = staffLead.enumerated().map { staffIndex, voice in
+                    LineBreaker.VoiceLine(measures: columnsPerStaff[staffIndex],
+                                          clef: printedVoices[voice].properties.clef,
+                                          keySignature: voiceKeys[voice],
                                           meter: regionMeter,
-                                          firstSystemLabel: firstLabels[index],
-                                          laterSystemLabel: laterLabels[index],
-                                          stemDirection: voice.properties.stemDirection)
+                                          firstSystemLabel: firstLabels[staffIndex],
+                                          laterSystemLabel: laterLabels[staffIndex],
+                                          stemDirection: printedVoices[voice].properties.stemDirection)
                 }
                 // Space for the region's braces and brackets, reserved before anything is
                 // packed into the line.  It is added to the header widths rather than taken
@@ -170,7 +186,7 @@ public struct SVGRenderer: CeolKitRenderer {
                 // justifier already subtract, and `VerticalLayoutEngine` spends exactly the
                 // same amount moving the staves right (see `BracketColumns`).
                 let indent = BracketColumns(grouping: selection.grouping,
-                                            staffCount: printedVoices.count,
+                                            staffCount: voicesByStaff.count,
                                             metadata: metadata,
                                             staffSize: tuneConfig.staffSize).indent
 
@@ -187,15 +203,15 @@ public struct SVGRenderer: CeolKitRenderer {
                 // Header widths differ between the first system (has time sig) and later
                 // ones, and are the max across the group: the staves of a system have to
                 // start at the same x even when one voice's clef or key signature is wider.
-                let openingHeaderW = indent + openingGutter + printedVoices.indices.reduce(0.0) { widest, index in
-                    max(widest, systemHeaderWidth(clef: printedVoices[index].properties.clef,
-                                                  keySignature: voiceKeys[index],
+                let openingHeaderW = indent + openingGutter + staffLead.reduce(0.0) { widest, voice in
+                    max(widest, systemHeaderWidth(clef: printedVoices[voice].properties.clef,
+                                                  keySignature: voiceKeys[voice],
                                                   meter: regionMeter, metadata: metadata,
                                                   staffSize: tuneConfig.staffSize))
                 }
-                let laterHeaderW = indent + laterGutter + printedVoices.indices.reduce(0.0) { widest, index in
-                    max(widest, systemHeaderWidth(clef: printedVoices[index].properties.clef,
-                                                  keySignature: voiceKeys[index],
+                let laterHeaderW = indent + laterGutter + staffLead.reduce(0.0) { widest, voice in
+                    max(widest, systemHeaderWidth(clef: printedVoices[voice].properties.clef,
+                                                  keySignature: voiceKeys[voice],
                                                   meter: nil, metadata: metadata,
                                                   staffSize: tuneConfig.staffSize))
                 }

--- a/Sources/CeolKitSVGRenderer/Layout/ColumnMetrics.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/ColumnMetrics.swift
@@ -1,0 +1,236 @@
+import Foundation
+import CeolKitModel
+
+/// How wide one horizontal column of music has to be, and how much room the furniture at
+/// each end of a bar takes.
+///
+/// Split out of ``MeasureSizer`` because a shared staff (§11.1 `( … )`) needs the same
+/// answers for a column that several voices contribute to, and the two must agree exactly:
+/// a single-voice staff and a "shared" staff with one sounding voice have to lay out
+/// identically, and they only do that if there is one implementation of the question.
+///
+/// Column width is square-root proportional to duration (linear spacing is far too extreme
+/// for long notes) with a minimum floor so very short notes stay legible.
+struct ColumnMetrics: Sendable {
+    let config: SVGRenderConfig
+    let metadata: BravuraMetadata
+    let graceMetrics: GraceMetrics
+    let accidentalMetrics: AccidentalMetrics
+
+    init(config: SVGRenderConfig, metadata: BravuraMetadata) {
+        self.config = config
+        self.metadata = metadata
+        self.graceMetrics = GraceMetrics(config: config, metadata: metadata)
+        self.accidentalMetrics = AccidentalMetrics(config: config, metadata: metadata)
+    }
+
+    // MARK: - Column width
+
+    /// The width of the column `event` occupies.
+    ///
+    /// - Parameters:
+    ///   - durationUnits: the duration the column is spaced *for*, in unit note lengths,
+    ///     when that is not the event's own — which is the case on a shared staff, where a
+    ///     column runs only as far as the next voice's onset and a note sounding across
+    ///     several columns is spaced by the first of them.  `nil` (the single-voice case)
+    ///     means the event's own duration.  Everything that is a property of the event
+    ///     rather than of the column — accidental reservation, the dotted-note minimum —
+    ///     is unaffected by it.
+    func columnWidth(for event: Event, durationUnits: Double? = nil,
+                     quarterInUnits: Double) -> Double {
+        let s = config.staffSize
+        let minCol = s * 1.2
+        let base   = s * 2.0
+
+        switch event {
+        case .note(let n):
+            let rawCol = base * durationFactor(durationUnits ?? rawDuration(n.duration),
+                                               quarterInUnits: quarterInUnits)
+            var col = max(minCol, rawCol)
+            let accWidth = accidentalMetrics.reservation(for: n.displayedAccidental)
+            // Very short notes (at the minimum floor) get a dot-gap equivalent of extra space
+            // so consecutive beamed notes aren't visually pressed against each other.
+            let breathingRoom = rawCol < minCol ? noteheadWidth() * 0.2 : 0
+            // Dotted notes need enough column to clear the augmentation dot before the next note.
+            // Minimum = notehead + dotGap + dotWidth + clearance = noteheadWidth × 1.4 + dotWidth.
+            if isDottedDuration(n.duration) {
+                col = max(col, noteheadWidth() * 1.4 + augmentationDotWidth())
+            }
+            return col + accWidth + breathingRoom
+
+        case .rest(let r):
+            return max(minCol, base * durationFactor(durationUnits ?? rawDuration(r.duration),
+                                                     quarterInUnits: quarterInUnits))
+
+        case .chord(let c):
+            let col = max(minCol, base * durationFactor(durationUnits ?? rawDuration(c.duration),
+                                                        quarterInUnits: quarterInUnits))
+            // Chord accidentals are not yet stacked, so reserve for the widest of them.
+            let accWidth = c.notes
+                .map { accidentalMetrics.reservation(for: $0.displayedAccidental) }
+                .max() ?? 0
+            return col + accWidth
+
+        case .tuplet(let t):
+            let df = durationFactor(durationUnits ?? tupletDuration(t),
+                                    quarterInUnits: quarterInUnits)
+            return max(minCol, base * df)
+
+        case .grace(let g):
+            // Fallback for orphaned grace events (not immediately followed by a spacing event).
+            return graceGroupWidth(g)
+
+        case .spacer(let sp):
+            guard sp.width > 0 else { return 0 }
+            return s * 0.5 * Double(sp.width)
+
+        case .directiveAnchor:
+            return 0
+
+        case .tempoChange:
+            return s * 6
+        }
+    }
+
+    // MARK: - Grace helpers
+
+    /// Returns true for events that carry rhythmic duration and act as spacing anchors.
+    func isSpacingEvent(_ event: Event) -> Bool {
+        switch event {
+        case .note, .chord, .rest: return true
+        default: return false
+        }
+    }
+
+    /// Width consumed by a grace group: outer padding at each edge plus one `advance`
+    /// per additional notehead.  See `GraceMetrics`.
+    func graceGroupWidth(_ grace: GraceGroup) -> Double {
+        graceMetrics.width(grace.notes)
+    }
+
+    /// Gap between the grace group's right edge and the principal notehead.
+    ///
+    /// For a single grace note the 32nd-note flag extends right of the stem and overhangs the
+    /// column boundary.  We measure the overhang from the bounding-box data and add a small
+    /// comfortable clearance so the flag tip is visibly separated from the principal note.
+    /// Multi-note groups use beams that don't overhang, so a simpler fixed gap is used there.
+    func graceNoteGap(for grace: GraceGroup) -> Double {
+        guard let single = grace.notes.first, grace.notes.count == 1 else {
+            // Beamed group: no flag overhang; the group's own trailing pad plus a
+            // notehead-quarter of clearance before the principal note.
+            return noteheadWidth() * (GraceMetrics.edgePad * GraceMetrics.scale + 0.25)
+        }
+        // Single grace note: compute how far the flag extends past the group's right edge.
+        // flagWidth (rendered) = bboxWidth × staffSize × graceScale.
+        let flagW = metadata.glyphBBoxes["flag32ndUp"]
+                        .map { $0.width * config.staffSize * GraceMetrics.scale }
+                    ?? config.staffSize * 0.625
+        let stemX        = graceMetrics.stemOffsets([single])[0]
+        let flagOverhang = max(0, stemX + flagW - graceMetrics.width([single]))
+        return flagOverhang + config.staffSize * 0.25
+    }
+
+    // MARK: - Bar furniture
+
+    /// Right padding after the last event column.
+    ///
+    /// Compound closing bars (final, repeat-end, double) are drawn right-anchored so
+    /// their trailing edge aligns with other lines' thin bar edges.  The leading bar
+    /// sits to the left of that anchor — `wideSep` for the thick-barred kinds, `sep`
+    /// for the thin-thin double bar — so the padding must be large enough to keep it
+    /// clear of the last note.
+    func rightPadding(for measure: Measure) -> Double {
+        let s       = config.staffSize
+        let sep     = metadata.engravingDefaults.barlineSeparation * s
+        let wideSep = sep * 2.0
+        switch measure.closingBar.kind {
+        case .final, .repeatEnd, .repeatEndSection, .repeatBoth:
+            return wideSep + s * 0.5
+        case .double:
+            return sep + s * 0.5
+        default:
+            return s * 0.5
+        }
+    }
+
+    /// Left margin before the first event.
+    ///
+    /// For measures that begin with a start-repeat bar line the dots occupy
+    /// the space immediately after the bar complex, so the first note is
+    /// pushed past them before the standard one-notehead gap is added.
+    /// A mid-line time-signature change adds its glyph width before the note gap.
+    func leftMargin(for measure: Measure) -> Double {
+        let nhw = noteheadWidth()
+        let thin = metadata.engravingDefaults.thinBarlineThickness * config.staffSize
+        let meterGap = measure.meter != nil ? 2.0 * thin : 0
+        let timeSigW = measure.meter.map { timeSignatureWidth(for: $0, metadata: metadata, staffSize: config.staffSize) } ?? 0
+        guard let opening = measure.openingBar else { return meterGap + timeSigW + nhw }
+        switch opening.kind {
+        case .repeatStart, .sectionRepeatStart, .repeatBoth:
+            let wideSep = metadata.engravingDefaults.barlineSeparation * config.staffSize * 2.0
+            // Must match `emitRepeatDots`, which places the dots by this same measurement.
+            let dotSep  = metadata.engravingDefaults.repeatBarlineDotSeparation * config.staffSize
+            let dotW    = metadata.glyphBBoxes["repeatDot"].map { $0.width * config.staffSize }
+                          ?? config.staffSize * 0.25
+            return wideSep + dotSep + dotW + meterGap + timeSigW + nhw
+        default:
+            return meterGap + timeSigW + nhw
+        }
+    }
+
+    // MARK: - Helpers
+
+    func noteheadWidth() -> Double {
+        metadata.glyphBBoxes["noteheadBlack"].map { $0.width * config.staffSize }
+            ?? config.staffSize * 1.2
+    }
+
+    func augmentationDotWidth() -> Double {
+        metadata.glyphBBoxes["augmentationDot"].map { $0.width * config.staffSize }
+            ?? config.staffSize * 0.4
+    }
+
+    func isDottedDuration(_ dur: Fraction) -> Bool {
+        let n = dur.numerator
+        let d = dur.denominator
+        guard n > 0, d > 0, (d & (d - 1)) == 0 else { return false }
+        var m = n
+        while m % 2 == 0 { m /= 2 }
+        return m == 3
+    }
+
+    func durationFactor(_ durationUnits: Double, quarterInUnits: Double) -> Double {
+        sqrt(max(durationUnits, 0) / quarterInUnits)
+    }
+
+    /// The written duration of a single event in unit note lengths.
+    ///
+    /// `0` for everything that is not a note, rest or chord — a nested tuplet included, which
+    /// is why ``tupletDuration(_:)`` is only ever right about a tuplet one level deep.  That
+    /// is what the sizer has always measured, and the shared-staff merge reads the same
+    /// number so the two agree about where a column starts.
+    func rawDuration(_ event: Event) -> Double {
+        switch event {
+        case .note(let n):  return rawDuration(n.duration)
+        case .rest(let r):  return rawDuration(r.duration)
+        case .chord(let c): return rawDuration(c.duration)
+        default:            return 0
+        }
+    }
+
+    /// How far an event advances the clock, in unit note lengths.
+    func soundingDuration(_ event: Event) -> Double {
+        if case .tuplet(let t) = event { return tupletDuration(t) }
+        return rawDuration(event)
+    }
+
+    private func rawDuration(_ fraction: Fraction) -> Double {
+        Double(fraction.numerator) / Double(fraction.denominator)
+    }
+
+    /// A tuplet's sounding duration in unit note lengths: the written total scaled by `q/p`.
+    func tupletDuration(_ tuplet: Tuplet) -> Double {
+        let written = tuplet.events.reduce(0.0) { $0 + rawDuration($1) }
+        return written * Double(tuplet.q) / Double(tuplet.p)
+    }
+}

--- a/Sources/CeolKitSVGRenderer/Layout/Justifier.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/Justifier.swift
@@ -141,15 +141,24 @@ public struct Justifier: Sendable {
     /// `naturalWidth` minus the leading margin (`base`) and all fixed grace-to-note gaps
     /// (`fixedTotal`).  Grace events (identified by `graceIndices`) stay fixed relative to
     /// the note they precede; every other event is scaled proportionally.
+    ///
+    /// How much fixed width lies to an event's left is asked of the *offsets*, not of the
+    /// array order.  On a single-voice measure the two agree, because offsets only ever
+    /// increase.  A shared staff (§11.1 `( … )`) is where they part: its events are ordered
+    /// voice by voice within each onset so that no grace group is separated from its note,
+    /// which means the array steps backwards every time a new voice starts its run.
     private func stretchOffsets(_ offsets: [Double], naturalWidth: Double, finalWidth: Double,
                                  graceIndices: Set<Int>) -> [Double] {
         guard !offsets.isEmpty else { return offsets }
         let base = offsets[0]
 
-        // Total fixed gap = sum of (note_offset - grace_offset) for each grace+note pair.
-        let fixedTotal = graceIndices.reduce(0.0) { sum, i in
-            i + 1 < offsets.count ? sum + (offsets[i + 1] - offsets[i]) : sum
+        // One entry per grace+note pair: where its note sits, and the incompressible gap
+        // between the two.
+        let pairs: [(note: Int, x: Double, gap: Double)] = graceIndices.sorted().compactMap {
+            guard $0 + 1 < offsets.count else { return nil }
+            return (note: $0 + 1, x: offsets[$0 + 1], gap: offsets[$0 + 1] - offsets[$0])
         }
+        let fixedTotal = pairs.reduce(0.0) { $0 + $1.gap }
 
         let elasticNatural = naturalWidth - base - fixedTotal
         guard elasticNatural > 0 else { return offsets }
@@ -157,18 +166,26 @@ public struct Justifier: Sendable {
         // measure are incompressible, so there is nothing sane to do below that point.
         let elasticScale = max(0, (finalWidth - base - fixedTotal) / elasticNatural)
 
+        /// The fixed width of every grace pair that finishes to the left of event `i`.
+        /// Ties — a zero-width column, or a second voice sounding at the same x — are broken
+        /// by array position, which is what the single-voice walk this replaces did.
+        func fixedLeftOf(_ i: Int) -> Double {
+            pairs.reduce(0.0) { sum, pair in
+                guard pair.note != i, pair.note - 1 != i else { return sum }
+                let isLeft = pair.x < offsets[i] || (pair.x == offsets[i] && pair.note < i)
+                return isLeft ? sum + pair.gap : sum
+            }
+        }
+
         var result = [Double](repeating: 0, count: offsets.count)
-        var cumFixed = 0.0
         for i in 0..<offsets.count {
             if i > 0 && graceIndices.contains(i - 1) {
                 // Pair-follower: preserve the fixed gap from the preceding grace event.
-                let gap = offsets[i] - offsets[i - 1]
-                result[i] = result[i - 1] + gap
-                cumFixed += gap
+                result[i] = result[i - 1] + (offsets[i] - offsets[i - 1])
             } else {
                 // Elastic event: scale its position relative to the base.
-                let elasticOffset = offsets[i] - base - cumFixed
-                result[i] = base + cumFixed + elasticOffset * elasticScale
+                let fixed = fixedLeftOf(i)
+                result[i] = base + fixed + (offsets[i] - base - fixed) * elasticScale
             }
         }
         return result

--- a/Sources/CeolKitSVGRenderer/Layout/MeasureSizer.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/MeasureSizer.swift
@@ -4,18 +4,15 @@ import CeolKitModel
 /// Pass 1: computes the natural width of a `Measure` and the x offset of each event.
 ///
 /// Column width uses square-root proportional spacing (linear spacing is too extreme for long
-/// notes) with a minimum floor so very short notes remain legible.
+/// notes) with a minimum floor so very short notes remain legible.  ``ColumnMetrics`` owns
+/// those measurements, so the shared-staff merge sizes a column exactly as this does.
 public struct MeasureSizer: Sendable {
-    private let config: SVGRenderConfig
-    private let metadata: BravuraMetadata
-    private let graceMetrics: GraceMetrics
-    private let accidentalMetrics: AccidentalMetrics
+    private let metrics: ColumnMetrics
+    private let merger: SharedStaffMerger
 
     public init(config: SVGRenderConfig, metadata: BravuraMetadata) {
-        self.config = config
-        self.metadata = metadata
-        self.graceMetrics = GraceMetrics(config: config, metadata: metadata)
-        self.accidentalMetrics = AccidentalMetrics(config: config, metadata: metadata)
+        self.metrics = ColumnMetrics(config: config, metadata: metadata)
+        self.merger = SharedStaffMerger(metrics: metrics)
     }
 
     /// Sizes a single measure.
@@ -24,9 +21,10 @@ public struct MeasureSizer: Sendable {
     ///   - measure: The measure to size.
     ///   - unitNoteLength: The voice's `L:` value (e.g. `Fraction(1, 8)` for eighth-note unit).
     ///     Used to convert `Note.duration` multipliers to an absolute quarter-note reference.
-    ///   - voiceIndex: Which printed voice the measure belongs to.  Every event is tagged
-    ///     with it, so the passes below can tell the voices of a shared staff apart without
-    ///     the layout types growing a second dimension.
+    ///   - voiceIndex: Which voice of its staff the measure belongs to.  Every event is
+    ///     tagged with it, so the passes below can tell the voices of a shared staff apart
+    ///     without the layout types growing a second dimension.  A staff with one voice —
+    ///     which is every staff but a `( … )` group — passes `0`.
     public func size(_ measure: Measure, unitNoteLength: Fraction,
                      voiceIndex: Int = 0) -> SizedMeasure {
         // Quarter-note duration expressed in unit-note-length units.
@@ -36,7 +34,7 @@ public struct MeasureSizer: Sendable {
 
         var offsets: [Double] = []
         var graceEventIndices: Set<Int> = []
-        var x: Double = leftMargin(for: measure)
+        var x: Double = metrics.leftMargin(for: measure)
         var i = 0
 
         while i < measure.events.count {
@@ -44,19 +42,20 @@ public struct MeasureSizer: Sendable {
 
             if case .grace(let g) = event,
                i + 1 < measure.events.count,
-               isSpacingEvent(measure.events[i + 1]) {
+               metrics.isSpacingEvent(measure.events[i + 1]) {
                 // Grace + following note/chord/rest: treat as a combined unit so the pair
                 // moves together during justification.
-                let graceW = graceGroupWidth(g)
-                let gap    = graceNoteGap(for: g)
+                let graceW = metrics.graceGroupWidth(g)
+                let gap    = metrics.graceNoteGap(for: g)
                 graceEventIndices.insert(offsets.count)  // record before appending
                 offsets.append(x)                        // grace event
                 offsets.append(x + graceW + gap)         // paired note/chord/rest
-                x += graceW + gap + columnWidth(for: measure.events[i + 1], quarterInUnits: quarterInUnits)
+                x += graceW + gap + metrics.columnWidth(for: measure.events[i + 1],
+                                                        quarterInUnits: quarterInUnits)
                 i += 2
             } else {
                 offsets.append(x)
-                x += columnWidth(for: event, quarterInUnits: quarterInUnits)
+                x += metrics.columnWidth(for: event, quarterInUnits: quarterInUnits)
                 i += 1
             }
         }
@@ -64,185 +63,48 @@ public struct MeasureSizer: Sendable {
         // Right-side padding: enough space so the thin bar of a compound closing bar
         // (final, repeat-end) clears the last note after the thick bar is anchored at
         // the measure's right edge.
-        let naturalWidth = x + rightPadding(for: measure)
+        let naturalWidth = x + metrics.rightPadding(for: measure)
 
         return SizedMeasure(measure: measure, naturalWidth: naturalWidth, eventOffsets: offsets,
                             unitNoteLength: unitNoteLength, graceEventIndices: graceEventIndices,
                             eventVoiceIndices: Array(repeating: voiceIndex, count: offsets.count))
     }
 
-    // MARK: - Column width
-
-    private func columnWidth(for event: Event, quarterInUnits: Double) -> Double {
-        let s = config.staffSize
-        let minCol = s * 1.2
-        let base   = s * 2.0
-
-        switch event {
-        case .note(let n):
-            let rawCol = base * durationFactor(n.duration, quarterInUnits: quarterInUnits)
-            var col = max(minCol, rawCol)
-            let accWidth = accidentalMetrics.reservation(for: n.displayedAccidental)
-            // Very short notes (at the minimum floor) get a dot-gap equivalent of extra space
-            // so consecutive beamed notes aren't visually pressed against each other.
-            let breathingRoom = rawCol < minCol ? noteheadWidth() * 0.2 : 0
-            // Dotted notes need enough column to clear the augmentation dot before the next note.
-            // Minimum = notehead + dotGap + dotWidth + clearance = noteheadWidth × 1.4 + dotWidth.
-            if isDottedDuration(n.duration) {
-                col = max(col, noteheadWidth() * 1.4 + augmentationDotWidth())
-            }
-            return col + accWidth + breathingRoom
-
-        case .rest(let r):
-            return max(minCol, base * durationFactor(r.duration, quarterInUnits: quarterInUnits))
-
-        case .chord(let c):
-            let col = max(minCol, base * durationFactor(c.duration, quarterInUnits: quarterInUnits))
-            // Chord accidentals are not yet stacked, so reserve for the widest of them.
-            let accWidth = c.notes
-                .map { accidentalMetrics.reservation(for: $0.displayedAccidental) }
-                .max() ?? 0
-            return col + accWidth
-
-        case .tuplet(let t):
-            var totalUnits = 0.0
-            for e in t.events { totalUnits += rawDuration(e) }
-            let adjustedUnits = totalUnits * Double(t.q) / Double(t.p)
-            let df = sqrt(max(adjustedUnits, 0) / quarterInUnits)
-            return max(minCol, base * df)
-
-        case .grace(let g):
-            // Fallback for orphaned grace events (not immediately followed by a spacing event).
-            return graceGroupWidth(g)
-
-        case .spacer(let sp):
-            guard sp.width > 0 else { return 0 }
-            return s * 0.5 * Double(sp.width)
-
-        case .directiveAnchor:
-            return 0
-
-        case .tempoChange:
-            return s * 6
-        }
-    }
-
-    // MARK: - Grace helpers
-
-    /// Returns true for events that carry rhythmic duration and act as spacing anchors.
-    private func isSpacingEvent(_ event: Event) -> Bool {
-        switch event {
-        case .note, .chord, .rest: return true
-        default: return false
-        }
-    }
-
-    /// Width consumed by a grace group: outer padding at each edge plus one `advance`
-    /// per additional notehead.  See `GraceMetrics`.
-    private func graceGroupWidth(_ grace: GraceGroup) -> Double {
-        graceMetrics.width(grace.notes)
-    }
-
-    /// Gap between the grace group's right edge and the principal notehead.
+    /// Sizes one bar of a staff several voices share (§11.1 `( … )`), merging them onto a
+    /// common onset grid first.
     ///
-    /// For a single grace note the 32nd-note flag extends right of the stem and overhangs the
-    /// column boundary.  We measure the overhang from the bounding-box data and add a small
-    /// comfortable clearance so the flag tip is visibly separated from the principal note.
-    /// Multi-note groups use beams that don't overhang, so a simpler fixed gap is used there.
-    private func graceNoteGap(for grace: GraceGroup) -> Double {
-        guard let single = grace.notes.first, grace.notes.count == 1 else {
-            // Beamed group: no flag overhang; the group's own trailing pad plus a
-            // notehead-quarter of clearance before the principal note.
-            return noteheadWidth() * (GraceMetrics.edgePad * GraceMetrics.scale + 0.25)
+    /// A staff whose voices all fell silent here but one is not a shared staff for this bar,
+    /// and is sized as the single voice it is — which is what makes an aligner-padded voice
+    /// contribute nothing at all.  See ``SharedStaffMerger``.
+    public func size(sharedStaff parts: [SharedVoice]) -> SizedMeasure {
+        let sounding = parts.filter { !$0.isPadding }
+        if let only = sounding.count == 1 ? sounding[0] : nil {
+            return size(only.measure, unitNoteLength: only.unitNoteLength,
+                        voiceIndex: only.voiceIndex)
         }
-        // Single grace note: compute how far the flag extends past the group's right edge.
-        // flagWidth (rendered) = bboxWidth × staffSize × graceScale.
-        let flagW = metadata.glyphBBoxes["flag32ndUp"]
-                        .map { $0.width * config.staffSize * GraceMetrics.scale }
-                    ?? config.staffSize * 0.625
-        let stemX        = graceMetrics.stemOffsets([single])[0]
-        let flagOverhang = max(0, stemX + flagW - graceMetrics.width([single]))
-        return flagOverhang + config.staffSize * 0.25
+        return merger.merge(parts.map {
+            SharedStaffMerger.VoicePart(measure: $0.measure, unitNoteLength: $0.unitNoteLength,
+                                        voiceIndex: $0.voiceIndex, isPadding: $0.isPadding)
+        })
     }
 
-    // MARK: - Helpers
+    /// One voice's contribution to one bar of a shared staff.
+    public struct SharedVoice: Sendable {
+        public let measure: Measure
+        /// The voice's own `L:`; §7.3 lets the voices of one staff differ.
+        public let unitNoteLength: Fraction
+        /// The voice's position within the staff, top to bottom.
+        public let voiceIndex: Int
+        /// `true` when ``VoiceAligner`` invented this measure to keep the staves the same
+        /// length.  Padding is dropped by the merge, never spaced.
+        public let isPadding: Bool
 
-    private func noteheadWidth() -> Double {
-        metadata.glyphBBoxes["noteheadBlack"].map { $0.width * config.staffSize }
-            ?? config.staffSize * 1.2
-    }
-
-    /// Right padding after the last event column.
-    ///
-    /// Compound closing bars (final, repeat-end, double) are drawn right-anchored so
-    /// their trailing edge aligns with other lines' thin bar edges.  The leading bar
-    /// sits to the left of that anchor — `wideSep` for the thick-barred kinds, `sep`
-    /// for the thin-thin double bar — so the padding must be large enough to keep it
-    /// clear of the last note.
-    private func rightPadding(for measure: Measure) -> Double {
-        let s       = config.staffSize
-        let sep     = metadata.engravingDefaults.barlineSeparation * s
-        let wideSep = sep * 2.0
-        switch measure.closingBar.kind {
-        case .final, .repeatEnd, .repeatEndSection, .repeatBoth:
-            return wideSep + s * 0.5
-        case .double:
-            return sep + s * 0.5
-        default:
-            return s * 0.5
-        }
-    }
-
-    /// Left margin before the first event.
-    ///
-    /// For measures that begin with a start-repeat bar line the dots occupy
-    /// the space immediately after the bar complex, so the first note is
-    /// pushed past them before the standard one-notehead gap is added.
-    /// A mid-line time-signature change adds its glyph width before the note gap.
-    private func leftMargin(for measure: Measure) -> Double {
-        let nhw = noteheadWidth()
-        let thin = metadata.engravingDefaults.thinBarlineThickness * config.staffSize
-        let meterGap = measure.meter != nil ? 2.0 * thin : 0
-        let timeSigW = measure.meter.map { timeSignatureWidth(for: $0, metadata: metadata, staffSize: config.staffSize) } ?? 0
-        guard let opening = measure.openingBar else { return meterGap + timeSigW + nhw }
-        switch opening.kind {
-        case .repeatStart, .sectionRepeatStart, .repeatBoth:
-            let wideSep = metadata.engravingDefaults.barlineSeparation * config.staffSize * 2.0
-            // Must match `emitRepeatDots`, which places the dots by this same measurement.
-            let dotSep  = metadata.engravingDefaults.repeatBarlineDotSeparation * config.staffSize
-            let dotW    = metadata.glyphBBoxes["repeatDot"].map { $0.width * config.staffSize }
-                          ?? config.staffSize * 0.25
-            return wideSep + dotSep + dotW + meterGap + timeSigW + nhw
-        default:
-            return meterGap + timeSigW + nhw
-        }
-    }
-
-    private func augmentationDotWidth() -> Double {
-        metadata.glyphBBoxes["augmentationDot"].map { $0.width * config.staffSize }
-            ?? config.staffSize * 0.4
-    }
-
-    private func isDottedDuration(_ dur: Fraction) -> Bool {
-        let n = dur.numerator
-        let d = dur.denominator
-        guard n > 0, d > 0, (d & (d - 1)) == 0 else { return false }
-        var m = n
-        while m % 2 == 0 { m /= 2 }
-        return m == 3
-    }
-
-    private func durationFactor(_ duration: Fraction, quarterInUnits: Double) -> Double {
-        let d = Double(duration.numerator) / Double(duration.denominator)
-        return sqrt(max(d, 0) / quarterInUnits)
-    }
-
-    private func rawDuration(_ event: Event) -> Double {
-        switch event {
-        case .note(let n):  return Double(n.duration.numerator) / Double(n.duration.denominator)
-        case .rest(let r):  return Double(r.duration.numerator) / Double(r.duration.denominator)
-        case .chord(let c): return Double(c.duration.numerator) / Double(c.duration.denominator)
-        default:            return 0
+        public init(measure: Measure, unitNoteLength: Fraction, voiceIndex: Int,
+                    isPadding: Bool) {
+            self.measure = measure
+            self.unitNoteLength = unitNoteLength
+            self.voiceIndex = voiceIndex
+            self.isPadding = isPadding
         }
     }
 }

--- a/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
@@ -20,10 +20,11 @@ public struct SizedMeasure: Sendable {
     /// The voice each event came from, parallel to `eventOffsets`.
     /// `eventVoiceIndices.count == eventOffsets.count`.
     ///
-    /// An index into the *printed* voices of the plan region the measure belongs to — the
-    /// same numbering ``SystemGroup/staves`` is in.  A staff carrying one voice tags every
-    /// event with that staff's own index; a shared staff (§11.1 `( … )`) is what makes this
-    /// a per-event table rather than a property of the measure.
+    /// The voice's position *within its own staff*, top to bottom — which staff that is, the
+    /// enclosing ``System`` already says.  A staff carrying one voice therefore tags every
+    /// event `0`; a shared staff (§11.1 `( … )`) is what makes this a per-event table rather
+    /// than a property of the measure, and what the opposed stems and per-voice beaming above
+    /// this pass read to tell its tenants apart.
     public let eventVoiceIndices: [Int]
 
     public init(
@@ -98,8 +99,8 @@ public struct System: Sendable {
 /// *printed* staff indices — positions in ``SystemGroup/staves``.
 ///
 /// `%%score` / `%%staves` states them over the staves of the *plan*, which are not the
-/// staves that get printed: a voice the body never wrote to is dropped, a `( … )` shared
-/// staff is still drawn one staff per voice, and a floating `*V` takes a staff of its own.
+/// staves that get printed: a voice the body never wrote to is dropped, and a floating `*V`
+/// takes a staff of its own that the plan never counted.
 /// ``VoiceSelector`` translates them as it selects, so everything below this point can read
 /// the indices straight off.
 ///
@@ -131,13 +132,15 @@ public struct StaffGrouping: Sendable {
     }
 }
 
-/// One system's worth of unjustified music: the staves of every voice that is active on
-/// the source line the system came from, in `V:` declaration order.
+/// One system's worth of unjustified music: the staves the voices active on the source line
+/// the system came from are drawn on, top to bottom.
 ///
-/// A single-voice tune produces groups of exactly one staff, which is the pre-grouping
-/// path unchanged — every stage below treats a one-staff group as an ordinary system.
+/// One staff per voice, except where a `%%score ( … )` group put several on one — those are
+/// merged into a single staff before this point (see ``SharedStaffMerger``).  A single-voice
+/// tune produces groups of exactly one staff, which is the pre-grouping path unchanged:
+/// every stage below treats a one-staff group as an ordinary system.
 public struct SystemGroup: Sendable {
-    /// One entry per voice, top to bottom.  Never empty.
+    /// One entry per printed staff, top to bottom.  Never empty.
     ///
     /// Every staff holds the same number of measures and was broken at the same measure
     /// index, because `VoiceAligner` padded the voices into agreement before the line
@@ -567,8 +570,8 @@ public struct ResolvedEvent: Sendable {
     public let origin: Point
     public let kind: ResolvedEventKind
     /// The voice this event was written by, carried through from
-    /// ``SizedMeasure/eventVoiceIndices``.  With one voice per staff every event on a staff
-    /// shares the staff's index; a shared staff is where they differ.
+    /// ``SizedMeasure/eventVoiceIndices``: its position within the staff it is drawn on.
+    /// With one voice per staff every event is `0`; a shared staff is where they differ.
     public let voiceIndex: Int
 
     public init(origin: Point, kind: ResolvedEventKind, voiceIndex: Int = 0) {

--- a/Sources/CeolKitSVGRenderer/Layout/SharedStaffMerger.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/SharedStaffMerger.swift
@@ -1,0 +1,329 @@
+import Foundation
+import CeolKitModel
+
+/// Pass 1¾: merges the voices of a `( … )` group (ABC v2.2 §11.1) into the single event
+/// sequence one staff is drawn from, keyed by **onset**.
+///
+/// Everything downstream of here places events by their index in a flat array — the sizer
+/// accumulates `x` per event, and `SizedMeasure.eventOffsets` is index-parallel to
+/// `Measure.events`.  Duration sizes a column but never *places* one, so two voices agree
+/// only at bar lines.  That is tolerable on two staves and impossible on one, where a note
+/// in the lower voice has to sit under the note the upper voice sounds with it.
+///
+/// So the merge runs *before* sizing rather than after grouping.  `LineBreaker` and
+/// `Justifier` both take a column's width as the max across staves, which is right for two
+/// staves and wrong for one: interleaved onsets need *more* columns than either voice alone,
+/// and no `max` can invent them.
+///
+/// ## What a column is here
+///
+/// One onset, subdivided.  Every voice sounding at an onset contributes a run of events —
+/// any grace groups, spacers, directive anchors and tempo changes that precede the note,
+/// then the note itself — and those runs are **right-aligned** against the onset, so the
+/// principal notes of every voice land in the same sub-column at the same x while their
+/// approach spacing stays their own.  A sub-column is as wide as the widest thing any voice
+/// puts in it.
+///
+/// The principal sub-column is spaced for the distance to the *next* onset rather than for
+/// the notes' own durations: a half note in one voice against four eighths in another gets
+/// the four eighth-columns it sounds across, not a half note's worth of space followed by
+/// three crushed ones.  Where the voices agree on every onset — two identical voices, or one
+/// voice merged with nothing — inter-onset distance *is* the note's duration, and the result
+/// is offset-for-offset what ``MeasureSizer`` alone produces.
+///
+/// ## Two traps, both load-bearing
+///
+/// **Padded measures are dropped, not merged.**  ``VoiceAligner`` fills a short voice with
+/// an invisible full-measure rest, and a rest sizes to at least the minimum column — so a
+/// padded bar would widen the shared staff for music nobody wrote.  ``VoicePart/isPadding``
+/// is the aligner's own answer to that, not a guess made from the events.
+///
+/// **Grace groups keep their principal note adjacent.**  `Justifier.stretchOffsets` reads
+/// `graceEventIndices` as indices into the flat offsets array and pairs *i* with *i+1*, so
+/// a merge that interleaved a grace away from its note would corrupt grace spacing silently.
+/// Events are therefore emitted voice by voice within an onset — never sub-column by
+/// sub-column — which keeps every run contiguous and every grace pair adjacent.
+struct SharedStaffMerger: Sendable {
+
+    /// One voice's contribution to one bar of a shared staff.
+    struct VoicePart {
+        let measure: Measure
+        /// The voice's own `L:`, which its co-tenants need not share (§7.3).
+        let unitNoteLength: Fraction
+        /// The voice's position within the staff, top to bottom.  This is what
+        /// ``SizedMeasure/eventVoiceIndices`` carries.
+        let voiceIndex: Int
+        /// `true` when ``VoiceAligner`` invented this measure to keep the staves the same
+        /// length.  Such a measure contributes no columns.
+        let isPadding: Bool
+    }
+
+    private let metrics: ColumnMetrics
+
+    init(metrics: ColumnMetrics) {
+        self.metrics = metrics
+    }
+
+    // MARK: - Merge
+
+    /// Merges `parts` — the voices of one shared staff, for one bar — into a single sized
+    /// measure.
+    ///
+    /// Callers with fewer than two sounding voices should size with ``MeasureSizer`` instead;
+    /// this handles the case anyway, and identically, but the sizer says what it means.
+    func merge(_ parts: [VoicePart]) -> SizedMeasure {
+        let sounding = parts.filter { !$0.isPadding }
+        // Every voice padded: the bar is furniture only.  Its bar lines still draw, so it
+        // keeps its width, and it contributes not one column of music.
+        guard let primary = sounding.first ?? parts.first else {
+            return SizedMeasure(measure: emptyMeasure(), naturalWidth: 0, eventOffsets: [])
+        }
+        let voices = sounding.map { Prepared(part: $0, metrics: metrics) }
+
+        // The bar's clock runs as far as its longest voice.  The last column is spaced for
+        // the distance from its onset to there.
+        let end = voices.map(\.end).max() ?? .zero
+        let onsets = Set(voices.flatMap { $0.slots.map(\.onset) }).sorted()
+
+        var mergedEvents: [Event] = []
+        var offsets: [Double] = []
+        var voiceTags: [Int] = []
+        var graceEventIndices: Set<Int> = []
+
+        var x = voices.map { metrics.leftMargin(for: $0.part.measure) }.max()
+            ?? metrics.leftMargin(for: primary.measure)
+
+        for (index, onset) in onsets.enumerated() {
+            let next = index + 1 < onsets.count ? onsets[index + 1] : end
+            let gapQuarters = (next - onset).value
+
+            // Sub-columns: as many as the busiest voice needs at this onset, each as wide as
+            // the widest thing any voice puts in it.  A voice with fewer events right-aligns
+            // into the last of them, so the principal notes coincide.
+            let runs = voices.compactMap { voice -> Run? in
+                voice.slot(at: onset).map { Run(voice: voice, slot: $0, gapQuarters: gapQuarters,
+                                                metrics: metrics) }
+            }
+            let subColumnCount = runs.map(\.widths.count).max() ?? 0
+            var subWidths = [Double](repeating: 0, count: subColumnCount)
+            for run in runs {
+                for (j, width) in run.widths.enumerated() {
+                    let sub = subColumnCount - run.widths.count + j
+                    subWidths[sub] = max(subWidths[sub], width)
+                }
+            }
+            var subX = [Double](repeating: 0, count: subColumnCount)
+            var cursor = x
+            for j in 0..<subColumnCount {
+                subX[j] = cursor
+                cursor += subWidths[j]
+            }
+
+            // Emitted voice by voice, so each voice's run stays contiguous and every grace
+            // group keeps the note it belongs to immediately after it.
+            for run in runs {
+                let first = subColumnCount - run.widths.count
+                for (j, eventIndex) in run.slot.events.enumerated() {
+                    if run.pairedGraceOffsets.contains(j) {
+                        graceEventIndices.insert(offsets.count)
+                    }
+                    mergedEvents.append(run.voice.part.measure.events[eventIndex])
+                    offsets.append(subX[first + j])
+                    voiceTags.append(run.voice.part.voiceIndex)
+                }
+            }
+            x = cursor
+        }
+
+        let naturalWidth = x + (voices.map { metrics.rightPadding(for: $0.part.measure) }.max()
+            ?? metrics.rightPadding(for: primary.measure))
+
+        return SizedMeasure(
+            measure: Measure(openingBar: primary.measure.openingBar, events: mergedEvents,
+                             closingBar: primary.measure.closingBar,
+                             endingNumber: primary.measure.endingNumber,
+                             source: primary.measure.source, meter: primary.measure.meter),
+            naturalWidth: naturalWidth,
+            eventOffsets: offsets,
+            unitNoteLength: primary.unitNoteLength,
+            graceEventIndices: graceEventIndices,
+            eventVoiceIndices: voiceTags)
+    }
+
+    /// The measure a fully padded bar keeps: its own furniture, and no music at all.
+    private func emptyMeasure() -> Measure {
+        let bar = BarLine(kind: .single, source: .emptySourceRange)
+        return Measure(openingBar: nil, events: [], closingBar: bar, endingNumber: nil,
+                       source: .emptySourceRange)
+    }
+
+    // MARK: - One voice, cut into onsets
+
+    /// A voice's bar as a list of onsets, each holding the run of events that sounds there.
+    private struct Prepared {
+        let part: VoicePart
+        /// Quarter notes per unit note length, for this voice's `L:`.
+        let quarterInUnits: Double
+        let slots: [Slot]
+        /// Where this voice's music ends, as an onset.
+        let end: Rational
+
+        struct Slot {
+            let onset: Rational
+            /// Indices into the measure's events, in source order.  The last is the note,
+            /// chord, rest or tuplet that sounds at ``onset`` — unless the run is the tail of
+            /// a bar that ends with grace notes or a directive, which sounds nothing.
+            let events: [Int]
+        }
+
+        init(part: VoicePart, metrics: ColumnMetrics) {
+            self.part = part
+            let unl = Double(part.unitNoteLength.numerator) / Double(part.unitNoteLength.denominator)
+            self.quarterInUnits = 0.25 / unl
+
+            var slots: [Slot] = []
+            var pending: [Int] = []
+            var onset = Rational.zero
+            for (index, event) in part.measure.events.enumerated() {
+                let duration = Rational.quarters(of: event, unitNoteLength: part.unitNoteLength)
+                guard duration > .zero else {
+                    // Grace groups, spacers, directive anchors, tempo changes: they take
+                    // width but no time, so they belong to the onset they lead up to.
+                    pending.append(index)
+                    continue
+                }
+                slots.append(Slot(onset: onset, events: pending + [index]))
+                pending = []
+                onset = onset + duration
+            }
+            // A bar that ends with something untimed still has to draw it.
+            if !pending.isEmpty { slots.append(Slot(onset: onset, events: pending)) }
+
+            self.slots = slots
+            self.end = onset
+        }
+
+        func slot(at onset: Rational) -> Slot? {
+            slots.first { $0.onset == onset }
+        }
+    }
+
+    /// One voice's events at one onset, with the width each of them claims.
+    private struct Run {
+        let voice: Prepared
+        let slot: Prepared.Slot
+        let widths: [Double]
+        /// Positions within ``slot`` holding a grace group that is immediately followed by
+        /// the note it ornaments — the pairs `Justifier.stretchOffsets` must not stretch.
+        let pairedGraceOffsets: Set<Int>
+
+        init(voice: Prepared, slot: Prepared.Slot, gapQuarters: Double, metrics: ColumnMetrics) {
+            self.voice = voice
+            self.slot = slot
+
+            let events = slot.events.map { voice.part.measure.events[$0] }
+            var widths: [Double] = []
+            var paired: Set<Int> = []
+            for (j, event) in events.enumerated() {
+                // A grace group and the note it ornaments move together: the group's width
+                // plus the gap to the notehead is one fixed sub-column.
+                if case .grace(let group) = event, j + 1 < events.count,
+                   metrics.isSpacingEvent(events[j + 1]) {
+                    paired.insert(j)
+                    widths.append(metrics.graceGroupWidth(group) + metrics.graceNoteGap(for: group))
+                    continue
+                }
+                // The last event of a run is the one that sounds, and it is spaced for the
+                // distance to the next onset rather than for its own duration — on a shared
+                // staff those differ whenever the voices do.
+                let sounds = j == events.count - 1 && metrics.soundingDuration(event) > 0
+                widths.append(metrics.columnWidth(
+                    for: event,
+                    durationUnits: sounds ? gapQuarters * voice.quarterInUnits : nil,
+                    quarterInUnits: voice.quarterInUnits))
+            }
+            self.widths = widths
+            self.pairedGraceOffsets = paired
+        }
+    }
+}
+
+// MARK: - Onsets
+
+/// An exact position in time within a bar, in quarter notes.
+///
+/// Rational rather than `Double` because onsets are *compared*: two voices sound together
+/// when their onsets are equal, and a tuplet against plain notes makes thirds of a beat that
+/// no binary fraction represents.  One rounding error would split a shared column in two.
+struct Rational: Hashable, Comparable {
+    let numerator: Int
+    /// Always positive; the sign lives in ``numerator``.
+    let denominator: Int
+
+    static let zero = Rational(0, 1)
+
+    init(_ numerator: Int, _ denominator: Int) {
+        precondition(denominator != 0, "a rational onset cannot have a zero denominator")
+        let sign = denominator < 0 ? -1 : 1
+        let n = numerator * sign
+        let d = denominator * sign
+        let g = Rational.gcd(abs(n), d)
+        self.numerator = g == 0 ? 0 : n / g
+        self.denominator = g == 0 ? 1 : d / g
+    }
+
+    var value: Double { Double(numerator) / Double(denominator) }
+
+    static func + (lhs: Rational, rhs: Rational) -> Rational {
+        Rational(lhs.numerator * rhs.denominator + rhs.numerator * lhs.denominator,
+                 lhs.denominator * rhs.denominator)
+    }
+
+    static func - (lhs: Rational, rhs: Rational) -> Rational {
+        Rational(lhs.numerator * rhs.denominator - rhs.numerator * lhs.denominator,
+                 lhs.denominator * rhs.denominator)
+    }
+
+    static func < (lhs: Rational, rhs: Rational) -> Bool {
+        lhs.numerator * rhs.denominator < rhs.numerator * lhs.denominator
+    }
+
+    private static func gcd(_ a: Int, _ b: Int) -> Int {
+        var a = a, b = b
+        while b != 0 { (a, b) = (b, a % b) }
+        return a
+    }
+}
+
+extension Rational {
+    /// How far `event` advances the clock, in quarter notes.
+    ///
+    /// A duration in the model is a multiple of the voice's unit note length, so a quarter
+    /// note is `4 × duration × L`.  Tuplets scale by `q/p`; everything untimed is zero.
+    static func quarters(of event: Event, unitNoteLength: Fraction) -> Rational {
+        let unit = Rational(4 * unitNoteLength.numerator, unitNoteLength.denominator)
+        switch event {
+        case .note(let n):  return unit * Rational(n.duration.numerator, n.duration.denominator)
+        case .rest(let r):  return unit * Rational(r.duration.numerator, r.duration.denominator)
+        case .chord(let c): return unit * Rational(c.duration.numerator, c.duration.denominator)
+        case .tuplet(let t):
+            // Summed the way `ColumnMetrics` sums it, so the merge and the sizer never
+            // disagree about how long a tuplet is — a nested one included.
+            let written = t.events.reduce(Rational.zero) { total, inner in
+                switch inner {
+                case .note(let n):  return total + Rational(n.duration.numerator, n.duration.denominator)
+                case .rest(let r):  return total + Rational(r.duration.numerator, r.duration.denominator)
+                case .chord(let c): return total + Rational(c.duration.numerator, c.duration.denominator)
+                default:            return total
+                }
+            }
+            return unit * written * Rational(t.q, t.p)
+        default:
+            return .zero
+        }
+    }
+
+    static func * (lhs: Rational, rhs: Rational) -> Rational {
+        Rational(lhs.numerator * rhs.numerator, lhs.denominator * rhs.denominator)
+    }
+}

--- a/Sources/CeolKitSVGRenderer/Layout/VoiceAligner.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VoiceAligner.swift
@@ -24,8 +24,21 @@ enum VoiceAligner {
     struct AlignedStave {
         /// `measures[voiceIndex]` — one entry per voice, all of the same count.
         let measures: [[Measure]]
+        /// How many of each voice's measures the source actually wrote; everything from
+        /// there to ``measureCount`` is padding this pass invented.
+        ///
+        /// Recorded rather than recognised later: an invisible full-measure rest is
+        /// something an author may legitimately write, and a shared staff has to drop the
+        /// padding while keeping the `X` that was typed (see ``SharedStaffMerger``).
+        let realMeasureCounts: [Int]
 
         var measureCount: Int { measures.first?.count ?? 0 }
+
+        /// Whether `voice` has nothing of its own in `column`.
+        func isPadding(voice: Int, column: Int) -> Bool {
+            guard realMeasureCounts.indices.contains(voice) else { return false }
+            return column >= realMeasureCounts[voice]
+        }
     }
 
     /// Aligns `voices` stave by stave, padding wherever they disagree.
@@ -40,7 +53,9 @@ enum VoiceAligner {
         guard !voices.isEmpty else { return [] }
         // The single-voice case has nothing to align and nothing to warn about.
         guard voices.count > 1 else {
-            return voices[0].staves.map { AlignedStave(measures: [$0.measures]) }
+            return voices[0].staves.map {
+                AlignedStave(measures: [$0.measures], realMeasureCounts: [$0.measures.count])
+            }
         }
 
         let staveCount = voices.reduce(0) { max($0, $1.staves.count) }
@@ -59,7 +74,8 @@ enum VoiceAligner {
                 diagnostics.append(diagnostic)
             }
 
-            result.append(AlignedStave(measures: perVoice.map { pad($0, to: width) }))
+            result.append(AlignedStave(measures: perVoice.map { pad($0, to: width) },
+                                       realMeasureCounts: perVoice.map(\.count)))
             measureOrigin += width
         }
 

--- a/Sources/CeolKitSVGRenderer/Layout/VoiceSelector.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VoiceSelector.swift
@@ -7,26 +7,52 @@ import CeolKitModel
 /// the score directive."  A plan therefore both *filters* and *orders*, and its order wins
 /// over the order the voices were declared in.
 ///
-/// **One staff per voice, always.**  This pass runs ahead of the shared-staff work, so the
-/// voices of a `( … )` group each get a staff of their own and a floating `*V` gets one at
-/// the position it was written; both say so in a `staffPlanNotFullyApplied` diagnostic.
-/// That is strictly better than ignoring the directive — the right voices print in the right
-/// order, and only the vertical grouping is missing — and it keeps every voice the plan
-/// names on the page, which silently dropping the ones this pass cannot group would not.
+/// **A `( … )` group is one staff.**  Its voices come back as several entries of ``voices``
+/// mapped by ``Selection/staffOfVoice`` onto a single printed staff, which the driver hands
+/// to ``SharedStaffMerger`` to lay out on a common onset grid.  A floating `*V` still gets a
+/// staff of its own at the position it was written, and says so in a
+/// `staffPlanNotFullyApplied` diagnostic: that is strictly better than ignoring the directive
+/// — the right voices print in the right order, and only the vertical placement is missing —
+/// and it keeps every voice the plan names on the page, which silently dropping the ones this
+/// pass cannot place would not.
 ///
 /// **It also translates the plan's grouping into printed staff indices.**  `StaffPlanLayout`
-/// counts staves in the *plan*, and the four approximations above mean those are not the
+/// counts staves in the *plan*, and a dropped voice or a floating one means those are not the
 /// staves that reach the page.  This is the only pass that sees both numberings at once, so
 /// it is the one that has to do the translation; see ``Selection/grouping``.
 enum VoiceSelector {
 
     /// What the plan asked for, in the terms the rest of the layout works in.
     struct Selection {
-        /// The voices to print, top to bottom — one staff each.
+        /// The voices to print, top to bottom.
         let voices: [Voice]
-        /// The plan's spans and bar-line joins over ``voices``, or `nil` when there was no
-        /// plan to take them from, or the plan selected nothing and was fallen back from.
+        /// Which printed staff each of ``voices`` is drawn on, parallel to it.  Two voices
+        /// share an entry exactly when the plan put them in one `( … )` group; otherwise
+        /// this is `[0, 1, 2, …]` and a staff is a voice, as it always was.
+        let staffOfVoice: [Int]
+        /// The plan's spans and bar-line joins over the *printed staves*, or `nil` when there
+        /// was no plan to take them from, or the plan selected nothing and was fallen back from.
         let grouping: StaffGrouping?
+
+        /// How many staves will be drawn.
+        var staffCount: Int { (staffOfVoice.max() ?? -1) + 1 }
+
+        /// The voices on each printed staff, top to bottom.
+        var voicesByStaff: [[Int]] {
+            (0..<staffCount).map { staff in voices.indices.filter { staffOfVoice[$0] == staff } }
+        }
+
+        /// One staff per voice, in the order given — the shape every tune without a `( … )`
+        /// group has.
+        init(voices: [Voice], grouping: StaffGrouping?) {
+            self.init(voices: voices, staffOfVoice: Array(voices.indices), grouping: grouping)
+        }
+
+        init(voices: [Voice], staffOfVoice: [Int], grouping: StaffGrouping?) {
+            self.voices = voices
+            self.staffOfVoice = staffOfVoice
+            self.grouping = grouping
+        }
     }
 
     /// - Parameters:
@@ -48,11 +74,13 @@ enum VoiceSelector {
         let byId = Dictionary(voices.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
 
         var printed: [Voice] = []
+        var staffOfVoice: [Int] = []
         var seen: Set<VoiceId> = []
-        // Printed staff indices contributed by each staff of the plan, in order.  Empty for a
-        // plan staff whose every voice was dropped; more than one where a `( … )` shared staff
-        // was expanded to a staff per voice.
-        var printedByPlanStaff = [[Int]](repeating: [], count: layout.staves.count)
+        // The printed staff each staff of the plan turned into.  Absent for a plan staff whose
+        // every voice was dropped; shared by every voice of a `( … )` group, which is what
+        // makes the group one staff.
+        var staffForPlanStaff: [Int: Int] = [:]
+        var nextStaff = 0
         for (id, planStaff) in order(of: layout) {
             guard seen.insert(id).inserted else {
                 diagnostics.append(Diagnostic(
@@ -73,9 +101,21 @@ enum VoiceSelector {
             // the tune body, and this one does not appear there.  Not worth a diagnostic —
             // the plan is right and the body simply has nothing to say.
             guard !voice.isEmpty else { continue }
-            if let planStaff { printedByPlanStaff[planStaff].append(printed.count) }
+            // A floating voice belongs to no staff of the plan, so it takes one of its own.
+            let staff: Int
+            if let planStaff, let existing = staffForPlanStaff[planStaff] {
+                staff = existing
+            } else {
+                staff = nextStaff
+                nextStaff += 1
+                if let planStaff { staffForPlanStaff[planStaff] = staff }
+            }
+            staffOfVoice.append(staff)
             printed.append(voice)
         }
+        // Printed staff indices contributed by each staff of the plan: at most one now, and
+        // none where every voice of a plan staff was dropped.
+        let printedByPlanStaff = layout.staves.indices.map { staffForPlanStaff[$0].map { [$0] } ?? [] }
 
         guard !printed.isEmpty else {
             // Reporting each voice as unprinted would be a lie: the fallback prints them all.
@@ -89,7 +129,7 @@ enum VoiceSelector {
 
         diagnostics += omissions(from: printable, namedBy: layout, plan: plan)
         diagnostics += approximations(of: layout, printedBy: printed, plan: plan)
-        return Selection(voices: printed,
+        return Selection(voices: printed, staffOfVoice: staffOfVoice,
                          grouping: grouping(of: layout, printedBy: printedByPlanStaff))
     }
 
@@ -144,13 +184,6 @@ enum VoiceSelector {
                   let bottom = printedByPlanStaff[above + 1].first else { continue }
             joins.formUnion(top..<bottom)
         }
-        // §11.1 says nothing about the boundary between two staves that are one staff in the
-        // source: a `( … )` group the shared-staff work has not landed for yet.  Continuing
-        // the bar line through it is the closest drawing to the single staff it stands in for.
-        for printed in printedByPlanStaff where printed.count > 1 {
-            joins.formUnion(printed.dropLast())
-        }
-
         return StaffGrouping(spans: spans, barlineJoins: joins)
     }
 
@@ -181,16 +214,6 @@ enum VoiceSelector {
         let ids = Set(printed.map(\.id))
         var result: [Diagnostic] = []
 
-        for staff in layout.staves {
-            let sharing = staff.filter { ids.contains($0) }
-            guard sharing.count > 1 else { continue }
-            result.append(Diagnostic(
-                severity: .info, code: .staffPlanNotFullyApplied,
-                message: "voices \(list(sharing)) share one staff in the plan; "
-                       + "each is drawn on a staff of its own for now",
-                source: plan.source))
-        }
-
         for floating in layout.floating where ids.contains(floating.id) {
             result.append(Diagnostic(
                 severity: .info, code: .staffPlanNotFullyApplied,
@@ -211,7 +234,4 @@ enum VoiceSelector {
         }
     }
 
-    private static func list(_ ids: [VoiceId]) -> String {
-        ids.map(label).joined(separator: ", ")
-    }
 }

--- a/Tests/CeolKitSVGRendererTests/SharedStaffMergeTests.swift
+++ b/Tests/CeolKitSVGRendererTests/SharedStaffMergeTests.swift
@@ -1,0 +1,317 @@
+import Testing
+import CeolKitModel
+import CeolKitParser
+import CeolKitSVGGeometry
+@testable import CeolKitSVGRenderer
+
+// MARK: - Helpers
+
+private let config   = SVGRenderConfig()
+private let metadata = try! BravuraMetadata.load()
+private let sizer    = MeasureSizer(config: config, metadata: metadata)
+private let eighth   = Fraction(numerator: 1, denominator: 8)
+
+/// The first bar of every voice of `abc`, in `V:` declaration order.
+private func firstBars(_ abc: String) -> [Measure] {
+    CeolKitParser().parse(abc, options: .default).score.tunes[0]
+        .voices.map { $0.staves[0].measures[0] }
+}
+
+private func shared(_ measures: [Measure], padding: Set<Int> = [],
+                    unitNoteLength: Fraction = eighth) -> SizedMeasure {
+    sizer.size(sharedStaff: measures.enumerated().map { index, measure in
+        MeasureSizer.SharedVoice(measure: measure, unitNoteLength: unitNoteLength,
+                                 voiceIndex: index, isPadding: padding.contains(index))
+    })
+}
+
+/// The offsets of one voice's events within a merged measure.
+private func offsets(of voice: Int, in merged: SizedMeasure) -> [Double] {
+    zip(merged.eventOffsets, merged.eventVoiceIndices).filter { $0.1 == voice }.map(\.0)
+}
+
+/// The merged measure's distinct x positions, left to right.  Two events at the same x are
+/// one column, which is the whole point of the merge.
+private func columns(of merged: SizedMeasure) -> [Double] {
+    Array(Set(merged.eventOffsets)).sorted()
+}
+
+private func isClose(_ a: Double, _ b: Double) -> Bool { abs(a - b) < 1e-9 }
+
+/// Issue #76: the voices of a `%%score ( … )` group are merged onto one onset grid so they
+/// can share a staff.  Everything here is layout — the emitter draws whatever the offsets
+/// say, and #77/#78 are what make it *look* like two voices.
+@Suite("Shared staff merge")
+struct SharedStaffMergeTests {
+
+    // MARK: - Degenerate cases: the merge must vanish
+
+    @Test("Two identical voices lay out exactly as one voice alone")
+    func identicalVoicesMatchOneVoice() {
+        let bars = firstBars("""
+            X:1
+            L:1/8
+            K:C
+            V:1
+            V:2
+            [V:1]CDEFGABc|
+            [V:2]CDEFGABc|
+            """)
+        let merged = shared(bars)
+        let alone  = sizer.size(bars[0], unitNoteLength: eighth)
+
+        #expect(isClose(merged.naturalWidth, alone.naturalWidth))
+        #expect(columns(of: merged).count == 8)
+        for voice in 0...1 {
+            #expect(zip(offsets(of: voice, in: merged), alone.eventOffsets).allSatisfy(isClose))
+        }
+    }
+
+    @Test("A voice the aligner padded contributes no columns at all")
+    func paddedVoiceContributesNothing() {
+        // The second voice's bar is one the aligner invented, so the staff is the first
+        // voice's alone — invisible rest and all, it must not widen a single column.
+        let bars = firstBars("""
+            X:1
+            L:1/8
+            K:C
+            V:1
+            V:2
+            [V:1]CDEF|
+            [V:2]X|
+            """)
+        let merged = shared(bars, padding: [1])
+        let alone  = sizer.size(bars[0], unitNoteLength: eighth)
+
+        #expect(isClose(merged.naturalWidth, alone.naturalWidth))
+        #expect(zip(merged.eventOffsets, alone.eventOffsets).allSatisfy(isClose))
+        #expect(merged.measure.events.count == alone.measure.events.count)
+        #expect(merged.eventVoiceIndices.allSatisfy { $0 == 0 })
+    }
+
+    @Test("Every voice padded leaves a bar with no music in it")
+    func everyVoicePadded() {
+        let bars = firstBars("""
+            X:1
+            L:1/8
+            K:C
+            V:1
+            V:2
+            [V:1]X|
+            [V:2]X|
+            """)
+        let merged = shared(bars, padding: [0, 1])
+        #expect(merged.eventOffsets.isEmpty)
+        #expect(merged.measure.events.isEmpty)
+    }
+
+    // MARK: - Onsets
+
+    @Test("Notes that sound together land in one column at one x")
+    func simultaneousNotesShareAColumn() {
+        let bars = firstBars("""
+            X:1
+            L:1/8
+            K:C
+            V:1
+            V:2
+            [V:1]CDEF|
+            [V:2]EFGA|
+            """)
+        let merged = shared(bars)
+
+        #expect(merged.eventOffsets.count == 8)
+        #expect(columns(of: merged).count == 4)
+        // Emitted voice by voice within each onset, so the pairs are adjacent.
+        #expect(merged.eventVoiceIndices == [0, 1, 0, 1, 0, 1, 0, 1])
+        for pair in stride(from: 0, to: 8, by: 2) {
+            #expect(isClose(merged.eventOffsets[pair], merged.eventOffsets[pair + 1]))
+        }
+    }
+
+    @Test("Voices in strict alternation interleave, each note at its own onset")
+    func alternatingVoicesInterleave() {
+        // V:1 sounds on the beat, V:2 off it: onsets 0, ½, 1, 1½ quarter notes.
+        let bars = firstBars("""
+            X:1
+            L:1/8
+            K:C
+            V:1
+            V:2
+            [V:1]C2E2|
+            [V:2]zD2z|
+            """)
+        let merged = shared(bars)
+        let grid = columns(of: merged)
+
+        #expect(grid.count == 4)
+        // The upper voice took the first and third columns…
+        let upper = offsets(of: 0, in: merged)
+        #expect(upper.count == 2)
+        #expect(isClose(upper[0], grid[0]))
+        #expect(isClose(upper[1], grid[2]))
+        // …and the lower voice's note landed between them, on a column of its own.
+        let lower = offsets(of: 1, in: merged)
+        #expect(lower.count == 3)
+        #expect(isClose(lower[0], grid[0]))
+        #expect(isClose(lower[1], grid[1]))
+        #expect(isClose(lower[2], grid[3]))
+    }
+
+    @Test("A long note is spaced by the onsets it sounds across, not by its own length")
+    func longNoteSpansTheColumnsUnderIt() {
+        // A half note against four eighths: the half note occupies the first of four
+        // columns, and the eighths keep an eighth note's spacing under it.
+        let bars = firstBars("""
+            X:1
+            L:1/8
+            K:C
+            V:1
+            V:2
+            [V:1]C4|
+            [V:2]EFGA|
+            """)
+        let merged = shared(bars)
+        let grid = columns(of: merged)
+
+        #expect(grid.count == 4)
+        #expect(isClose(offsets(of: 0, in: merged)[0], grid[0]))
+        // The four eighth columns are evenly spaced — the long note widened none of them.
+        let steps = zip(grid.dropFirst(), grid).map(-)
+        #expect(steps.allSatisfy { isClose($0, steps[0]) })
+        // And the lower voice alone would have used exactly the same grid.
+        let alone = sizer.size(bars[1], unitNoteLength: eighth)
+        #expect(zip(grid, alone.eventOffsets).allSatisfy(isClose))
+    }
+
+    @Test("Voices with different L: values still meet on the same onsets")
+    func differingUnitNoteLengthsAgree() {
+        // `C2` at L:1/8 and `C` at L:1/4 are the same quarter note, so the two voices sound
+        // together on every beat and the staff gets four columns, not eight.
+        let bars = firstBars("""
+            X:1
+            L:1/8
+            K:C
+            V:1
+            V:2
+            [V:1]C2D2E2F2|
+            [V:2][L:1/4]CDEF|
+            """)
+        let merged = sizer.size(sharedStaff: [
+            MeasureSizer.SharedVoice(measure: bars[0], unitNoteLength: eighth,
+                                     voiceIndex: 0, isPadding: false),
+            MeasureSizer.SharedVoice(measure: bars[1],
+                                     unitNoteLength: Fraction(numerator: 1, denominator: 4),
+                                     voiceIndex: 1, isPadding: false)
+        ])
+        #expect(merged.eventOffsets.count == 8)
+        #expect(columns(of: merged).count == 4)
+    }
+
+    // MARK: - Grace notes
+
+    @Test("A grace group keeps its principal note adjacent, and its gap unchanged")
+    func graceGroupsSurviveTheMerge() throws {
+        let bars = firstBars("""
+            X:1
+            L:1/8
+            K:C
+            V:1
+            V:2
+            [V:1]{g}A2B2|
+            [V:2]C2D2|
+            """)
+        let merged = shared(bars)
+        let alone  = sizer.size(bars[0], unitNoteLength: eighth)
+
+        #expect(!merged.graceEventIndices.isEmpty)
+        let graceIndex = try #require(alone.graceEventIndices.min())
+        let aloneGap = alone.eventOffsets[graceIndex + 1] - alone.eventOffsets[graceIndex]
+        for index in merged.graceEventIndices {
+            // Adjacency is what `Justifier.stretchOffsets` reads, so it is the contract.
+            #expect(index + 1 < merged.measure.events.count)
+            if case .grace = merged.measure.events[index] {} else { Issue.record("not a grace") }
+            #expect(merged.eventVoiceIndices[index] == merged.eventVoiceIndices[index + 1])
+            // The grace-to-note gap is a fixed measurement, so the merge must not change it.
+            #expect(isClose(merged.eventOffsets[index + 1] - merged.eventOffsets[index], aloneGap))
+        }
+    }
+
+    @Test("Justification preserves the grace gap of a merged measure")
+    func justifyingAMergedMeasureKeepsTheGraceGap() {
+        let bars = firstBars("""
+            X:1
+            L:1/8
+            K:C
+            V:1
+            V:2
+            [V:1]{g}A2B2|
+            [V:2]C2D2|
+            """)
+        let merged = shared(bars)
+        let index  = merged.graceEventIndices.min()!
+        let gap    = merged.eventOffsets[index + 1] - merged.eventOffsets[index]
+
+        let system = System(measures: [merged], isLastSystem: false, sourceForced: false)
+        let justified = Justifier().justify([system], usableWidth: merged.naturalWidth * 2,
+                                            justifyLastSystem: true)
+        let stretched = justified[0].measures[0]
+
+        #expect(stretched.eventOffsets != merged.eventOffsets)   // it really did stretch
+        #expect(isClose(stretched.eventOffsets[index + 1] - stretched.eventOffsets[index], gap))
+        // The voices still meet: the second voice's first note stayed under the first
+        // voice's, which is what an out-of-order offsets array most easily breaks.
+        let upper = zip(stretched.eventOffsets, stretched.eventVoiceIndices)
+            .filter { $0.1 == 0 }.map(\.0)
+        let lower = zip(stretched.eventOffsets, stretched.eventVoiceIndices)
+            .filter { $0.1 == 1 }.map(\.0)
+        #expect(isClose(upper[1], lower[0]))   // grace's principal over voice 2's first note
+    }
+
+    // MARK: - End to end
+
+    @Test("%%score (1 2) draws one staff; %%score [1 2] still draws two")
+    func planDecidesTheStaffCount() throws {
+        func staffCount(_ plan: String) throws -> Int {
+            let abc = """
+                X:1
+                L:1/4
+                \(plan)
+                V:1
+                V:2
+                K:C
+                [V:1]CDEF|
+                [V:2]EFGA|
+                """
+            let score = CeolKitParser().parse(abc, options: .default).score
+            var diagnostics: [Diagnostic] = []
+            let svgs = try SVGRenderer().render(score, diagnostics: &diagnostics)
+            return try SVGGeometry.pages(from: svgs).flatMap(\.systems).count
+        }
+        #expect(try staffCount("%%score (1 2)") == 1)
+        #expect(try staffCount("%%score [1 2]") == 2)
+    }
+
+    @Test("Voices on separate staves are sized exactly as the single-voice sizer sizes them")
+    func separateStavesAreUntouched() {
+        // The driver runs every staff through the shared-staff entry point, so a staff of one
+        // voice has to come out of it bit for bit as it did before the merge existed.
+        let bars = firstBars("""
+            X:1
+            L:1/8
+            K:C
+            V:1
+            V:2
+            [V:1]{g}CDEFG2A2|
+            [V:2]EFGAB2c2|
+            """)
+        for bar in bars {
+            let viaShared = shared([bar])
+            let alone     = sizer.size(bar, unitNoteLength: eighth)
+            #expect(isClose(viaShared.naturalWidth, alone.naturalWidth))
+            #expect(zip(viaShared.eventOffsets, alone.eventOffsets).allSatisfy(isClose))
+            #expect(viaShared.graceEventIndices == alone.graceEventIndices)
+            #expect(viaShared.eventVoiceIndices == alone.eventVoiceIndices)
+        }
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/StaffPlanSelectionTests.swift
+++ b/Tests/CeolKitSVGRendererTests/StaffPlanSelectionTests.swift
@@ -16,12 +16,13 @@ struct StaffPlanSelectionTests {
     // MARK: - Helpers
 
     /// Runs the selection the renderer runs, on a real parse.
-    private func select(_ abc: String) -> (voices: [VoiceId], diagnostics: [Diagnostic]) {
+    private func select(_ abc: String)
+        -> (voices: [VoiceId], selection: VoiceSelector.Selection, diagnostics: [Diagnostic]) {
         let tune = CeolKitParser().parse(abc, options: .default).score.tunes[0]
         var diagnostics: [Diagnostic] = []
         let plan = tune.staffPlans.last { $0.effectiveFromStave == 0 }?.plan
         let chosen = VoiceSelector.select(from: tune.voices, plan: plan, into: &diagnostics)
-        return (chosen.voices.map(\.id), diagnostics)
+        return (chosen.voices.map(\.id), chosen, diagnostics)
     }
 
     private func codes(_ diagnostics: [Diagnostic], _ code: DiagnosticCode) -> [Diagnostic] {
@@ -110,15 +111,14 @@ struct StaffPlanSelectionTests {
 
     // MARK: - Approximations this phase makes
 
-    @Test("A shared-staff group is drawn as separate staves, and says so")
-    func sharedStaffIsSeparateForNow() {
+    @Test("A shared-staff group keeps both voices and puts them on one staff")
+    func sharedStaffIsOneStaff() {
         let result = select(threeVoices("%%score (1 2)"))
         #expect(result.voices == [.named("1"), .named("2")])
-
-        let notes = codes(result.diagnostics, .staffPlanNotFullyApplied)
-        #expect(notes.count == 1)
-        #expect(notes.first?.message.contains("share one staff") == true)
-        #expect(notes.first?.severity == .info)
+        #expect(result.selection.staffOfVoice == [0, 0])
+        #expect(result.selection.staffCount == 1)
+        // Nothing is approximated any more: #76 lays the group out on a shared staff.
+        #expect(codes(result.diagnostics, .staffPlanNotFullyApplied).isEmpty)
     }
 
     @Test("A floating voice keeps the position it was written at, and says so")
@@ -214,9 +214,9 @@ struct StaffPlanSelectionTests {
         #expect(render(threeVoices("%%score [1 2]")).pages.flatMap(\.systems).count == 2)
     }
 
-    @Test("%%score (1 2) renders two staves at this phase, not one")
-    func sharedStaffStillDrawsTwo() {
-        #expect(render(threeVoices("%%score (1 2)")).pages.flatMap(\.systems).count == 2)
+    @Test("%%score (1 2) renders one staff carrying both voices")
+    func sharedStaffDrawsOne() {
+        #expect(render(threeVoices("%%score (1 2)")).pages.flatMap(\.systems).count == 1)
     }
 
     /// Two voices on known source lines.  The system's scroll-sync anchor is taken from the

--- a/Tests/CeolKitSVGRendererTests/StaffSpanThreadingTests.swift
+++ b/Tests/CeolKitSVGRendererTests/StaffSpanThreadingTests.swift
@@ -101,13 +101,13 @@ struct StaffSpanThreadingTests {
         #expect(grouping.barlineJoins == [0, 1])
     }
 
-    @Test("The staves standing in for one shared staff are joined")
-    func sharedStaffStandInsAreJoined() throws {
-        // `(1 2)` is one staff in the source and two on the page until the shared-staff work
-        // lands; a continued bar line is the closest drawing to the staff it stands in for.
+    @Test("A shared staff is one staff, so the span over it covers one")
+    func sharedStaffIsOneStaff() throws {
+        // `(1 2)` is one staff in the source and one on the page (#76), so the bracket
+        // covers two staves and there is no boundary inside the group to join.
         let grouping = try #require(selectGrouping(threeVoices("%%score [(1 2) 3]")))
-        #expect(grouping.spans == [StaffGrouping.Span(bracket: .bracket, staves: 0...2, depth: 0)])
-        #expect(grouping.barlineJoins == [0])
+        #expect(grouping.spans == [StaffGrouping.Span(bracket: .bracket, staves: 0...1, depth: 0)])
+        #expect(grouping.barlineJoins.isEmpty)
     }
 
     @Test("A plan that selects no voice is fallen back from, grouping and all")


### PR DESCRIPTION
Closes #76.

`%%score ( … )` now draws **one staff carrying every voice of the group**, placed by onset rather than by array index. This is the load-bearing change of the §11.1 milestone.

## What lands

**`Layout/SharedStaffMerger.swift`** — the merge pass. Per bar it cuts each voice into onsets (exact rationals in quarter notes, so a tuplet against plain notes still compares equal), unions them into columns, and subdivides each column so the approach events — grace groups, spacers, directive anchors, tempo changes — right-align against the note. The principal sub-column is spaced for the distance to the *next* onset rather than for the note's own duration, so a half note against four eighths gets the four columns it sounds across instead of one wide one followed by three crushed ones.

It runs **before sizing, not after grouping**, exactly as the issue argues: `LineBreaker` and `Justifier` take a column's width as the max across staves, and no `max` can invent the extra columns interleaved onsets need.

**`Layout/ColumnMetrics.swift`** — the width and margin measurements lifted out of `MeasureSizer`, so the single-voice sizer and the merge cannot drift apart. A staff with one sounding voice must lay out exactly as it did before, and it only does that if there is one implementation of "how wide is this column".

## The two traps the issue names

**Padding is dropped, not merged.** `VoiceAligner.AlignedStave` now records `realMeasureCounts` and answers `isPadding(voice:column:)`. Recorded rather than recognised later: an invisible full-measure rest is something an author may legitimately write, and the merge has to drop the padding while keeping the `X` that was typed.

**Grace groups keep their principal note adjacent**, so merged events are emitted voice by voice within an onset rather than sub-column by sub-column. That makes the offsets array step backwards every time a new voice starts its run — which the running total in `Justifier.stretchOffsets` would have mis-scaled. Fixed grace width is now derived from the offsets (with an array-position tiebreak) instead of from array order; provably identical for monotonic single-voice input.

## Also

- `VoiceSelector.Selection` gains `staffOfVoice`; a `( … )` group maps to one printed staff. The `staffPlanNotFullyApplied` note for shared staves and the bar-line-join hack that stood in for one staff are both gone.
- The driver sizes per *staff* rather than per voice; clef, key and gutter label come from the top voice of each staff.
- `eventVoiceIndices` is now the voice's position **within its staff** (0 on a single-voice staff) — which staff it is, the enclosing `System` already says. That is the form #77 and #78 need.

## Acceptance

| Criterion | Test |
| --- | --- |
| Two identical voices == one voice alone | `identicalVoicesMatchOneVoice` |
| Strict alternation interleaves columns | `alternatingVoicesInterleave` |
| Simultaneous notes share one x | `simultaneousNotesShareAColumn` |
| Padded voice contributes no columns | `paddedVoiceContributesNothing` |
| Grace principal stays adjacent, spacing unchanged | `graceGroupsSurviveTheMerge`, `justifyingAMergedMeasureKeepsTheGraceGap` |
| Separate staves untouched | `separateStavesAreUntouched`, `planDecidesTheStaffCount` |

Plus differing `L:` between co-tenants, and a long note spanning the columns under it.

## Verification

- Full suite: **916 tests pass**.
- Byte-identity for separate staves checked for real, not just asserted: rendered `tunebook.abc` and a two-staff grace/tuplet tune with this branch and with `develop`, and diffed. The only difference anywhere is the footer's own `%H:%M` timestamp, which ticked over between the two runs.

## Not in scope

Stems, beams, ties, slurs and simultaneous rests on a shared staff are still wrong — that is #77 and #78, which this unblocks. A `%%score ( … )` page today shows both voices correctly *placed* and incorrectly *drawn*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KR3aznXhn6agRykrrBdPH1