### PR TITLE
Fix #77 — draw a shared staff as two parts: opposed stems, offset rests

### DIFF
--- a/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
+++ b/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
@@ -171,6 +171,10 @@ public struct SVGRenderer: CeolKitRenderer {
                 }
                 let laterLabels = staffLead.map { printedVoices[$0].properties.subname }
 
+                // The clef, key and label are the staff lead's; the stem directions are
+                // every tenant's, in staff order.  A shared staff opposes its voices' stems
+                // rather than reading each note's pitch (issue #77), and it is the voices
+                // that were *not* drawn first whose own `stem=` would otherwise be lost.
                 let voiceLines = staffLead.enumerated().map { staffIndex, voice in
                     LineBreaker.VoiceLine(measures: columnsPerStaff[staffIndex],
                                           clef: printedVoices[voice].properties.clef,
@@ -178,7 +182,9 @@ public struct SVGRenderer: CeolKitRenderer {
                                           meter: regionMeter,
                                           firstSystemLabel: firstLabels[staffIndex],
                                           laterSystemLabel: laterLabels[staffIndex],
-                                          stemDirection: printedVoices[voice].properties.stemDirection)
+                                          voiceStemDirections: voicesByStaff[staffIndex].map {
+                                              printedVoices[$0].properties.stemDirection
+                                          })
                 }
                 // Space for the region's braces and brackets, reserved before anything is
                 // packed into the line.  It is added to the header widths rather than taken
@@ -387,7 +393,7 @@ private extension SystemGroup {
             System(measures: $0.measures, isLastSystem: isLast, sourceForced: $0.sourceForced,
                    staveWasSplit: $0.staveWasSplit, clef: $0.clef,
                    keySignature: $0.keySignature, meter: $0.meter,
-                   voiceLabel: $0.voiceLabel, stemDirection: $0.stemDirection)
+                   voiceLabel: $0.voiceLabel, voiceStemDirections: $0.voiceStemDirections)
         }, grouping: grouping)
     }
 }

--- a/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
@@ -49,19 +49,26 @@ struct SVGEmitter: Sendable {
     /// `V:` `stem=` overrides it (issue #74), so this is the fallback rather than the answer
     /// — see ``configured(for:)``.
     let documentStemDirection: StemDirection
-    /// The direction in force for the system being emitted: the voice's own where it stated
-    /// one, ``documentStemDirection`` where it did not.  `.auto` leaves the choice to the
-    /// note's staff position, which is the ordinary engraving rule.
+    /// The direction in force for the staff being emitted, where its voices state none of
+    /// their own: the lead voice's where it stated one, ``documentStemDirection`` where it
+    /// did not.  `.auto` leaves the choice to the note's staff position, which is the
+    /// ordinary engraving rule.
     let stemDirection: StemDirection
+    /// What each voice of the staff being emitted asked for with `V:` `stem=`, in staff
+    /// order — carried from ``ResolvedSystem/voiceStemDirections``, so its count is how many
+    /// voices share the staff.  Empty on the page-level emitter, which draws nothing itself.
+    let voiceStemDirections: [StemDirection]
     let accidentalMetrics: AccidentalMetrics
 
     init(config: SVGRenderConfig, metadata: BravuraMetadata,
          stemDirection: StemDirection = .auto,
-         systemStemDirection: StemDirection? = nil) {
+         systemStemDirection: StemDirection? = nil,
+         voiceStemDirections: [StemDirection] = []) {
         self.config = config
         self.metadata = metadata
         self.documentStemDirection = stemDirection
         self.stemDirection = systemStemDirection ?? stemDirection
+        self.voiceStemDirections = voiceStemDirections
         self.accidentalMetrics = AccidentalMetrics(config: config, metadata: metadata)
     }
 
@@ -137,12 +144,80 @@ struct SVGEmitter: Sendable {
         let systemStem = system.stemDirection != .auto ? system.stemDirection : documentStemDirection
         guard system.staffSize != config.staffSize
                 || system.graceNoteSpacing != config.graceNoteSpacing
-                || systemStem != stemDirection else { return self }
+                || systemStem != stemDirection
+                || system.voiceStemDirections != voiceStemDirections else { return self }
         var systemConfig = config
         systemConfig.staffSize = system.staffSize
         systemConfig.graceNoteSpacing = system.graceNoteSpacing
         return SVGEmitter(config: systemConfig, metadata: metadata,
-                          stemDirection: documentStemDirection, systemStemDirection: systemStem)
+                          stemDirection: documentStemDirection, systemStemDirection: systemStem,
+                          voiceStemDirections: system.voiceStemDirections)
+    }
+
+    // MARK: - Voices on a staff
+
+    /// How many voices are drawn on the staff being emitted.  One everywhere but inside a
+    /// `%%score ( … )` group (§11.1).
+    private var staffVoiceCount: Int { max(1, voiceStemDirections.count) }
+
+    /// Which way voice `index` of this staff stems, before the note's own pitch is consulted.
+    ///
+    /// The order is the one §11.1 implies and #77 asks for: what the voice itself said with
+    /// `V:` `stem=` beats everything; failing that, a staff shared by more than one voice
+    /// opposes them — the top voice up and the bottom voice down, whatever the pitches, so
+    /// that a low note in the upper voice and a high note in the lower one stay legible as
+    /// two parts; failing *that*, the staff's own answer (`%%ceolkit:pipeformat`, else
+    /// `.auto` for the pitch rule).
+    ///
+    /// A staff with three or more voices opposes only its outer two.  Nothing an engraver
+    /// draws opposes a middle voice against both its neighbours, so it keeps the ordinary
+    /// rule.
+    private func resolvedStemDirection(forVoice index: Int) -> StemDirection {
+        let own = index < voiceStemDirections.count ? voiceStemDirections[index] : .auto
+        guard own == .auto else { return own }
+        guard staffVoiceCount > 1 else { return stemDirection }
+        if index == 0 { return .up }
+        if index == staffVoiceCount - 1 { return .down }
+        return documentStemDirection
+    }
+
+    /// How far off centre a rest of voice `index` is drawn, in points, positive downward.
+    ///
+    /// Two voices resting at the same onset draw the same glyph at the same x, so without
+    /// this they land exactly on top of each other and the staff reads as one part resting.
+    /// An engraver separates them the way the stems are separated: the upper voice's rest
+    /// one staff space above centre, the lower voice's one below.  A middle voice keeps the
+    /// centre, as its stems keep the pitch rule.
+    private func restOffset(forVoice index: Int) -> Double {
+        guard staffVoiceCount > 1 else { return 0 }
+        if index == 0 { return -config.staffSize }
+        if index == staffVoiceCount - 1 { return config.staffSize }
+        return 0
+    }
+
+    /// Which voices draw ink in `measure` — the ones a reader can see are there.
+    ///
+    /// A voice written as invisible rests (`x`, §4.9) occupies the bar without appearing in
+    /// it, and a bar where only one voice appears is read as that voice's alone.  Rests are
+    /// therefore left centred there: displacing the only rest on the staff would open a gap
+    /// under a part nobody can see.  It is what `abcm2ps -g` draws for the `x8` bars of the
+    /// §7 Zocharti Loch example, and the stems are deliberately *not* conditioned this way —
+    /// a voice keeps one stem direction for the whole staff however its partner is written.
+    private func inkedVoices(of measure: ResolvedMeasure) -> Set<Int> {
+        var voices: Set<Int> = []
+        for event in measure.events {
+            switch event.kind {
+            case .note, .chord, .grace, .tuplet:
+                voices.insert(event.voiceIndex)
+            case .rest(let r):
+                if r.kind != .invisible && r.kind != .fullMeasureInvisible {
+                    voices.insert(event.voiceIndex)
+                }
+            case .spacer, .directiveAnchor, .tempoChange:
+                break
+            }
+        }
+        return voices
     }
 
     // MARK: - Scroll-sync metadata
