### PR TITLE
Fix #78 — key the emitter's open beams, ties and slurs by part

### DIFF
--- a/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
@@ -11,6 +11,23 @@ private struct StemInfo {
     let noteheadY: Double  // y of the notehead end (used by emitBeamGroup to draw stems)
 }
 
+/// Which part an open tie or slur belongs to: the staff of the system it was opened on, and
+/// the voice of that staff that opened it.
+///
+/// Both halves are needed, and for the same reason.  The pending anchors are threaded across
+/// every staff of every system of every page so that an arc spanning a system or page break
+/// is drawn dangling rather than dropped (#27) — which, undiscriminated, lets any staff
+/// resolve or re-dangle an arc opened on the staff above it, at that staff's y.  A `%%score
+/// ( … )` staff (§11.1) carries several voices whose arcs are exactly as unrelated to each
+/// other as two staves' are, so the voice tag the merge pass attached (#76) is the second
+/// half of the same key (#78).
+private struct PartKey: Hashable {
+    /// Position of the staff within its system group, top to bottom; 0 on a single staff.
+    let staff: Int
+    /// Position of the voice within that staff; 0 unless a `( … )` group shares it.
+    let voice: Int
+}
+
 /// Pending tie: records where a tied note's arc must start so the arc can be drawn
 /// when the matching end note is encountered (possibly in the next measure).
 private struct TieAnchor {
@@ -18,6 +35,7 @@ private struct TieAnchor {
     let noteY: Double   // y of the notehead
     let pitch: Pitch    // matched against the end note's pitch
     let staffPos: Int   // determines whether the arc curves above or below the note
+    let part: PartKey   // only the part that opened it may close it
     // True once this anchor has been carried across a system/page break: `x` then refers
     // to the left staff edge of the new system rather than a real notehead, so the arc
     // drawn to resolve it must not add notehead-width clearance on that side (see #27).
@@ -26,11 +44,15 @@ private struct TieAnchor {
 
 /// Pending slur: records the start position of an open slur bracket so the arc
 /// can be drawn when the matching closing `)` note is encountered.  Stored as a
-/// LIFO stack so that nested slurs resolve correctly (innermost closes first).
+/// LIFO stack *per part* so that nested slurs resolve correctly (innermost closes first)
+/// while a `)` in one voice cannot close a slur another voice opened — a slur carries
+/// neither pitch nor any other mark to match on, so without the part key two voices with
+/// interleaved slurs pair up entirely wrongly (#78).
 private struct SlurAnchor {
     let x: Double       // left-edge x of the notehead where the slur opens (or a staff edge, see below)
     let noteY: Double   // y of the notehead
     let staffPos: Int   // determines whether the arc curves above or below
+    let part: PartKey   // the stack is per part; see PartKey
     var isCarriedOver: Bool = false  // see TieAnchor.isCarriedOver
 }
 
@@ -293,16 +315,25 @@ struct SVGEmitter: Sendable {
         // Anchors still open from the previous system/page (#27) are dangling ties/slurs.
         // Re-anchor them to this system's left staff edge so the closing logic in
         // emitMeasure draws an "arriving" arc when the matching note is found.
+        //
+        // Only *this staff's* anchors: the array is threaded across every staff of the
+        // system, and an anchor left open on the staff above holds that staff's y.  Moving
+        // it here would redraw it a staff down from where its note is.
+        let staffIndex = staffIndex(of: system)
         let leftEdge = system.origin.x
         pendingTies = pendingTies.map {
-            TieAnchor(x: leftEdge, noteY: $0.noteY, pitch: $0.pitch, staffPos: $0.staffPos, isCarriedOver: true)
+            guard $0.part.staff == staffIndex else { return $0 }
+            return TieAnchor(x: leftEdge, noteY: $0.noteY, pitch: $0.pitch, staffPos: $0.staffPos,
+                             part: $0.part, isCarriedOver: true)
         }
         pendingSlurs = pendingSlurs.map {
-            SlurAnchor(x: leftEdge, noteY: $0.noteY, staffPos: $0.staffPos, isCarriedOver: true)
+            guard $0.part.staff == staffIndex else { return $0 }
+            return SlurAnchor(x: leftEdge, noteY: $0.noteY, staffPos: $0.staffPos,
+                              part: $0.part, isCarriedOver: true)
         }
 
         for measure in system.measures {
-            emitMeasure(measure, system: system,
+            emitMeasure(measure, system: system, staffIndex: staffIndex,
                         pendingTies: &pendingTies, pendingSlurs: &pendingSlurs,
                         builder: &builder)
         }
@@ -310,20 +341,29 @@ struct SVGEmitter: Sendable {
         // Anchors still open at the end of this system span into the next system/page.
         // Draw a departing dangling arc to the right staff edge; the anchor itself is left
         // in place (still holding pitch/staffPos) so the next emitSystem call can resolve
-        // or re-dangle it in turn.
+        // or re-dangle it in turn.  Again this staff's only — the staff below has not been
+        // drawn yet, and its own anchors dangle off its own right edge when it is.
         if let lastMeasure = system.measures.last {
             let rightEdge = lastMeasure.origin.x + lastMeasure.width
-            for anchor in pendingTies {
+            for anchor in pendingTies where anchor.part.staff == staffIndex {
                 emitDanglingArc(fromX: anchor.x, y: anchor.noteY, staffPos: anchor.staffPos,
                                 toEdgeX: rightEdge, isCarriedOver: anchor.isCarriedOver,
                                 kind: .tie, builder: &builder)
             }
-            for anchor in pendingSlurs {
+            for anchor in pendingSlurs where anchor.part.staff == staffIndex {
                 emitDanglingArc(fromX: anchor.x, y: anchor.noteY, staffPos: anchor.staffPos,
                                 toEdgeX: rightEdge, isCarriedOver: anchor.isCarriedOver,
                                 kind: .slur, builder: &builder)
             }
         }
+    }
+
+    /// Where `system` sits in its group, top to bottom — the staff half of a ``PartKey``.
+    ///
+    /// A system that is a staff of its own has no group and is staff 0, which is what every
+    /// single-voice tune draws and what keys every anchor it opens.
+    private func staffIndex(of system: ResolvedSystem) -> Int {
+        system.staffGroup?.index ?? 0
     }
 
     /// The voice's `V:` `name=` / `sname=`, standing in the gutter left of the system
@@ -587,7 +627,7 @@ struct SVGEmitter: Sendable {
 
     // MARK: - Measure
 
-    private func emitMeasure(_ measure: ResolvedMeasure, system: ResolvedSystem,
+    private func emitMeasure(_ measure: ResolvedMeasure, system: ResolvedSystem, staffIndex: Int,
                               pendingTies: inout [TieAnchor], pendingSlurs: inout [SlurAnchor],
                               builder: inout SVGBuilder) {
         let topY    = system.origin.y + system.staffOrigin
@@ -617,44 +657,49 @@ struct SVGEmitter: Sendable {
         // Two parts are only visibly two where both of them draw: see `inkedVoices(of:)`.
         let separateRests = inkedVoices(of: measure).count > 1
 
-        // Beam accumulator: per-note (StemInfo, beamCount) pairs for the current beam run.
-        var pendingBeam: [(stem: StemInfo, beamCount: Int)]?
-        // Grace note beam tip Y for the note that immediately follows; reset after each non-grace event.
-        var lastGraceBeamY: Double? = nil
+        // Beam accumulator: per-note (StemInfo, beamCount) pairs for the current beam run,
+        // one run per voice of the staff.  A shared staff interleaves its voices in one event
+        // stream, so a single accumulator would take a `.start` in one voice as the end of
+        // the other's open run and beam the two together (#78).
+        var pendingBeams: [Int: [(stem: StemInfo, beamCount: Int)]] = [:]
+        // Grace note beam tip Y for the note that immediately follows, per voice for the same
+        // reason; reset after each non-grace event of that voice.
+        var lastGraceBeamY: [Int: Double] = [:]
 
-        func flushBeam() {
-            guard let g = pendingBeam else { return }
+        func flushBeam(voice: Int) {
+            guard let g = pendingBeams.removeValue(forKey: voice) else { return }
             emitBeamGroup(g, builder: &builder)
-            pendingBeam = nil
         }
 
         for event in measure.events {
+            let voice = event.voiceIndex
+            let part = PartKey(staff: staffIndex, voice: voice)
             // Grace events are handled here so their stem-tip Y can be forwarded
             // to the next note for fermata clearance.
             if case .grace(let g) = event.kind {
-                lastGraceBeamY = emitGraceGroup(g, originX: event.origin.x, topStaffY: topY,
-                                                bottomStaffY: bottomY, builder: &builder)
+                lastGraceBeamY[voice] = emitGraceGroup(g, originX: event.origin.x, topStaffY: topY,
+                                                       bottomStaffY: bottomY, builder: &builder)
                 continue
             }
             let stemInfo = emitEvent(event, topStaffY: topY, bottomStaffY: bottomY,
                                      unitNoteLength: measure.unitNoteLength,
                                      separateRests: separateRests,
-                                     precedingGraceBeamY: lastGraceBeamY,
+                                     precedingGraceBeamY: lastGraceBeamY[voice],
                                      builder: &builder)
-            lastGraceBeamY = nil
+            lastGraceBeamY[voice] = nil
             if let info = stemInfo, let note = noteFrom(event) {
                 let bc = requiredBeamCount(absoluteDuration(note.duration,
                                                             unitNoteLength: measure.unitNoteLength))
                 let entry = (stem: info, beamCount: bc)
                 switch note.beam {
                 case .start:
-                    flushBeam()  // safety: shouldn't have an open group here
-                    pendingBeam = [entry]
+                    flushBeam(voice: voice)  // safety: shouldn't have an open group here
+                    pendingBeams[voice] = [entry]
                 case .middle:
-                    pendingBeam?.append(entry)
+                    pendingBeams[voice]?.append(entry)
                 case .end:
-                    pendingBeam?.append(entry)
-                    flushBeam()
+                    pendingBeams[voice]?.append(entry)
+                    flushBeam(voice: voice)
                 case .single:
                     break
                 }
@@ -668,7 +713,9 @@ struct SVGEmitter: Sendable {
                 let ny = noteY(staffPos: sp, bottomStaffY: bottomY)
 
                 if note.ties == .endsTie || note.ties == .continuesTie {
-                    if let idx = pendingTies.firstIndex(where: { $0.pitch == note.pitch }) {
+                    if let idx = pendingTies.firstIndex(where: {
+                        $0.part == part && $0.pitch == note.pitch
+                    }) {
                         let anchor = pendingTies.remove(at: idx)
                         if anchor.isCarriedOver {
                             emitArrivingTieArc(edgeX: anchor.x, staffPos: anchor.staffPos,
@@ -682,7 +729,7 @@ struct SVGEmitter: Sendable {
                 }
                 if note.ties == .startsTie || note.ties == .continuesTie {
                     pendingTies.append(TieAnchor(x: event.origin.x, noteY: ny,
-                                                 pitch: note.pitch, staffPos: sp))
+                                                 pitch: note.pitch, staffPos: sp, part: part))
                 }
             }
 
@@ -693,7 +740,8 @@ struct SVGEmitter: Sendable {
                 let ny = noteY(staffPos: sp, bottomStaffY: bottomY)
 
                 for _ in 0..<note.slurs.closes {
-                    if let anchor = pendingSlurs.popLast() {
+                    if let idx = pendingSlurs.lastIndex(where: { $0.part == part }) {
+                        let anchor = pendingSlurs.remove(at: idx)
                         if anchor.isCarriedOver {
                             emitArrivingTieArc(edgeX: anchor.x, staffPos: anchor.staffPos,
                                                toX: event.origin.x, toY: ny,
@@ -705,11 +753,14 @@ struct SVGEmitter: Sendable {
                     }
                 }
                 for _ in 0..<note.slurs.opens {
-                    pendingSlurs.append(SlurAnchor(x: event.origin.x, noteY: ny, staffPos: sp))
+                    pendingSlurs.append(SlurAnchor(x: event.origin.x, noteY: ny, staffPos: sp,
+                                                   part: part))
                 }
             }
         }
-        flushBeam()  // safety flush for malformed input
+        // Safety flush for malformed input, in voice order so that what a broken bar draws
+        // does not depend on which voice happened to open a run last.
+        for voice in pendingBeams.keys.sorted() { flushBeam(voice: voice) }
     }
 
     private func noteFrom(_ event: ResolvedEvent) -> Note? {

--- a/Tests/CeolKitSVGRendererTests/SharedStaffArcAndBeamTests.swift
+++ b/Tests/CeolKitSVGRendererTests/SharedStaffArcAndBeamTests.swift
@@ -1,0 +1,220 @@
+import Testing
+import CeolKitModel
+import CeolKitParser
+@testable import CeolKitSVGRenderer
+
+/// Issue #78: the emitter's per-measure accumulators — the open beam run, the open ties, the
+/// open slurs — belong to a *part*, not to a staff.
+///
+/// A `%%score ( … )` staff (§11.1) interleaves its voices in one event stream, so a single
+/// accumulator takes one voice's beam start as the end of the other's run, closes one voice's
+/// tie with the other's equal pitch, and — a slur carrying neither pitch nor any other mark to
+/// match on — pairs interleaved slurs by nothing better than arrival order.  The same array of
+/// open anchors is threaded across every staff of every system (#27), which lets a staff
+/// resolve or re-dangle an arc opened on the staff above it, drawn at that staff's y.
+///
+/// End to end, source in and SVG out, like ``SharedStaffVoiceDrawingTests``: every one of these
+/// is a question about what got *drawn*, and the layout it was drawn from was already right.
+@Suite("Shared staff: beams, ties and slurs bucketed by voice")
+struct SharedStaffArcAndBeamTests {
+
+    private let config = SVGRenderConfig()
+
+    private func svg(_ abc: String) throws -> String {
+        let score = CeolKitParser().parse(abc, options: .default).score
+        var diagnostics: [Diagnostic] = []
+        return try textProbeRenderer(config).render(score, diagnostics: &diagnostics).joined()
+    }
+
+    /// A two-voice tune, both voices on one staff unless `plan` says otherwise.
+    private func tune(_ upper: String, _ lower: String, unitLength: String = "1/4",
+                      plan: String = "%%score (T1 T2)") -> String {
+        (["X:1", "T:Shared", "M:4/4", "L:\(unitLength)", plan, "K:C", "V:T1", "V:T2"]
+            + zip(upper.split(separator: "|"), lower.split(separator: "|")).flatMap {
+                ["[V:T1] \($0.0.trimmingCharacters(in: .whitespaces)) |",
+                 "[V:T2] \($0.1.trimmingCharacters(in: .whitespaces)) |"]
+            }).joined(separator: "\n") + "\n"
+    }
+
+    // MARK: - Probes
+
+    /// Every horizontal `<line>` in the document, as its y, its ends, and its weight.
+    private func horizontals(in svg: String) -> [(y: Double, x1: Double, x2: Double, width: Double)] {
+        svg.matches(
+            of: /<line x1="([-0-9.]+)" y1="([-0-9.]+)" x2="([-0-9.]+)" y2="([-0-9.]+)" stroke="black" stroke-width="([-0-9.]+)"\/>/
+        ).compactMap { match in
+            guard let x1 = Double(match.1), let y1 = Double(match.2), let x2 = Double(match.3),
+                  let y2 = Double(match.4), let w = Double(match.5), y1 == y2 else { return nil }
+            return (y1, x1, x2, w)
+        }
+    }
+
+    /// The y of every staff line drawn, top to bottom — five per staff.
+    ///
+    /// Staff lines are the horizontals that run a whole system's width; nothing else drawn
+    /// here (beams, ledger lines) comes close to that length.
+    private func staffLineYs(in svg: String) throws -> [Double] {
+        let hs = horizontals(in: svg)
+        let systemWidth = try #require(hs.map { $0.x2 - $0.x1 }.max())
+        return hs.filter { $0.x2 - $0.x1 == systemWidth }.map(\.y).sorted()
+    }
+
+    /// Every beam stroke: the horizontals at Bravura's beam thickness, which is thicker than
+    /// any staff or ledger line in the document.
+    private func beams(in svg: String, metadata: BravuraMetadata) -> [(x1: Double, x2: Double, y: Double)] {
+        let thickness = metadata.engravingDefaults.beamThickness * config.staffSize
+        return horizontals(in: svg)
+            .filter { abs($0.width - thickness) < 0.01 }
+            .map { (x1: $0.x1, x2: $0.x2, y: $0.y) }
+            .sorted { $0.y < $1.y }
+    }
+
+    /// One drawn tie or slur, reduced to the two ends of its centre line.
+    private struct ProbedArc {
+        let startX: Double
+        let endX: Double
+        /// Y of the endpoints — the notehead's y shifted a staff space clear of it, so it says
+        /// which part drew the arc without being that part's notehead y.
+        let y: Double
+    }
+
+    /// Every arc painted on the page.
+    ///
+    /// A drawn arc is the only `<path d=…>` in a document rendered this way: glyph outlines
+    /// live in `<defs>` as `<path id=…>`, and this renderer draws its glyphs as `<text>`
+    /// anyway.  The `d` is `M … C … L … C … Z` — one boundary of the tapered ribbon out and
+    /// the other back — so its 16 coordinates hold each endpoint twice, half the ribbon's end
+    /// thickness either side of the centre line.
+    private func arcs(in svg: String) -> [ProbedArc] {
+        svg.components(separatedBy: "<path d=\"").dropFirst()
+            .compactMap { $0.components(separatedBy: "\"").first }
+            .compactMap { d in
+                let c = d.split(whereSeparator: { $0 == " " || $0 == "," }).compactMap { Double($0) }
+                guard c.count == 16 else { return nil }
+                return ProbedArc(startX: c[0], endX: c[6], y: (c[1] + c[15]) / 2)
+            }
+    }
+
+    /// The x of every onset in the bar, left to right: one per column of the merged grid.
+    ///
+    /// Both voices of a shared staff draw at the x of the onset they share (#76), so the
+    /// distinct notehead x's *are* the columns, and an arc's endpoints can be named by which
+    /// column they land on rather than by a coordinate.
+    private func onsetXs(in svg: String) -> [Double] {
+        let heads: Set<Character> = [SMuFLGlyph.noteheadBlack.character,
+                                     SMuFLGlyph.noteheadHalf.character,
+                                     SMuFLGlyph.noteheadWhole.character]
+        let xs = svg.matches(
+            of: /<text x="([-0-9.]+)" y="([-0-9.]+)" font-family="Bravura"[^>]*>(.)<\/text>/
+        ).compactMap { match -> Double? in
+            guard let x = Double(match.1), let ch = String(match.3).first,
+                  heads.contains(ch) else { return nil }
+            return x
+        }
+        return Array(Set(xs)).sorted()
+    }
+
+    // MARK: - Beams
+
+    @Test("Each voice of a shared staff is beamed on its own, not with its neighbour")
+    func eachVoiceKeepsItsOwnBeamRun() throws {
+        // Four beamed eighths in each voice, note for note.  Interleaved into one stream the
+        // lower voice's `.start` arrives inside the upper voice's open run, and a single
+        // accumulator answers it by flushing that run and beaming the rest of both voices
+        // together — one beam where there should be two.
+        let metadata = try BravuraMetadata.load()
+        let document = try svg(tune("cdef c4", "CDEF C4", unitLength: "1/8"))
+        let drawn = beams(in: document, metadata: metadata)
+        try #require(drawn.count == 2, "expected one beam per voice, got \(drawn.count)")
+        // The upper voice stems up and the lower down (#77), so the staff is between them.
+        let staff = try staffLineYs(in: document)
+        try #require(staff.count == 5)
+        #expect(drawn[0].y < staff.first!)
+        #expect(drawn[1].y > staff.last!)
+    }
+
+    @Test("Beam runs of different lengths keep their own extents")
+    func beamRunsOfDifferentLengthsDoNotMerge() throws {
+        // Six beamed eighths above, four below, starting two columns later: the two runs
+        // overlap without coinciding, so a merged group could not pass for either of them.
+        let metadata = try BravuraMetadata.load()
+        let document = try svg(tune("cdefga c2", "C2 DEFG C2", unitLength: "1/8"))
+        let drawn = beams(in: document, metadata: metadata)
+        try #require(drawn.count == 2)
+        let (upper, lower) = (drawn[0], drawn[1])
+        #expect(upper.x1 < lower.x1)
+        #expect(upper.x2 > lower.x2)
+    }
+
+    // MARK: - Ties
+
+    @Test("A tie is closed by its own voice, not by an equal pitch in the other")
+    func tieIsNotClosedByTheOtherVoice() throws {
+        // Both voices tie the same pitch, the lower voice's tie opening and closing inside the
+        // upper voice's.  Matching on pitch alone hands the upper voice's anchor to the first
+        // note that asks for one, which is the lower voice's — and the two arcs come out
+        // crossed, each spanning from one voice's note to the other's.
+        let document = try svg(tune("c3- c", "z c- c z"))
+        let drawn = arcs(in: document).sorted { $0.startX < $1.startX }
+        try #require(drawn.count == 2)
+        let columns = onsetXs(in: document)
+        try #require(columns.count == 4)
+        // Outer arc: the upper voice's, column 0 to column 3.  Inner: the lower voice's, 1 to 2.
+        #expect(drawn[0].endX == columns[3])
+        #expect(drawn[1].endX == columns[2])
+        #expect(drawn[0].startX > columns[0] && drawn[0].startX < columns[1])
+        #expect(drawn[1].startX > columns[1] && drawn[1].startX < columns[2])
+    }
+
+    // MARK: - Slurs
+
+    @Test("Interleaved slurs resolve to the voice that opened them")
+    func interleavedSlursPairWithinTheirVoice() throws {
+        // The upper voice's slur opens first and closes first; the lower voice's opens inside
+        // it and closes after it.  A single LIFO stack answers the upper voice's `)` with the
+        // lower voice's anchor, which pairs each arc with the other part's note.
+        let document = try svg(tune("(c d e) f", "C (D E F)"))
+        let drawn = arcs(in: document).sorted { $0.y < $1.y }
+        try #require(drawn.count == 2)
+        let columns = onsetXs(in: document)
+        try #require(columns.count == 4)
+        let (upper, lower) = (drawn[0], drawn[1])
+        #expect(upper.endX == columns[2])
+        #expect(lower.endX == columns[3])
+        #expect(upper.startX < lower.startX)
+    }
+
+    // MARK: - Across a break
+
+    @Test("A tie spanning a system break dangles once per voice, on its own part")
+    func tiesDangleAcrossASystemBreakPerVoice() throws {
+        // Both voices tie across the break, so each should leave a departing arc at the first
+        // system's right edge and pick up an arriving one at the second system's left edge:
+        // four arcs, at four different heights, two per system.
+        let document = try svg(tune("c4- | c4", "C4- | C4"))
+        let drawn = arcs(in: document).sorted { $0.y < $1.y }
+        try #require(drawn.count == 4)
+        #expect(Set(drawn.map(\.y)).count == 4)
+
+        let (departing, arriving) = (Array(drawn.prefix(2)), Array(drawn.suffix(2)))
+        let rightEdge = try #require(drawn.map(\.endX).max())
+        let leftEdge  = try #require(drawn.map(\.startX).min())
+        #expect(departing.allSatisfy { $0.endX == rightEdge })
+        #expect(arriving.allSatisfy { $0.startX == leftEdge })
+    }
+
+    @Test("An unclosed tie does not follow its pitch onto the staff below")
+    func anOpenTieStaysOnItsOwnStaff() throws {
+        // Two staves this time, not a shared one.  The upper voice opens a tie it never closes
+        // and the lower voice sounds the same pitch: the anchors are threaded across both
+        // staves, so an undiscriminated match lets the lower staff resolve it — and draw the
+        // arc at the upper staff's y, a staff clear of any note in it.
+        let document = try svg(tune("c- d e f", "c d e f", plan: "%%score T1 T2"))
+        let drawn = arcs(in: document)
+        try #require(drawn.count == 1, "expected one dangling arc, got \(drawn.count)")
+        let staff = try staffLineYs(in: document)
+        try #require(staff.count == 10)
+        // Inside the upper staff, where the note it dangles from is — not near the lower one.
+        #expect(drawn[0].y > staff[0] && drawn[0].y < staff[4])
+    }
+}


### PR DESCRIPTION
Closes #78.

`emitMeasure` kept one beam accumulator, matched ties on pitch alone and popped slurs off one LIFO stack — none of which knows which voice wrote the event it is looking at. On a `%%score ( … )` staff (§11.1), whose voices the merge pass (#76) interleaves into one event stream, all three misfire.

## What was drawn, before and after

| | before | after |
|---|---|---|
| `cdef c4` over `CDEF C4`, one staff | **one** beam, across both parts | one beam per part, above and below the staff |
| `c3- c` over `z c- c z`, same pitch | arcs **crossed**: col 0→2 and col 1→3 | nested: col 0→3 and col 1→2 |
| `(c d e) f` over `C (D E F)` | each arc ends on the **other** voice's note | each arc ends on its own |

## What changed

All three accumulators are keyed by a `PartKey` of staff and voice.

The staff half is not redundant. `pendingTies` / `pendingSlurs` are threaded across every staff of every system of every page so an arc spanning a system or page break is drawn dangling rather than dropped (#27) — and undiscriminated, that lets a staff resolve or re-dangle an anchor opened on the staff *above* it, drawn at that staff's y, a whole staff clear of any note in the one it lands on. `%%score T1 T2` with `[V:T1] c- d e f` over `[V:T2] c d e f` drew two arcs for that reason where it should draw one. Re-anchoring at a system break, and the departing arcs at its end, are now this staff's own; the staff below draws its own when it is drawn.

The grace-note beam tip forwarded to the following note for fermata clearance is bucketed the same way and for the same reason: it is a per-measure accumulator, and on a shared staff the event following a grace group in the stream is as often the other voice's as its own.

## Scope

Notehead collisions between the voices — unisons, seconds, dot displacement — are still #79's.

## Testing

- New `SharedStaffArcAndBeamTests`: 6 cases, source in and SVG out — one beam run per voice, runs of unequal length keeping their own extents, a tie closed by its own voice against an equal pitch in the other, interleaved slurs pairing within their voice, a tie dangling once per voice across a system break, and an unclosed tie staying on its own staff. Five of the six fail against the base emitter; the sixth is a no-regression guard on the #27 dangling path.
- Full suite: 929 tests pass.
- Byte-identical where it should be: the 16-page `tunebook.abc` and a two-staff tune with ties and slurs in both parts both diff clean against a build of the base commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G82eK1fXZg7kiBqsKuWezv