@@ -539,6 +614,9 @@ struct SVGEmitter: Sendable {
                                    system: system, builder: &builder)
         }
 
+        // Two parts are only visibly two where both of them draw: see `inkedVoices(of:)`.
+        let separateRests = inkedVoices(of: measure).count > 1
+
         // Beam accumulator: per-note (StemInfo, beamCount) pairs for the current beam run.
         var pendingBeam: [(stem: StemInfo, beamCount: Int)]?
         // Grace note beam tip Y for the note that immediately follows; reset after each non-grace event.
@@ -560,6 +638,7 @@ struct SVGEmitter: Sendable {
             }
             let stemInfo = emitEvent(event, topStaffY: topY, bottomStaffY: bottomY,
                                      unitNoteLength: measure.unitNoteLength,
+                                     separateRests: separateRests,
                                      precedingGraceBeamY: lastGraceBeamY,
                                      builder: &builder)
             lastGraceBeamY = nil
@@ -830,20 +909,30 @@ struct SVGEmitter: Sendable {
 
     @discardableResult
     private func emitEvent(_ event: ResolvedEvent, topStaffY: Double, bottomStaffY: Double,
-                           unitNoteLength: Fraction, precedingGraceBeamY: Double? = nil,
+                           unitNoteLength: Fraction, separateRests: Bool = false,
+                           precedingGraceBeamY: Double? = nil,
                            builder: inout SVGBuilder) -> StemInfo? {
+        // Which voice of the staff wrote this decides which way it stems and where its
+        // rests sit — the two things a shared staff has to draw differently from a staff of
+        // its own (issue #77).  On every other staff `voiceIndex` is 0 and both resolve to
+        // exactly what they always did.
+        let stem = resolvedStemDirection(forVoice: event.voiceIndex)
         switch event.kind {
         case .note(let n):
             return emitNote(n, x: event.origin.x, topStaffY: topStaffY, bottomStaffY: bottomStaffY,
-                            unitNoteLength: unitNoteLength, precedingGraceBeamY: precedingGraceBeamY,
+                            unitNoteLength: unitNoteLength, stemDirection: stem,
+                            precedingGraceBeamY: precedingGraceBeamY,
                             builder: &builder)
         case .rest(let r):
             emitRest(r, x: event.origin.x, topStaffY: topStaffY, bottomStaffY: bottomStaffY,
-                     unitNoteLength: unitNoteLength, builder: &builder)
+                     unitNoteLength: unitNoteLength,
+                     voiceIndex: separateRests ? event.voiceIndex : nil,
+                     builder: &builder)
         case .chord(let c):
             for note in c.notes {
                 emitNote(note, x: event.origin.x, topStaffY: topStaffY, bottomStaffY: bottomStaffY,
-                         unitNoteLength: unitNoteLength, precedingGraceBeamY: precedingGraceBeamY,
+                         unitNoteLength: unitNoteLength, stemDirection: stem,
+                         precedingGraceBeamY: precedingGraceBeamY,
                          builder: &builder)
             }
         case .grace:
@@ -865,7 +954,8 @@ struct SVGEmitter: Sendable {
 
     @discardableResult
     private func emitNote(_ note: Note, x: Double, topStaffY: Double, bottomStaffY: Double,
-                          unitNoteLength: Fraction, precedingGraceBeamY: Double? = nil,
+                          unitNoteLength: Fraction, stemDirection: StemDirection,
+                          precedingGraceBeamY: Double? = nil,
                           builder: inout SVGBuilder) -> StemInfo? {
         let staffPos  = self.staffPos(for: note.pitch)
         let y         = noteY(staffPos: staffPos, bottomStaffY: bottomStaffY)
@@ -891,7 +981,7 @@ struct SVGEmitter: Sendable {
         var stemInfo: StemInfo?
         if absDur < 1.0 {
             stemInfo = emitStem(staffPos: staffPos, noteheadY: y, x: x, absDur: absDur,
-                                beamState: note.beam, builder: &builder)
+                                beamState: note.beam, direction: stemDirection, builder: &builder)
         }
 
         emitLedgerLines(staffPos: staffPos, x: x, bottomStaffY: bottomStaffY, builder: &builder)
@@ -925,11 +1015,15 @@ struct SVGEmitter: Sendable {
         return rounded % 3 == 0
     }
 
+    /// - Parameter direction: The direction resolved for this note's voice — its own
+    ///   `V:` `stem=`, the opposition a shared staff imposes, or the document's — with
+    ///   `.auto` left for the note's own staff position to settle here.
     @discardableResult
     private func emitStem(staffPos: Int, noteheadY: Double, x: Double, absDur: Double,
-                           beamState: BeamState, builder: inout SVGBuilder) -> StemInfo {
+                           beamState: BeamState, direction: StemDirection,
+                           builder: inout SVGBuilder) -> StemInfo {
         let stemUp: Bool
-        switch stemDirection {
+        switch direction {
         case .up:   stemUp = true
         case .down: stemUp = false
         case .auto: stemUp = staffPos <= 4
@@ -1120,8 +1214,13 @@ struct SVGEmitter: Sendable {
 
     // MARK: - Rests
 
+    /// - Parameter voiceIndex: Which voice of the staff is resting, where the bar draws more
+    ///   than one of them: it moves the glyph off centre so two voices resting at one onset
+    ///   stay apart (see ``restOffset(forVoice:)``).  `nil` in a bar that shows one part,
+    ///   which is every bar of every staff carrying one voice.
     private func emitRest(_ rest: Rest, x: Double, topStaffY: Double, bottomStaffY: Double,
-                          unitNoteLength: Fraction, builder: inout SVGBuilder) {
+                          unitNoteLength: Fraction, voiceIndex: Int? = nil,
+                          builder: inout SVGBuilder) {
         switch rest.kind {
         case .invisible, .fullMeasureInvisible: return
         default: break
@@ -1159,7 +1258,8 @@ struct SVGEmitter: Sendable {
             y = bottomStaffY - 4.0 * s / 2.0
         }
 
-        builder.text(String(glyph.character), x: x, y: y,
+        let offset = voiceIndex.map { restOffset(forVoice: $0) } ?? 0
+        builder.text(String(glyph.character), x: x, y: y + offset,
                      fontFamily: "Bravura", fontSize: fontSize)
     }
 

--- a/Sources/CeolKitSVGRenderer/Layout/Justifier.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/Justifier.swift
@@ -116,7 +116,8 @@ public struct Justifier: Sendable {
             return JustifiedSystem(measures: measures, isLastSystem: staff.isLastSystem,
                                    sourceForced: staff.sourceForced, clef: staff.clef,
                                    keySignature: staff.keySignature, meter: staff.meter,
-                                   voiceLabel: staff.voiceLabel, stemDirection: staff.stemDirection)
+                                   voiceLabel: staff.voiceLabel,
+                                   voiceStemDirections: staff.voiceStemDirections)
         }
         return JustifiedSystemGroup(staves: staves, grouping: group.grouping)
     }

--- a/Sources/CeolKitSVGRenderer/Layout/LineBreaker.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/LineBreaker.swift
@@ -70,21 +70,23 @@ public struct LineBreaker: Sendable {
         /// has none, and deliberately not defaulted to ``firstSystemLabel``: a voice named
         /// once and never again is what the spec asks for and what abcm2ps prints.
         public let laterSystemLabel: String?
-        /// The voice's `V:` `stem=`, stamped on every system it appears on — unlike the
-        /// label, it does not change between the first system and the rest.
-        public let stemDirection: StemDirection
+        /// The `V:` `stem=` of every voice drawn on this staff, in staff order — one entry
+        /// each, so a shared staff (§11.1 `( … )`) has one per tenant.  Stamped on every
+        /// system the staff appears on: unlike the label, `stem=` does not change between
+        /// the first system and the rest.
+        public let voiceStemDirections: [StemDirection]
 
         public init(measures: [SizedMeasure], clef: ClefSpec = ClefSpec(clef: .treble, octaveShift: 0),
                     keySignature: KeySignature? = nil, meter: Meter? = nil,
                     firstSystemLabel: String? = nil, laterSystemLabel: String? = nil,
-                    stemDirection: StemDirection = .auto) {
+                    voiceStemDirections: [StemDirection] = []) {
             self.measures = measures
             self.clef = clef
             self.keySignature = keySignature
             self.meter = meter
             self.firstSystemLabel = firstSystemLabel
             self.laterSystemLabel = laterSystemLabel
-            self.stemDirection = stemDirection
+            self.voiceStemDirections = voiceStemDirections
         }
     }
 
@@ -151,7 +153,7 @@ public struct LineBreaker: Sendable {
                         keySignature: voice.keySignature,
                         meter: isFirstOfTune ? voice.meter : nil,
                         voiceLabel: isFirstOfTune ? voice.firstSystemLabel : voice.laterSystemLabel,
-                        stemDirection: voice.stemDirection
+                        voiceStemDirections: voice.voiceStemDirections
                     )
                 }, grouping: grouping))
             }
@@ -163,7 +165,8 @@ public struct LineBreaker: Sendable {
                 System(measures: staff.measures, isLastSystem: true,
                        sourceForced: staff.sourceForced, staveWasSplit: staff.staveWasSplit,
                        clef: staff.clef, keySignature: staff.keySignature, meter: staff.meter,
-                       voiceLabel: staff.voiceLabel, stemDirection: staff.stemDirection)
+                       voiceLabel: staff.voiceLabel,
+                       voiceStemDirections: staff.voiceStemDirections)
             }, grouping: last.grouping))
         }
 

--- a/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
@@ -68,9 +68,16 @@ public struct System: Sendable {
     /// (ABC v2.2 §4.1).  A voice with a name but no subname is therefore labelled once and
     /// then not again, which is what abcm2ps does.
     public let voiceLabel: String?
-    /// What this voice asked for with `V:` `stem=` (§4.1, issue #74).  `.auto` — the
-    /// overwhelmingly common case — means it asked for nothing and the document decides.
-    public let stemDirection: StemDirection
+    /// What each voice drawn on this staff asked for with `V:` `stem=` (§4.1, issue #74),
+    /// in staff order.  One entry per voice: a staff carrying one voice has one entry, and a
+    /// shared staff (§11.1 `( … )`) one per tenant.  `.auto` — the overwhelmingly common
+    /// case — means that voice asked for nothing, and its position on the staff, then the
+    /// document, then the note's own pitch decides (issue #77).
+    public let voiceStemDirections: [StemDirection]
+
+    /// What the staff's *first* voice asked for.  That is the whole answer for a staff
+    /// carrying one voice, which is every staff until a `%%score` group shares one.
+    public var stemDirection: StemDirection { voiceStemDirections.first ?? .auto }
 
     public init(
         measures: [SizedMeasure],
@@ -81,7 +88,7 @@ public struct System: Sendable {
         keySignature: KeySignature? = nil,
         meter: Meter? = nil,
         voiceLabel: String? = nil,
-        stemDirection: StemDirection = .auto
+        voiceStemDirections: [StemDirection] = []
     ) {
         self.measures = measures
         self.isLastSystem = isLastSystem
@@ -91,7 +98,7 @@ public struct System: Sendable {
         self.keySignature = keySignature
         self.meter = meter
         self.voiceLabel = voiceLabel
-        self.stemDirection = stemDirection
+        self.voiceStemDirections = voiceStemDirections
     }
 }
 
@@ -241,9 +248,12 @@ public struct JustifiedSystem: Sendable {
     /// Carried through from ``System/voiceLabel`` — justification moves x positions, never
     /// what a staff is called.
     public let voiceLabel: String?
-    /// Carried through from ``System/stemDirection`` — justification moves x positions,
-    /// never which way a voice's stems point.
-    public let stemDirection: StemDirection
+    /// Carried through from ``System/voiceStemDirections`` — justification moves x
+    /// positions, never which way a voice's stems point.
+    public let voiceStemDirections: [StemDirection]
+
+    /// What the staff's first voice asked for; see ``System/stemDirection``.
+    public var stemDirection: StemDirection { voiceStemDirections.first ?? .auto }
 
     public init(
         measures: [JustifiedMeasure],
@@ -253,7 +263,7 @@ public struct JustifiedSystem: Sendable {
         keySignature: KeySignature? = nil,
         meter: Meter? = nil,
         voiceLabel: String? = nil,
-        stemDirection: StemDirection = .auto
+        voiceStemDirections: [StemDirection] = []
     ) {
         self.measures = measures
         self.isLastSystem = isLastSystem
@@ -262,7 +272,7 @@ public struct JustifiedSystem: Sendable {
         self.keySignature = keySignature
         self.meter = meter
         self.voiceLabel = voiceLabel
-        self.stemDirection = stemDirection
+        self.voiceStemDirections = voiceStemDirections
     }
 }
 
@@ -480,10 +490,15 @@ public struct ResolvedSystem: Sendable {
     /// voice has nothing to print on this system, which is every voice of every tune that
     /// names none.
     public let voiceLabel: VoiceLabel?
-    /// What this staff's voice asked for with `V:` `stem=`.  A voice that states a
-    /// direction overrides `%%ceolkit:pipeformat`; `.auto` leaves the choice to the
-    /// document, and failing that to the note's own staff position.
-    public let stemDirection: StemDirection
+    /// What each voice drawn on this staff asked for with `V:` `stem=`, in staff order —
+    /// one entry per voice, so its count is also how many voices share the staff.  A voice
+    /// that states a direction overrides both the automatic opposition of a shared staff and
+    /// `%%ceolkit:pipeformat`; `.auto` leaves the choice to the voice's position on the
+    /// staff, then the document, then the note's own staff position.
+    public let voiceStemDirections: [StemDirection]
+
+    /// What the staff's first voice asked for; see ``System/stemDirection``.
+    public var stemDirection: StemDirection { voiceStemDirections.first ?? .auto }
 
     public init(
         origin: Point,
@@ -501,7 +516,7 @@ public struct ResolvedSystem: Sendable {
         abcLine: Int = 1,
         staffGroup: StaffGroup? = nil,
         voiceLabel: VoiceLabel? = nil,
-        stemDirection: StemDirection = .auto
+        voiceStemDirections: [StemDirection] = []
     ) {
         self.origin = origin
         self.measures = measures
@@ -518,7 +533,7 @@ public struct ResolvedSystem: Sendable {
         self.abcLine = abcLine
         self.staffGroup = staffGroup
         self.voiceLabel = voiceLabel
-        self.stemDirection = stemDirection
+        self.voiceStemDirections = voiceStemDirections
     }
 }
 

--- a/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
@@ -309,7 +309,7 @@ public struct VerticalLayoutEngine: Sendable {
                 abcLine: abcLine,
                 staffGroup: membership,
                 voiceLabel: staff.voiceLabel.map { VoiceLabel(text: $0, x: labelRightX) },
-                stemDirection: staff.stemDirection
+                voiceStemDirections: staff.voiceStemDirections
             )
         }
     }

--- a/Tests/CeolKitSVGRendererTests/SharedStaffVoiceDrawingTests.swift
+++ b/Tests/CeolKitSVGRendererTests/SharedStaffVoiceDrawingTests.swift
@@ -1,0 +1,174 @@
+import Testing
+import CeolKitModel
+import CeolKitParser
+@testable import CeolKitSVGRenderer
+
+/// Issue #77: two voices on one staff (§11.1 `%%score ( … )`) are drawn as two parts —
+/// stems opposed by voice position rather than chosen from each note's pitch, and
+/// simultaneous rests moved off centre so they do not land on top of each other.
+///
+/// End to end, source in and SVG out, for the same reason ``StemDirectionTests`` is: the
+/// question is what got *drawn*, and every intermediate answer was already right before the
+/// fix — the merge pass (#76) had the voices in one event stream and tagged (#75), and the
+/// emitter still read the pitch.
+///
+/// Note collisions between the two voices — unisons, seconds, displaced dots — are #79's,
+/// not this suite's.  The tunes here keep the parts an octave or more apart so nothing in
+/// the assertions depends on collision handling that does not exist yet.
+@Suite("Shared staff: opposed stems and offset rests")
+struct SharedStaffVoiceDrawingTests {
+
+    private let config = SVGRenderConfig()
+
+    private func svg(_ abc: String) throws -> String {
+        let score = CeolKitParser().parse(abc, options: .default).score
+        var diagnostics: [Diagnostic] = []
+        return try textProbeRenderer(config).render(score, diagnostics: &diagnostics).joined()
+    }
+
+    /// Two voices, one staff, over the notes given.  `c d e f` sits above the middle line,
+    /// where the pitch rule stems *down*, and `C D E F` below it, where it stems *up* — so
+    /// on this staff both voices are a flip away from what pitch alone would draw, and an
+    /// assertion that passes cannot be passing by accident.
+    private func sharedStaff(upper: String = "c d e f", lower: String = "C D E F",
+                             upperVoice: String = "", lowerVoice: String = "",
+                             plan: String = "%%score (T1 T2)") -> String {
+        ([
+            "X:1", "T:Shared", "M:4/4", "L:1/4", plan, "K:C",
+            "V:T1 \(upperVoice)", "V:T2 \(lowerVoice)",
+            "[V:T1] \(upper) |", "[V:T2] \(lower) |"
+        ] as [String]).map { $0.trimmingCharacters(in: .whitespaces) }
+            .joined(separator: "\n") + "\n"
+    }
+
+    // MARK: - Stems
+
+    @Test("A shared staff stems its upper voice up and its lower voice down, against pitch")
+    func sharedStaffOpposesStems() throws {
+        let metadata = try BravuraMetadata.load()
+        let stems = probedStemsByPitchGroup(in: try svg(sharedStaff()),
+                                            staffSize: config.staffSize, metadata: metadata,
+                                            bucketCount: 2)
+        try #require(stems.count == 2)
+        try #require(stems[0].count == 4)
+        try #require(stems[1].count == 4)
+        #expect(stems[0].allSatisfy { $0.isUp })
+        #expect(stems[1].allSatisfy { !$0.isUp })
+    }
+
+    @Test("The opposition holds whichever side of the middle line the parts sit on")
+    func oppositionIgnoresPitchEntirely() throws {
+        // Both parts high, then both parts low: the pitch rule would stem the whole staff
+        // one way each time, and the opposition still splits it.
+        let metadata = try BravuraMetadata.load()
+        for (upper, lower) in [("c' b a g", "c d e f"), ("C D E F", "C, D, E, F,")] {
+            let stems = probedStemsByPitchGroup(in: try svg(sharedStaff(upper: upper, lower: lower)),
+                                                staffSize: config.staffSize, metadata: metadata,
+                                                bucketCount: 2)
+            try #require(stems.count == 2)
+            try #require(stems[0].count == 4)
+            try #require(stems[1].count == 4)
+            #expect(stems[0].allSatisfy { $0.isUp })
+            #expect(stems[1].allSatisfy { !$0.isUp })
+        }
+    }
+
+    @Test("V: stem= on the lower voice overrides the opposition")
+    func voiceStemOverridesOpposition() throws {
+        let metadata = try BravuraMetadata.load()
+        let stems = probedStemsByPitchGroup(in: try svg(sharedStaff(lowerVoice: "stem=up")),
+                                            staffSize: config.staffSize, metadata: metadata,
+                                            bucketCount: 2)
+        try #require(stems.count == 2)
+        try #require(stems[1].count == 4)
+        // The upper voice is unchanged; the lower one now points the same way it does.
+        #expect(stems[0].allSatisfy { $0.isUp })
+        #expect(stems[1].allSatisfy { $0.isUp })
+    }
+
+    @Test("Separate staves keep the pitch rule — the opposition is the shared staff's alone")
+    func separateStavesAreUntouched() throws {
+        let metadata = try BravuraMetadata.load()
+        // The same two voices, planned onto a staff each.  Both parts sit above the middle
+        // line of their own staff, so the pitch rule stems both down — which is exactly what
+        // the shared-staff test above proves does *not* happen when they share one.
+        let stems = probedStemsByPitchGroup(in: try svg(sharedStaff(lower: "c d e f",
+                                                                    plan: "%%score T1 T2")),
+                                            staffSize: config.staffSize, metadata: metadata,
+                                            bucketCount: 2)
+        try #require(stems.count == 2)
+        try #require(stems.allSatisfy { $0.count == 4 })
+        #expect(stems.flatMap { $0 }.allSatisfy { !$0.isUp })
+    }
+
+    // MARK: - Rests
+
+    /// The y of every rest glyph drawn, in the order they appear.
+    private func restYs(in svg: String) -> [Double] {
+        let rests: Set<Character> = [SMuFLGlyph.restWhole.character, SMuFLGlyph.restHalf.character,
+                                     SMuFLGlyph.restQuarter.character, SMuFLGlyph.rest8th.character,
+                                     SMuFLGlyph.rest16th.character, SMuFLGlyph.rest32nd.character,
+                                     SMuFLGlyph.rest64th.character]
+        return svg.matches(
+            of: /<text x="([-0-9.]+)" y="([-0-9.]+)" font-family="Bravura"[^>]*>(.)<\/text>/
+        ).compactMap { match in
+            guard let y = Double(match.2), let ch = String(match.3).first,
+                  rests.contains(ch) else { return nil }
+            return y
+        }
+    }
+
+    /// The y of the staff's middle line — where a rest sits when nothing displaces it.
+    ///
+    /// The staff lines are the five widest horizontal `<line>`s in the document: they run
+    /// the length of the system, and the only other horizontal lines drawn here are ledger
+    /// lines, which are a notehead wide.
+    private func middleLineY(in svg: String) throws -> Double {
+        let horizontals = svg.matches(
+            of: /<line x1="([-0-9.]+)" y1="([-0-9.]+)" x2="([-0-9.]+)" y2="([-0-9.]+)" stroke="black" stroke-width="([-0-9.]+)"\/>/
+        ).compactMap { match -> (y: Double, width: Double)? in
+            guard let x1 = Double(match.1), let y1 = Double(match.2),
+                  let x2 = Double(match.3), let y2 = Double(match.4), y1 == y2 else { return nil }
+            return (y1, x2 - x1)
+        }
+        let systemWidth = try #require(horizontals.map(\.width).max())
+        let staffLines = horizontals.filter { $0.width == systemWidth }.map(\.y).sorted()
+        try #require(staffLines.count == 5)
+        return staffLines[2]
+    }
+
+    @Test("Two voices resting at one onset are drawn a staff space either side of centre")
+    func simultaneousRestsAreSeparated() throws {
+        let document = try svg(sharedStaff(upper: "c z c z", lower: "C z C z"))
+        let ys = restYs(in: document).sorted()
+        try #require(ys.count == 4)
+        let middle = try middleLineY(in: document)
+        // Two above centre and two below, each by one staff space: the upper voice's rests
+        // rise and the lower voice's fall, so they never coincide.
+        #expect(ys[0] == middle - config.staffSize)
+        #expect(ys[1] == middle - config.staffSize)
+        #expect(ys[2] == middle + config.staffSize)
+        #expect(ys[3] == middle + config.staffSize)
+    }
+
+    @Test("A bar whose partner voice is invisible keeps its rest centred")
+    func restStaysCentredWhereOnlyOneVoiceIsDrawn() throws {
+        // `x` is a rest that occupies the bar without being drawn (§4.9), which is how the
+        // §7 Zocharti Loch example writes a part that has not entered yet.  Nothing is there
+        // to collide with, so nothing moves — and `abcm2ps -g` draws those bars the same way.
+        let document = try svg(sharedStaff(upper: "c z c z", lower: "x4"))
+        let ys = restYs(in: document)
+        try #require(ys.count == 2)
+        let middle = try middleLineY(in: document)
+        #expect(ys.allSatisfy { $0 == middle })
+    }
+
+    @Test("A staff with one voice rests on the middle line, as it always has")
+    func singleVoiceRestIsUnmoved() throws {
+        let document = try svg("X:1\nT:Alone\nM:4/4\nL:1/4\nK:C\nc z c z |\n")
+        let ys = restYs(in: document)
+        try #require(ys.count == 2)
+        let middle = try middleLineY(in: document)
+        #expect(ys.allSatisfy { $0 == middle })
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/StemDirectionTests.swift
+++ b/Tests/CeolKitSVGRendererTests/StemDirectionTests.swift
@@ -16,71 +16,19 @@ import CeolKitParser
 @Suite("Stem direction (V: stem=)")
 struct StemDirectionTests {
 
-    /// One drawn stem, with the direction recovered from where its notehead sits.
-    private struct Stem {
-        let x: Double
-        let noteheadY: Double
-        let tipY: Double
-        var isUp: Bool { tipY < noteheadY }
-    }
-
-    /// Every stem in `svg`, paired with the notehead it grows from.
-    ///
-    /// Stems are the `<line>`s at Bravura's stem thickness — thinner than every staff line
-    /// and bar line in the document, which is what ``BravuraMetadataTests`` pins.  Noteheads
-    /// are the Bravura `<text>` runs, so the renderer is driven in `.fontFace` mode to keep
-    /// them readable as text.
-    private func stems(in svg: String, staffSize: Double, metadata: BravuraMetadata) -> [Stem] {
-        let stemWidth = metadata.engravingDefaults.stemThickness * staffSize
-        let noteheads = svg.matches(
-            of: /<text x="([-0-9.]+)" y="([-0-9.]+)" font-family="Bravura"[^>]*>(.)<\/text>/
-        ).compactMap { match -> (x: Double, y: Double)? in
-            let heads: Set<Character> = [SMuFLGlyph.noteheadBlack.character,
-                                         SMuFLGlyph.noteheadHalf.character,
-                                         SMuFLGlyph.noteheadWhole.character]
-            guard let x = Double(match.1), let y = Double(match.2),
-                  let ch = String(match.3).first, heads.contains(ch) else { return nil }
-            return (x, y)
-        }
-
-        return svg.matches(
-            of: /<line x1="([-0-9.]+)" y1="([-0-9.]+)" x2="([-0-9.]+)" y2="([-0-9.]+)" stroke="black" stroke-width="([-0-9.]+)"\/>/
-        ).compactMap { match -> Stem? in
-            guard let x = Double(match.1), let y1 = Double(match.2),
-                  let y2 = Double(match.4), let width = Double(match.5),
-                  abs(width - stemWidth) < 0.01, y1 != y2 else { return nil }
-            // The notehead end is whichever end a notehead is drawn at.  A stem is attached
-            // to the right of its notehead when it points up and to the left when it points
-            // down, so the x match has to allow a notehead's width either way.
-            let touches: (Double) -> Bool = { end in
-                noteheads.contains { abs($0.y - end) < 0.01 && abs($0.x - x) < 4 * staffSize }
-            }
-            if touches(y2) { return Stem(x: x, noteheadY: y2, tipY: y1) }
-            if touches(y1) { return Stem(x: x, noteheadY: y1, tipY: y2) }
-            return nil
-        }
-    }
-
     /// Renders `abc` and returns the stems of each staff, top staff first.
     ///
-    /// Bucketed by the staff the notehead falls nearest, so a two-voice tune's staves can be
-    /// asserted against each other — the whole point of "other voices unaffected".
-    private func stemsPerStaff(_ abc: String, staffCount: Int) throws -> [[Stem]] {
+    /// Bucketed by pitch, which separates the staves of these tunes exactly: they are far
+    /// enough apart vertically that every stem of a staff is nearer its own staff's notes
+    /// than the next staff's.  See ``probedStemsByPitchGroup(in:staffSize:metadata:bucketCount:)``.
+    private func stemsPerStaff(_ abc: String, staffCount: Int) throws -> [[ProbedStem]] {
         let metadata = try BravuraMetadata.load()
         let config = SVGRenderConfig()
         let score = CeolKitParser().parse(abc, options: .default).score
         var diagnostics: [Diagnostic] = []
         let svg = try textProbeRenderer(config).render(score, diagnostics: &diagnostics).joined()
-        let all = stems(in: svg, staffSize: config.staffSize, metadata: metadata)
-        // Staves are far enough apart vertically that sorting the noteheads into `staffCount`
-        // clusters by y is unambiguous: every stem of a staff is nearer its own staff's notes
-        // than the next staff's.
-        let sorted = all.sorted { $0.noteheadY < $1.noteheadY }
-        guard staffCount > 1, !sorted.isEmpty else { return [sorted.sorted { $0.x < $1.x }] }
-        let perStaff = sorted.count / staffCount
-        return (0..<staffCount).map { staff in
-            Array(sorted[(staff * perStaff)..<((staff + 1) * perStaff)]).sorted { $0.x < $1.x }
-        }
+        return probedStemsByPitchGroup(in: svg, staffSize: config.staffSize, metadata: metadata,
+                                       bucketCount: staffCount)
     }
 
     /// Two voices over the same four notes, so any difference between the staves is the

--- a/Tests/CeolKitSVGRendererTests/StemProbe.swift
+++ b/Tests/CeolKitSVGRendererTests/StemProbe.swift
@@ -1,0 +1,69 @@
+import CeolKitModel
+@testable import CeolKitSVGRenderer
+
+/// One drawn stem, with its direction recovered from where its notehead sits.
+///
+/// Direction is read out of the emitted document rather than out of the layout: a stem is
+/// drawn from its notehead, so the end that coincides with a notehead's y is the notehead
+/// end, and the stem points away from it.
+struct ProbedStem {
+    let x: Double
+    let noteheadY: Double
+    let tipY: Double
+    var isUp: Bool { tipY < noteheadY }
+}
+
+/// Every stem in `svg`, paired with the notehead it grows from.
+///
+/// Stems are the `<line>`s at Bravura's stem thickness — thinner than every staff line and
+/// bar line in the document, which is what ``BravuraMetadataTests`` pins.  Noteheads are the
+/// Bravura `<text>` runs, so the renderer must be driven in `.fontFace` mode (see
+/// ``textProbeRenderer(_:)``) to keep them readable as text.
+func probedStems(in svg: String, staffSize: Double, metadata: BravuraMetadata) -> [ProbedStem] {
+    let stemWidth = metadata.engravingDefaults.stemThickness * staffSize
+    let noteheads = svg.matches(
+        of: /<text x="([-0-9.]+)" y="([-0-9.]+)" font-family="Bravura"[^>]*>(.)<\/text>/
+    ).compactMap { match -> (x: Double, y: Double)? in
+        let heads: Set<Character> = [SMuFLGlyph.noteheadBlack.character,
+                                     SMuFLGlyph.noteheadHalf.character,
+                                     SMuFLGlyph.noteheadWhole.character]
+        guard let x = Double(match.1), let y = Double(match.2),
+              let ch = String(match.3).first, heads.contains(ch) else { return nil }
+        return (x, y)
+    }
+
+    return svg.matches(
+        of: /<line x1="([-0-9.]+)" y1="([-0-9.]+)" x2="([-0-9.]+)" y2="([-0-9.]+)" stroke="black" stroke-width="([-0-9.]+)"\/>/
+    ).compactMap { match -> ProbedStem? in
+        guard let x = Double(match.1), let y1 = Double(match.2),
+              let y2 = Double(match.4), let width = Double(match.5),
+              abs(width - stemWidth) < 0.01, y1 != y2 else { return nil }
+        // The notehead end is whichever end a notehead is drawn at.  A stem is attached to
+        // the right of its notehead when it points up and to the left when it points down,
+        // so the x match has to allow a notehead's width either way.
+        let touches: (Double) -> Bool = { end in
+            noteheads.contains { abs($0.y - end) < 0.01 && abs($0.x - x) < 4 * staffSize }
+        }
+        if touches(y2) { return ProbedStem(x: x, noteheadY: y2, tipY: y1) }
+        if touches(y1) { return ProbedStem(x: x, noteheadY: y1, tipY: y2) }
+        return nil
+    }
+}
+
+/// The stems of `svg` split into `bucketCount` groups by pitch, highest group first.
+///
+/// Written for music whose parts do not cross: every note of the upper part is higher than
+/// every note of the lower one, so sorting by notehead y and cutting into equal groups
+/// separates them exactly.  That holds both for two staves of a system — where the staves
+/// are far apart vertically — and for two voices sharing one staff, which is what makes the
+/// same probe serve both.
+func probedStemsByPitchGroup(in svg: String, staffSize: Double, metadata: BravuraMetadata,
+                             bucketCount: Int) -> [[ProbedStem]] {
+    let sorted = probedStems(in: svg, staffSize: staffSize, metadata: metadata)
+        .sorted { $0.noteheadY < $1.noteheadY }
+    guard bucketCount > 1, !sorted.isEmpty else { return [sorted.sorted { $0.x < $1.x }] }
+    let perBucket = sorted.count / bucketCount
+    return (0..<bucketCount).map { bucket in
+        Array(sorted[(bucket * perBucket)..<((bucket + 1) * perBucket)]).sorted { $0.x < $1.x }
+    }
+}


### PR DESCRIPTION
Closes #77.

`emitStem` chose direction from the note's pitch and `emitRest` pinned every short rest to the middle line, so the two voices of a `%%score ( … )` group (§11.1) collided: a low note in the upper voice stemmed the same way as a high note in the lower one, and two voices resting together drew one glyph on top of another.

## What changed

**Stems.** Direction is now resolved per event from the voice tag the merge pass (#76) attached, so a shared staff opposes its voices — top voice up, bottom voice down, whatever the pitches. A voice's own `V:` `stem=` still wins over the opposition, which is why the staff now carries every tenant's direction rather than its lead's: `System`, `JustifiedSystem`, `ResolvedSystem` and `LineBreaker.VoiceLine` take `voiceStemDirections` (one entry per voice, in staff order) and keep `stemDirection` as a computed lead-voice value for the staves that carry one voice.

**Rests.** A shared staff's rests move one staff space either side of centre by voice position. A staff of three or more voices opposes only its outer two; a middle voice keeps the ordinary rules for both stems and rests.

Rests are separated only in bars where more than one voice draws ink — a part written as invisible rests (`x`) takes up the bar without appearing in it, and displacing the one rest that shows would open a gap under a voice nobody can see. That is what `abcm2ps -g` draws for the `x8` bars of the §7 Zocharti Loch example.

## Against abcm2ps

Checked against `abcm2ps -g` on the §7 Zocharti Loch example: stems match, including the opposition holding where the partner voice is invisible, as do the centred rests in the `x8` bars. One deliberate divergence — abcm2ps collapses two identical simultaneous rests into a single centred glyph, and this draws both, separated, as the issue asks for.

## Scope

Notehead collisions between the voices (unisons, seconds, dot displacement) are out of scope here, as are the per-voice beam, tie and slur accumulators (#78).

## Testing

- New `SharedStaffVoiceDrawingTests`: 7 cases, source in and SVG out — opposition against pitch on both sides of the middle line, `V: stem=` overriding it, separate staves untouched, simultaneous rests separated, an invisible partner leaving the rest centred, and a single-voice staff resting on the middle line.
- The stem probe from `StemDirectionTests` moved to a shared `StemProbe.swift`, so both suites read stems out of the emitted document the same way.
- Full suite: 923 tests pass.
- A staff carrying one voice is byte-identical: the 16-page `tunebook.abc` and a two-staff multi-voice tune both diff clean against a build of the base commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G82eK1fXZg7kiBqsKuWezv