### PR TITLE
Fix #79 — pull apart the noteheads two voices land on one spot

### DIFF
--- a/Sources/CeolKitSVGRenderer/Emission/NoteheadCollisions.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/NoteheadCollisions.swift
@@ -1,0 +1,283 @@
+import Foundation
+import CeolKitModel
+
+/// One notehead a staff is about to draw, reduced to what deciding a collision needs.
+///
+/// Built by whoever is about to draw — or to reserve room for — the head, because "the same
+/// note" is a question about the *ink*: two voices share a notehead when the glyph, the dot
+/// and the accidental they would each draw are identical, whatever the durations behind them
+/// were written as.
+struct CollisionHead {
+    let voiceIndex: Int
+    /// Diatonic staff position, as ``SVGEmitter`` counts it: one per step, rising.
+    let staffPos: Int
+    /// Which of the three notehead glyphs is drawn.
+    let glyph: SMuFLGlyph
+    let isDotted: Bool
+    let accidental: Alteration?
+    /// Which way this head's voice stems, already resolved.  Only the *direction* a displaced
+    /// unison moves depends on it; whether anything moves at all does not, which is what lets
+    /// ``SharedStaffMerger`` ask that question before stem directions are known.
+    let stemUp: Bool
+
+    /// Which line or space a pitch is drawn on: one per diatonic step, rising, zero on the
+    /// bottom line of a treble staff.  Only differences between two heads on one staff matter
+    /// here, so the origin is arbitrary — but it is the emitter's, so both agree.
+    static func staffPosition(of pitch: Pitch) -> Int {
+        (pitch.octave - 4) * 7 + (pitch.step.rawValue - DiatonicStep.e.rawValue)
+    }
+
+    /// Two heads that draw the same ink in the same place, and so need only be drawn once.
+    func drawsSameInk(as other: CollisionHead) -> Bool {
+        staffPos == other.staffPos && glyph == other.glyph && isDotted == other.isDotted
+            && accidental == other.accidental
+    }
+}
+
+/// Where one head, and the marks that belong to it, are drawn once its column's collisions
+/// are resolved.
+///
+/// Every offset is relative to the column's own x — the onset every voice in it shares — so
+/// the caller adds its own origin and nothing here knows about the page.
+struct HeadPlacement {
+    /// Horizontal displacement of the notehead, and with it the stem, the flag and the
+    /// ledger lines.  Negative is left.
+    var dx: Double = 0
+    /// `true` where another voice draws this very notehead.  The head, its accidental, its
+    /// dot and its ledger lines are that voice's; this one draws only its stem, which is what
+    /// tells a reader two parts are sounding the note.
+    var isShared: Bool = false
+    /// x of the augmentation dot relative to the column, where the column moved it out of
+    /// its default place beside the notehead.
+    var dotDX: Double?
+    /// How far the augmentation dot moves from where the notehead alone would put it,
+    /// positive downward, where two dots would otherwise land on the same spot.
+    var dotDY: Double?
+    /// x the accidental is drawn *left of*, relative to the column, where the column moved it
+    /// off its own notehead's edge.
+    var accidentalAnchorDX: Double?
+
+    /// What every head on a staff no one shares gets: drawn exactly where it was placed.
+    static let unmoved = HeadPlacement()
+}
+
+/// Resolves the notehead collisions of one column — one onset — of a staff several voices
+/// share (ABC v2.2 §11.1, issue #79).
+///
+/// Two voices on one staff sound together by definition, so their heads land at one x, and
+/// four things can collide there: the heads themselves at a unison or a second, their
+/// augmentation dots, and their accidentals.  Each is resolved the way `abcm2ps -g` resolves
+/// it, which is the way an engraver does:
+///
+/// - **Unison.**  Where both voices would draw the same ink — same staff position, same
+///   notehead, same dot, same accidental — one head is drawn and both stems grow from it.
+///   Where they would not, the heads are set side by side, the stem-down voice's to the
+///   left, so that each stem leaves the pair on its own side and neither runs through the
+///   other's head.
+/// - **Second.**  The lower-pitched head moves right by its own width.  The two stems then
+///   nearly coincide, which is what a second between parts looks like in print.
+/// - **Dots.**  Every dot in the column is drawn in one vertical strip right of the
+///   *rightmost* head, so a displaced head cannot be written over by its partner's dot; two
+///   that would then land on the same spot are split, the lower one taking the space below
+///   its note instead of the one above.
+/// - **Accidentals.**  All of them hang off the *leftmost* head rather than each off its own,
+///   and any two whose glyphs would overlap vertically are stacked, the lower one further
+///   left.  Vertical overlap is measured from the glyphs' own bounding boxes: accidentals
+///   differ in height as well as width, and a fixed threshold would stack pairs that clear
+///   each other and let pairs that do not through.
+///
+/// ## Where this parts company with abcm2ps
+///
+/// abcm2ps displaces a unison the voices cannot share to the *right* when what differs is the
+/// accidental, and draws that accidental on top of the displaced notehead — legibly wrong,
+/// and the reason it is not copied.  A unison always separates leftward here, whatever it was
+/// that stopped the voices sharing.
+struct NoteheadCollisions {
+    let noteheadWidth: Double
+    let staffSize: Double
+    let accidentalMetrics: AccidentalMetrics
+    let metadata: BravuraMetadata
+
+    /// Gap between a notehead's right edge and its augmentation dot.  Matches
+    /// ``SVGEmitter/emitAugmentationDot(x:noteheadY:staffPos:fontSize:builder:)``, which is
+    /// what draws the dot when no collision moves it.
+    private var dotGap: Double { noteheadWidth * 0.2 }
+
+    // MARK: - Resolution
+
+    /// Resolves `heads` — every notehead one column of a shared staff draws, in the order
+    /// they will be drawn — into one placement each.
+    func resolve(_ heads: [CollisionHead]) -> [HeadPlacement] {
+        var placements = [HeadPlacement](repeating: .unmoved, count: heads.count)
+        guard Set(heads.map(\.voiceIndex)).count > 1 else { return placements }
+
+        let (shared, dx) = Self.shareAndDisplace(heads, noteheadWidth: noteheadWidth)
+        for i in heads.indices {
+            placements[i].isShared = shared[i]
+            placements[i].dx = dx[i]
+        }
+
+        let visible = heads.indices.filter { !shared[$0] }
+        if dx.contains(where: { $0 != 0 }) {
+            placeDots(heads, visible: visible, dx: dx, into: &placements)
+        }
+        placeAccidentals(heads, visible: visible, dx: dx, into: &placements)
+        return placements
+    }
+
+    /// How much room a column's collisions need on each side of it, beyond what the notes in
+    /// it claim for themselves.
+    ///
+    /// ``SharedStaffMerger`` asks this before it places the heads: a head displaced by its own
+    /// width into a column sized for one is drawn over whatever stands next to it — over the
+    /// following note where a second sends it right, and over the bar line or the note behind
+    /// it where a unison sends it left.
+    ///
+    /// Which of two heads gives way depends on how they stem; that one of them does, and
+    /// which way it goes, does not — so this answer is the same whatever stem directions the
+    /// caller has filled in, and can be had before they are known.
+    static func extraWidth(_ heads: [CollisionHead], noteheadWidth: Double)
+        -> (left: Double, right: Double) {
+        guard Set(heads.map(\.voiceIndex)).count > 1 else { return (0, 0) }
+        let dx = shareAndDisplace(heads, noteheadWidth: noteheadWidth).dx
+        return (left: -min(dx.min() ?? 0, 0), right: max(dx.max() ?? 0, 0))
+    }
+
+    // MARK: - Heads
+
+    /// Which heads are drawn by another voice, and how far the rest move sideways.
+    ///
+    /// Voice order decides who keeps the place: the upper voice's head is the one drawn, and
+    /// the one left where the sizer put it.
+    private static func shareAndDisplace(_ heads: [CollisionHead], noteheadWidth: Double)
+        -> (shared: [Bool], dx: [Double]) {
+        let order = heads.indices.sorted {
+            (heads[$0].voiceIndex, -heads[$0].staffPos) < (heads[$1].voiceIndex, -heads[$1].staffPos)
+        }
+        var shared = [Bool](repeating: false, count: heads.count)
+        var dx = [Double](repeating: 0, count: heads.count)
+
+        for (n, i) in order.enumerated() where !shared[i] {
+            for j in order[(n + 1)...] where !shared[j] {
+                guard heads[j].voiceIndex != heads[i].voiceIndex else { continue }
+                if heads[i].drawsSameInk(as: heads[j]) { shared[j] = true }
+            }
+        }
+
+        let visible = order.filter { !shared[$0] }
+        for (n, a) in visible.enumerated() {
+            for b in visible[(n + 1)...] {
+                guard heads[a].voiceIndex != heads[b].voiceIndex else { continue }
+                let interval = heads[a].staffPos - heads[b].staffPos
+                // Anything a third or more apart clears on its own, and a pair one of whose
+                // heads has already moved is already apart.
+                guard abs(interval) <= 1, dx[a] == dx[b] else { continue }
+                if interval == 0 {
+                    // A unison the voices cannot share: side by side, each stem on its own
+                    // side of the pair.  Where both stem the same way — two voices that both
+                    // asked for `stem=` — the lower voice gives way.
+                    let mover = heads[a].stemUp == heads[b].stemUp
+                        ? (heads[a].voiceIndex > heads[b].voiceIndex ? a : b)
+                        : (heads[a].stemUp ? b : a)
+                    dx[mover] = -noteheadWidth
+                } else {
+                    dx[interval < 0 ? a : b] = noteheadWidth
+                }
+            }
+        }
+        return (shared, dx)
+    }
+
+    // MARK: - Dots
+
+    /// Aligns the column's augmentation dots right of its rightmost head, and splits any two
+    /// that would land on the same spot.
+    private func placeDots(_ heads: [CollisionHead], visible: [Int], dx: [Double],
+                           into placements: inout [HeadPlacement]) {
+        // Highest first, and the upper voice first where two heads are at one pitch: whoever
+        // is served first keeps the dot where the notehead alone would have put it.
+        let dotted = visible.filter { heads[$0].isDotted }.sorted {
+            (-heads[$0].staffPos, heads[$0].voiceIndex) < (-heads[$1].staffPos, heads[$1].voiceIndex)
+        }
+        guard !dotted.isEmpty else { return }
+
+        let dotDX = (visible.map { dx[$0] }.max() ?? 0) + noteheadWidth + dotGap
+        // Where each dot sits, in half staff spaces: beside a note in a space, and lifted
+        // into the space above one on a line.
+        var taken: Set<Int> = []
+        for i in dotted {
+            placements[i].dotDX = dotDX
+            let pos = heads[i].staffPos
+            let preferred = pos.isMultiple(of: 2) ? pos + 1 : pos
+            let alternative = pos.isMultiple(of: 2) ? pos - 1 : pos - 2
+            let chosen = taken.contains(preferred) && !taken.contains(alternative)
+                ? alternative : preferred
+            taken.insert(chosen)
+            // Positive is downward, and a half space of staff position is half a staff space.
+            placements[i].dotDY = Double(preferred - chosen) * staffSize / 2.0
+        }
+    }
+
+    // MARK: - Accidentals
+
+    /// Hangs the column's accidentals off its leftmost head, stacking any that would overlap.
+    private func placeAccidentals(_ heads: [CollisionHead], visible: [Int], dx: [Double],
+                                  into placements: inout [HeadPlacement]) {
+        let accidentals = visible.filter { heads[$0].accidental != nil }.sorted {
+            (-heads[$0].staffPos, heads[$0].voiceIndex) < (-heads[$1].staffPos, heads[$1].voiceIndex)
+        }
+        guard accidentals.count > 1 || dx.contains(where: { $0 != 0 }) else { return }
+
+        let anchor = visible.map { dx[$0] }.min() ?? 0
+        var slots: [[Int]] = []
+        var slotWidths: [Double] = []
+        for i in accidentals {
+            guard let alteration = heads[i].accidental else { continue }
+            var slot = 0
+            while slot < slots.count,
+                  slots[slot].contains(where: { overlapsVertically(heads[$0], heads[i]) }) {
+                slot += 1
+            }
+            if slot == slots.count { slots.append([]); slotWidths.append(0) }
+            slots[slot].append(i)
+            slotWidths[slot] = max(slotWidths[slot], accidentalMetrics.offset(for: alteration))
+        }
+        // Assigned only once every slot's width is known: a slot is as wide as the widest
+        // accidental in it, and the one to its left hangs off that.
+        for (slot, members) in slots.enumerated() {
+            let step = slotWidths[..<slot].reduce(0, +)
+            for i in members { placements[i].accidentalAnchorDX = anchor - step }
+        }
+    }
+
+    /// Whether the accidentals of two heads would run into each other vertically.
+    private func overlapsVertically(_ a: CollisionHead, _ b: CollisionHead) -> Bool {
+        guard let aExtent = accidentalExtent(a), let bExtent = accidentalExtent(b) else {
+            return false
+        }
+        let clearance = 0.1 * staffSize
+        return aExtent.lowerBound - clearance < bExtent.upperBound
+            && bExtent.lowerBound - clearance < aExtent.upperBound
+    }
+
+    /// The vertical span an accidental glyph covers, in page coordinates relative to the
+    /// staff's own zero — y grows downward, the glyph's bounding box grows upward.
+    private func accidentalExtent(_ head: CollisionHead) -> ClosedRange<Double>? {
+        guard let alteration = head.accidental,
+              let glyph = SMuFLGlyph.accidental(for: alteration) else { return nil }
+        let box = metadata.glyphBBoxes[glyph.rawValue]
+        let y = -Double(head.staffPos) * staffSize / 2.0
+        let top = y - (box?.neY ?? 1.4) * staffSize
+        let bottom = y - (box?.swY ?? -1.4) * staffSize
+        return top...bottom
+    }
+}
+
+extension SMuFLGlyph {
+    /// The notehead drawn for a duration in whole notes.
+    static func notehead(absoluteDuration d: Double) -> SMuFLGlyph {
+        if d >= 1.0 { return .noteheadWhole }
+        if d >= 0.5 { return .noteheadHalf  }
+        return .noteheadBlack
+    }
+}

--- a/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
@@ -81,6 +81,9 @@ struct SVGEmitter: Sendable {
     /// voices share the staff.  Empty on the page-level emitter, which draws nothing itself.
     let voiceStemDirections: [StemDirection]
     let accidentalMetrics: AccidentalMetrics
+    /// Resolves the notehead, dot and accidental collisions of one column of a shared staff
+    /// (issue #79).  Consulted only where a staff carries more than one voice.
+    let collisions: NoteheadCollisions
 
     init(config: SVGRenderConfig, metadata: BravuraMetadata,
          stemDirection: StemDirection = .auto,
@@ -91,7 +94,14 @@ struct SVGEmitter: Sendable {
         self.documentStemDirection = stemDirection
         self.stemDirection = systemStemDirection ?? stemDirection
         self.voiceStemDirections = voiceStemDirections
-        self.accidentalMetrics = AccidentalMetrics(config: config, metadata: metadata)
+        let accidentalMetrics = AccidentalMetrics(config: config, metadata: metadata)
+        self.accidentalMetrics = accidentalMetrics
+        self.collisions = NoteheadCollisions(
+            noteheadWidth: metadata.glyphBBoxes["noteheadBlack"].map { $0.width * config.staffSize }
+                ?? config.staffSize * 1.2,
+            staffSize: config.staffSize,
+            accidentalMetrics: accidentalMetrics,
+            metadata: metadata)
     }
 
     // MARK: - Public entry point
@@ -215,6 +225,69 @@ struct SVGEmitter: Sendable {
         if index == 0 { return -config.staffSize }
         if index == staffVoiceCount - 1 { return config.staffSize }
         return 0
+    }
+
+    // MARK: - Notehead collisions
+
+    /// Where every notehead of `measure` is drawn once the voices sharing the staff have been
+    /// pulled apart (issue #79), keyed by event index — one placement per notehead the event
+    /// draws, in the order ``emitEvent(_:topStaffY:bottomStaffY:unitNoteLength:separateRests:precedingGraceBeamY:placements:builder:)``
+    /// draws them.
+    ///
+    /// Columns are found by x rather than by onset because x is what the merge (#76) *did*
+    /// with the onsets: every voice sounding together was right-aligned onto one sub-column,
+    /// so heads that share an x are heads that sound together, and no second opinion about
+    /// the rhythm can disagree with the spacing already on the page.
+    ///
+    /// Empty on every staff carrying one voice, which is every staff outside a `%%score
+    /// ( … )` group: nothing there can collide, and nothing there is asked.
+    private func collisionPlacements(in measure: ResolvedMeasure) -> [Int: [HeadPlacement]] {
+        guard staffVoiceCount > 1 else { return [:] }
+        var heads: [Int: [CollisionHead]] = [:]
+        for (index, event) in measure.events.enumerated() {
+            let drawn = collisionHeads(of: event, unitNoteLength: measure.unitNoteLength)
+            if !drawn.isEmpty { heads[index] = drawn }
+        }
+        guard heads.count > 1 else { return [:] }
+
+        var placements: [Int: [HeadPlacement]] = [:]
+        let columns = Dictionary(grouping: heads.keys) {
+            (measure.events[$0].origin.x * 100).rounded()
+        }
+        for (_, indices) in columns {
+            let ordered = indices.sorted()
+            let column = ordered.flatMap { heads[$0] ?? [] }
+            guard Set(column.map(\.voiceIndex)).count > 1 else { continue }
+            let resolved = collisions.resolve(column)
+            var cursor = 0
+            for index in ordered {
+                let count = heads[index]?.count ?? 0
+                placements[index] = Array(resolved[cursor..<(cursor + count)])
+                cursor += count
+            }
+        }
+        return placements
+    }
+
+    /// The noteheads `event` draws, in drawing order.  Everything that draws none — a rest,
+    /// a grace group, a tuplet the emitter still defers — contributes nothing to a column.
+    private func collisionHeads(of event: ResolvedEvent,
+                                unitNoteLength: Fraction) -> [CollisionHead] {
+        let direction = resolvedStemDirection(forVoice: event.voiceIndex)
+        func head(_ note: Note) -> CollisionHead {
+            let staffPos = self.staffPos(for: note.pitch)
+            let absDur = absoluteDuration(note.duration, unitNoteLength: unitNoteLength)
+            return CollisionHead(voiceIndex: event.voiceIndex, staffPos: staffPos,
+                                 glyph: .notehead(absoluteDuration: absDur),
+                                 isDotted: isDotted(absDur),
+                                 accidental: note.displayedAccidental,
+                                 stemUp: stemsUp(direction, staffPos: staffPos))
+        }
+        switch event.kind {
+        case .note(let n):  return [head(n)]
+        case .chord(let c): return c.notes.map(head)
+        default:            return []
+        }
     }
 
     /// Which voices draw ink in `measure` — the ones a reader can see are there.
@@ -656,6 +729,9 @@ struct SVGEmitter: Sendable {
 
         // Two parts are only visibly two where both of them draw: see `inkedVoices(of:)`.
         let separateRests = inkedVoices(of: measure).count > 1
+        // Where the voices' noteheads land on top of each other, what each of them draws and
+        // where (issue #79).  Empty everywhere but on a shared staff.
+        let placements = collisionPlacements(in: measure)
 
         // Beam accumulator: per-note (StemInfo, beamCount) pairs for the current beam run,
         // one run per voice of the staff.  A shared staff interleaves its voices in one event
@@ -671,9 +747,13 @@ struct SVGEmitter: Sendable {
             emitBeamGroup(g, builder: &builder)
         }
 
-        for event in measure.events {
+        for (index, event) in measure.events.enumerated() {
             let voice = event.voiceIndex
             let part = PartKey(staff: staffIndex, voice: voice)
+            let eventPlacements = placements[index] ?? []
+            // A note pulled aside by a collision takes its ties and slurs with it: the arc
+            // has to leave the notehead it was written on, not the place the sizer put it.
+            let anchorX = event.origin.x + (eventPlacements.first?.dx ?? 0)
             // Grace events are handled here so their stem-tip Y can be forwarded
             // to the next note for fermata clearance.
             if case .grace(let g) = event.kind {
@@ -685,6 +765,7 @@ struct SVGEmitter: Sendable {
                                      unitNoteLength: measure.unitNoteLength,
                                      separateRests: separateRests,
                                      precedingGraceBeamY: lastGraceBeamY[voice],
+                                     placements: eventPlacements,
                                      builder: &builder)
             lastGraceBeamY[voice] = nil
             if let info = stemInfo, let note = noteFrom(event) {
@@ -719,16 +800,16 @@ struct SVGEmitter: Sendable {
                         let anchor = pendingTies.remove(at: idx)
                         if anchor.isCarriedOver {
                             emitArrivingTieArc(edgeX: anchor.x, staffPos: anchor.staffPos,
-                                               toX: event.origin.x, toY: ny,
+                                               toX: anchorX, toY: ny,
                                                kind: .tie, builder: &builder)
                         } else {
                             emitTieArc(fromX: anchor.x, fromY: anchor.noteY, staffPos: anchor.staffPos,
-                                       toX: event.origin.x, toY: ny, kind: .tie, builder: &builder)
+                                       toX: anchorX, toY: ny, kind: .tie, builder: &builder)
                         }
                     }
                 }
                 if note.ties == .startsTie || note.ties == .continuesTie {
-                    pendingTies.append(TieAnchor(x: event.origin.x, noteY: ny,
+                    pendingTies.append(TieAnchor(x: anchorX, noteY: ny,
                                                  pitch: note.pitch, staffPos: sp, part: part))
                 }
             }
@@ -744,16 +825,16 @@ struct SVGEmitter: Sendable {
                         let anchor = pendingSlurs.remove(at: idx)
                         if anchor.isCarriedOver {
                             emitArrivingTieArc(edgeX: anchor.x, staffPos: anchor.staffPos,
-                                               toX: event.origin.x, toY: ny,
+                                               toX: anchorX, toY: ny,
                                                kind: .slur, builder: &builder)
                         } else {
                             emitTieArc(fromX: anchor.x, fromY: anchor.noteY, staffPos: anchor.staffPos,
-                                       toX: event.origin.x, toY: ny, kind: .slur, builder: &builder)
+                                       toX: anchorX, toY: ny, kind: .slur, builder: &builder)
                         }
                     }
                 }
                 for _ in 0..<note.slurs.opens {
-                    pendingSlurs.append(SlurAnchor(x: event.origin.x, noteY: ny, staffPos: sp,
+                    pendingSlurs.append(SlurAnchor(x: anchorX, noteY: ny, staffPos: sp,
                                                    part: part))
                 }
             }
@@ -958,10 +1039,14 @@ struct SVGEmitter: Sendable {
 
     // MARK: - Events
 
+    /// - Parameter placements: what the collision pass decided about each notehead this event
+    ///   draws, in drawing order.  Empty — the single-voice case and every event that draws
+    ///   no notehead — means every head is drawn where it was placed.
     @discardableResult
     private func emitEvent(_ event: ResolvedEvent, topStaffY: Double, bottomStaffY: Double,
                            unitNoteLength: Fraction, separateRests: Bool = false,
                            precedingGraceBeamY: Double? = nil,
+                           placements: [HeadPlacement] = [],
                            builder: inout SVGBuilder) -> StemInfo? {
         // Which voice of the staff wrote this decides which way it stems and where its
         // rests sit — the two things a shared staff has to draw differently from a staff of
@@ -973,6 +1058,7 @@ struct SVGEmitter: Sendable {
             return emitNote(n, x: event.origin.x, topStaffY: topStaffY, bottomStaffY: bottomStaffY,
                             unitNoteLength: unitNoteLength, stemDirection: stem,
                             precedingGraceBeamY: precedingGraceBeamY,
+                            placement: placements.first ?? .unmoved,
                             builder: &builder)
         case .rest(let r):
             emitRest(r, x: event.origin.x, topStaffY: topStaffY, bottomStaffY: bottomStaffY,
@@ -980,10 +1066,11 @@ struct SVGEmitter: Sendable {
                      voiceIndex: separateRests ? event.voiceIndex : nil,
                      builder: &builder)
         case .chord(let c):
-            for note in c.notes {
+            for (i, note) in c.notes.enumerated() {
                 emitNote(note, x: event.origin.x, topStaffY: topStaffY, bottomStaffY: bottomStaffY,
                          unitNoteLength: unitNoteLength, stemDirection: stem,
                          precedingGraceBeamY: precedingGraceBeamY,
+                         placement: i < placements.count ? placements[i] : .unmoved,
                          builder: &builder)
             }
         case .grace:
@@ -1003,53 +1090,75 @@ struct SVGEmitter: Sendable {
 
     // MARK: - Notes
 
+    /// - Parameter placement: where a shared staff's collision pass moved this notehead and
+    ///   the marks that belong to it (issue #79).  ``HeadPlacement/unmoved`` — every note on
+    ///   a staff of its own — draws exactly where `x` says.
     @discardableResult
     private func emitNote(_ note: Note, x: Double, topStaffY: Double, bottomStaffY: Double,
                           unitNoteLength: Fraction, stemDirection: StemDirection,
                           precedingGraceBeamY: Double? = nil,
+                          placement: HeadPlacement = .unmoved,
                           builder: inout SVGBuilder) -> StemInfo? {
         let staffPos  = self.staffPos(for: note.pitch)
         let y         = noteY(staffPos: staffPos, bottomStaffY: bottomStaffY)
         let absDur    = absoluteDuration(note.duration, unitNoteLength: unitNoteLength)
         let glyph     = noteheadGlyph(absoluteDuration: absDur)
         let fontSize  = 4.0 * config.staffSize
+        // Everything drawn from the notehead moves with it; everything measured from the
+        // column — a stacked accidental, a shared dot strip — is placed from `x`.
+        let headX     = x + placement.dx
 
-        builder.text(String(glyph.character), x: x, y: y,
-                     fontFamily: "Bravura", fontSize: fontSize)
+        // A head another voice draws is drawn once: this voice contributes its stem, which is
+        // what says two parts are sounding the note, and nothing that would be laid twice.
+        if !placement.isShared {
+            builder.text(String(glyph.character), x: headX, y: y,
+                         fontFamily: "Bravura", fontSize: fontSize)
 
-        if let acc = note.displayedAccidental {
-            emitAccidental(acc, x: x, y: y, fontSize: fontSize, builder: &builder)
+            if let acc = note.displayedAccidental {
+                emitAccidental(acc, x: headX, y: y, fontSize: fontSize,
+                               anchorX: placement.accidentalAnchorDX.map { x + $0 },
+                               builder: &builder)
+            }
+
+            if isDotted(absDur) {
+                emitAugmentationDot(x: headX, noteheadY: y, staffPos: staffPos, fontSize: fontSize,
+                                    dotX: placement.dotDX.map { x + $0 }, dotDY: placement.dotDY ?? 0,
+                                    builder: &builder)
+            }
         }
 
-        if isDotted(absDur) {
-            emitAugmentationDot(x: x, noteheadY: y, staffPos: staffPos, fontSize: fontSize,
-                                builder: &builder)
-        }
-
-        emitDecorations(note.decorations, x: x, topStaffY: topStaffY, bottomStaffY: bottomStaffY,
+        emitDecorations(note.decorations, x: headX, topStaffY: topStaffY, bottomStaffY: bottomStaffY,
                         fontSize: fontSize, precedingGraceBeamY: precedingGraceBeamY, builder: &builder)
 
         var stemInfo: StemInfo?
         if absDur < 1.0 {
-            stemInfo = emitStem(staffPos: staffPos, noteheadY: y, x: x, absDur: absDur,
+            stemInfo = emitStem(staffPos: staffPos, noteheadY: y, x: headX, absDur: absDur,
                                 beamState: note.beam, direction: stemDirection, builder: &builder)
         }
 
-        emitLedgerLines(staffPos: staffPos, x: x, bottomStaffY: bottomStaffY, builder: &builder)
+        if !placement.isShared {
+            emitLedgerLines(staffPos: staffPos, x: headX, bottomStaffY: bottomStaffY, builder: &builder)
+        }
         return stemInfo
     }
 
+    /// - Parameters:
+    ///   - dotX: where the dot goes when its column moved it out of its default place beside
+    ///     the notehead — the dots of a shared staff's column are drawn in one strip.
+    ///   - dotDY: how far the dot moves from where the notehead alone would put it, positive
+    ///     downward, where another voice's dot has taken that spot.
     private func emitAugmentationDot(x: Double, noteheadY: Double, staffPos: Int,
-                                      fontSize: Double, builder: inout SVGBuilder) {
+                                      fontSize: Double, dotX: Double? = nil, dotDY: Double = 0,
+                                      builder: inout SVGBuilder) {
         let noteW   = noteheadWidth()
         let dotGap  = noteW * 0.2
-        let dotX    = x + noteW + dotGap
 
         // If the notehead sits on a line (even staffPos), shift dot up half a space to a space.
         let dotY = staffPos.isMultiple(of: 2)
             ? noteheadY - config.staffSize / 2.0
             : noteheadY
-        builder.text(String(SMuFLGlyph.augmentationDot.character), x: dotX, y: dotY,
+        builder.text(String(SMuFLGlyph.augmentationDot.character),
+                     x: dotX ?? (x + noteW + dotGap), y: dotY + dotDY,
                      fontFamily: "Bravura", fontSize: fontSize)
     }
 
@@ -1073,12 +1182,7 @@ struct SVGEmitter: Sendable {
     private func emitStem(staffPos: Int, noteheadY: Double, x: Double, absDur: Double,
                            beamState: BeamState, direction: StemDirection,
                            builder: inout SVGBuilder) -> StemInfo {
-        let stemUp: Bool
-        switch direction {
-        case .up:   stemUp = true
-        case .down: stemUp = false
-        case .auto: stemUp = staffPos <= 4
-        }
+        let stemUp       = stemsUp(direction, staffPos: staffPos)
         let noteheadW    = noteheadWidth()
         let stemThick    = metadata.engravingDefaults.stemThickness * config.staffSize
         let stemLength   = 3.5 * config.staffSize
@@ -1126,12 +1230,17 @@ struct SVGEmitter: Sendable {
     ///
     /// The offset is the glyph's own width plus a clearance gap — a fixed offset would let
     /// the wider glyphs (a double flat is 1.644 staff spaces) run over the notehead.
+    ///
+    /// - Parameter anchorX: what to hang the glyph off, where that is not the notehead's own
+    ///   left edge: on a shared staff every accidental in a column hangs off the leftmost
+    ///   head, and one that would overlap another is pushed a further glyph to the left.
     private func emitAccidental(_ alt: Alteration, x: Double, y: Double,
                                 fontSize: Double, scale: Double = 1.0,
+                                anchorX: Double? = nil,
                                 builder: inout SVGBuilder) {
         guard let glyph = SMuFLGlyph.accidental(for: alt) else { return }
         let offset = accidentalMetrics.offset(for: alt, scale: scale)
-        builder.text(String(glyph.character), x: x - offset, y: y,
+        builder.text(String(glyph.character), x: (anchorX ?? x) - offset, y: y,
                      fontFamily: "Bravura", fontSize: fontSize)
     }
 
@@ -1416,7 +1525,7 @@ struct SVGEmitter: Sendable {
     // MARK: - Helpers
 
     private func staffPos(for pitch: Pitch) -> Int {
-        (pitch.octave - 4) * 7 + (pitch.step.rawValue - DiatonicStep.e.rawValue)
+        CollisionHead.staffPosition(of: pitch)
     }
 
     private func noteY(staffPos: Int, bottomStaffY: Double) -> Double {
@@ -1430,9 +1539,18 @@ struct SVGEmitter: Sendable {
     }
 
     private func noteheadGlyph(absoluteDuration d: Double) -> SMuFLGlyph {
-        if d >= 1.0 { return .noteheadWhole }
-        if d >= 0.5 { return .noteheadHalf  }
-        return .noteheadBlack
+        .notehead(absoluteDuration: d)
+    }
+
+    /// Which way a note stems, once its voice's direction and its own staff position have
+    /// both had their say.  ``emitStem(staffPos:noteheadY:x:absDur:beamState:direction:builder:)``
+    /// draws by this, and the collision pass reads it to decide which way a unison separates.
+    private func stemsUp(_ direction: StemDirection, staffPos: Int) -> Bool {
+        switch direction {
+        case .up:   return true
+        case .down: return false
+        case .auto: return staffPos <= 4
+        }
     }
 
     private func flagGlyph(absDur: Double, stemUp: Bool) -> SMuFLGlyph {

--- a/Sources/CeolKitSVGRenderer/Layout/SharedStaffMerger.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/SharedStaffMerger.swift
@@ -112,8 +112,17 @@ struct SharedStaffMerger: Sendable {
                     subWidths[sub] = max(subWidths[sub], width)
                 }
             }
+            // A column whose voices collide has a head displaced sideways out of it (#79),
+            // and a head displaced by its own width into a column sized for one is drawn over
+            // whatever stands next to it.  Room to the right goes into the principal
+            // sub-column — the last, the one every voice's note lands in; room to the left is
+            // opened by starting the whole column further along.
+            let extra = NoteheadCollisions.extraWidth(runs.flatMap(\.collisionHeads),
+                                                      noteheadWidth: metrics.noteheadWidth())
+            if subColumnCount > 0 { subWidths[subColumnCount - 1] += extra.right }
+
             var subX = [Double](repeating: 0, count: subColumnCount)
-            var cursor = x
+            var cursor = x + extra.left
             for j in 0..<subColumnCount {
                 subX[j] = cursor
                 cursor += subWidths[j]
@@ -213,6 +222,9 @@ struct SharedStaffMerger: Sendable {
         let voice: Prepared
         let slot: Prepared.Slot
         let widths: [Double]
+        /// The noteheads this voice draws at the onset — what ``NoteheadCollisions`` needs to
+        /// say whether the column has to be widened for a displaced head.
+        let collisionHeads: [CollisionHead]
         /// Positions within ``slot`` holding a grace group that is immediately followed by
         /// the note it ornaments — the pairs `Justifier.stretchOffsets` must not stretch.
         let pairedGraceOffsets: Set<Int>
@@ -244,6 +256,38 @@ struct SharedStaffMerger: Sendable {
             }
             self.widths = widths
             self.pairedGraceOffsets = paired
+            // Only the event that sounds draws a head at this onset; a grace group ahead of
+            // it is drawn clear of the column and never collides with the other voice.
+            self.collisionHeads = events.last.map {
+                Run.heads(of: $0, voice: voice, metrics: metrics)
+            } ?? []
+        }
+
+        /// The heads `event` draws, as the collision pass sees them.
+        ///
+        /// The stem direction given is the opposition a shared staff imposes (#77), which is
+        /// right for all but a voice that stated `V:` `stem=` — and wrong there only about
+        /// *which way* a unison separates, never about whether it separates at all, which is
+        /// the whole of what the sizer is asking.
+        private static func heads(of event: Event, voice: Prepared,
+                                  metrics: ColumnMetrics) -> [CollisionHead] {
+            let unl = voice.part.unitNoteLength
+            func head(_ note: Note) -> CollisionHead {
+                let duration = Double(note.duration.numerator) / Double(note.duration.denominator)
+                    * Double(unl.numerator) / Double(unl.denominator)
+                return CollisionHead(
+                    voiceIndex: voice.part.voiceIndex,
+                    staffPos: CollisionHead.staffPosition(of: note.pitch),
+                    glyph: .notehead(absoluteDuration: duration),
+                    isDotted: metrics.isDottedDuration(note.duration),
+                    accidental: note.displayedAccidental,
+                    stemUp: voice.part.voiceIndex == 0)
+            }
+            switch event {
+            case .note(let n):  return [head(n)]
+            case .chord(let c): return c.notes.map(head)
+            default:            return []
+            }
         }
     }
 }

--- a/Tests/CeolKitSVGRendererTests/SharedStaffCollisionTests.swift
+++ b/Tests/CeolKitSVGRendererTests/SharedStaffCollisionTests.swift
@@ -1,0 +1,260 @@
+import Testing
+import CeolKitModel
+import CeolKitParser
+@testable import CeolKitSVGRenderer
+
+/// Issue #79: what two voices sharing a staff (§11.1 `%%score ( … )`) draw where their notes
+/// land on the same spot.
+///
+/// The merge (#76) puts every voice sounding at one onset at one x, which is what makes a
+/// shared staff readable as two parts and what makes its noteheads collide: a unison writes
+/// two heads over each other, a second writes two heads that half overlap, and the dots and
+/// accidentals of both hang in the same strip of air.
+///
+/// End to end, source in and SVG out, like ``SharedStaffVoiceDrawingTests`` and
+/// ``SharedStaffArcAndBeamTests``: the question is what got *drawn*, and the layout it was
+/// drawn from was already right.  The expected geometry is `abcm2ps -g`'s, checked against it
+/// case by case — except where this deliberately parts company, which is called out where it
+/// happens.
+@Suite("Shared staff: notehead collisions")
+struct SharedStaffCollisionTests {
+
+    private let config = SVGRenderConfig()
+
+    private func svg(_ abc: String) throws -> String {
+        let score = CeolKitParser().parse(abc, options: .default).score
+        var diagnostics: [Diagnostic] = []
+        return try textProbeRenderer(config).render(score, diagnostics: &diagnostics).joined()
+    }
+
+    /// A two-voice tune, both voices on one staff unless `plan` says otherwise.
+    private func tune(_ upper: String, _ lower: String, unitLength: String = "1/4",
+                      plan: String = "%%score (T1 T2)") -> String {
+        ["X:1", "T:Collisions", "M:4/4", "L:\(unitLength)", plan, "K:C", "V:T1", "V:T2",
+         "[V:T1] \(upper) |", "[V:T2] \(lower) |"].joined(separator: "\n") + "\n"
+    }
+
+    // MARK: - Probes
+
+    private struct ProbedGlyph {
+        let character: Character
+        let x: Double
+        let y: Double
+    }
+
+    /// Every Bravura glyph drawn, in document order.
+    private func glyphs(in svg: String) -> [ProbedGlyph] {
+        svg.matches(
+            of: /<text x="([-0-9.]+)" y="([-0-9.]+)" font-family="Bravura"[^>]*>(.)<\/text>/
+        ).compactMap { match in
+            guard let x = Double(match.1), let y = Double(match.2),
+                  let ch = String(match.3).first else { return nil }
+            return ProbedGlyph(character: ch, x: x, y: y)
+        }
+    }
+
+    private func glyphs(_ kinds: Set<SMuFLGlyph>, in svg: String) -> [ProbedGlyph] {
+        let characters = Set(kinds.map(\.character))
+        return glyphs(in: svg).filter { characters.contains($0.character) }
+    }
+
+    /// Every notehead drawn, left to right and top to bottom within a column.
+    private func noteheads(in svg: String) -> [ProbedGlyph] {
+        glyphs([.noteheadBlack, .noteheadHalf, .noteheadWhole], in: svg)
+            .sorted { ($0.x, $0.y) < ($1.x, $1.y) }
+    }
+
+    private func dots(in svg: String) -> [ProbedGlyph] {
+        glyphs([.augmentationDot], in: svg).sorted { ($0.x, $0.y) < ($1.x, $1.y) }
+    }
+
+    private func accidentals(in svg: String) -> [ProbedGlyph] {
+        glyphs([.accidentalSharp, .accidentalFlat, .accidentalNatural], in: svg)
+            .sorted { ($0.x, $0.y) < ($1.x, $1.y) }
+    }
+
+    /// The width a notehead is displaced by, which is its own.
+    private func noteheadWidth() throws -> Double {
+        let metadata = try BravuraMetadata.load()
+        return try #require(metadata.glyphBBoxes["noteheadBlack"]).width * config.staffSize
+    }
+
+    // MARK: - Unison
+
+    @Test("Two voices at the same pitch and duration share one notehead")
+    func unisonSharesOneNotehead() throws {
+        let document = try svg(tune("c c c c", "c c c c"))
+        // Four onsets, one head each: the lower voice draws no second head over the first.
+        let heads = noteheads(in: document)
+        #expect(heads.count == 4)
+        #expect(Set(heads.map(\.y)).count == 1)
+    }
+
+    @Test("The voice whose head is not drawn still draws its stem")
+    func sharedUnisonKeepsBothStems() throws {
+        let metadata = try BravuraMetadata.load()
+        let stems = probedStems(in: try svg(tune("c c c c", "c c c c")),
+                                staffSize: config.staffSize, metadata: metadata)
+        // Two stems per shared head, opposed: what tells a reader two parts are sounding it.
+        try #require(stems.count == 8)
+        #expect(stems.filter(\.isUp).count == 4)
+        #expect(stems.filter { !$0.isUp }.count == 4)
+    }
+
+    @Test("A unison the voices cannot share is drawn as two heads, the lower voice's left")
+    func unsharableUnisonSeparatesLeftward() throws {
+        // Same pitch, different note value: one head cannot say both, so they go side by side.
+        // Leftward, so that each stem leaves the pair on its own side rather than running
+        // through the other voice's head — `abcm2ps -g` draws this pair the same way.
+        let document = try svg(tune("c2 c2", "c c c c"))
+        let firstColumn = noteheads(in: document).prefix(2)
+        try #require(firstColumn.count == 2)
+        let (lower, upper) = (firstColumn[0], firstColumn[1])
+        #expect(lower.character == SMuFLGlyph.noteheadBlack.character)
+        #expect(upper.character == SMuFLGlyph.noteheadHalf.character)
+        #expect(abs((upper.x - lower.x) - (try noteheadWidth())) < 0.01)
+    }
+
+    @Test("A unison the voices spell differently separates, and the accidental clears both")
+    func unsharableUnisonClearsItsAccidental() throws {
+        // `abcm2ps -g` displaces this pair to the *right* and then draws the sharp on top of
+        // the displaced notehead.  Separating leftward, as every other unsharable unison
+        // does, leaves the accidental somewhere a reader can see it.
+        let document = try svg(tune("c4", "^c4"))
+        let heads = noteheads(in: document)
+        try #require(heads.count == 2)
+        #expect(abs((heads[1].x - heads[0].x) - (try noteheadWidth())) < 0.01)
+        let sharps = accidentals(in: document)
+        try #require(sharps.count == 1)
+        #expect(sharps[0].x < heads[0].x)
+    }
+
+    // MARK: - Second
+
+    @Test("Two voices a second apart draw offset noteheads, both legible")
+    func secondOffsetsTheLowerHead() throws {
+        let document = try svg(tune("d d d d", "c c c c"))
+        let heads = noteheads(in: document)
+        try #require(heads.count == 8)
+        // Both heads of every column are drawn, the lower-pitched one a notehead width right:
+        // the two stems then nearly coincide, which is what a second between parts looks like
+        // in print, and what `abcm2ps -g` draws.
+        for column in stride(from: 0, to: 8, by: 2) {
+            let (upper, lower) = (heads[column], heads[column + 1])
+            #expect(upper.y < lower.y)
+            #expect(abs((lower.x - upper.x) - (try noteheadWidth())) < 0.01)
+        }
+    }
+
+    @Test("A third apart is left alone: the heads clear each other unaided")
+    func thirdsAreNotDisplaced() throws {
+        let document = try svg(tune("e e e e", "c c c c"))
+        let heads = noteheads(in: document)
+        try #require(heads.count == 8)
+        for column in stride(from: 0, to: 8, by: 2) {
+            #expect(heads[column].x == heads[column + 1].x)
+        }
+    }
+
+    // MARK: - Augmentation dots
+
+    @Test("The dots of a column are drawn in one strip, clear of the rightmost head")
+    func dotsShareAStripRightOfBothHeads() throws {
+        let document = try svg(tune("c3/2 c/2", "B3/2 B/2"))
+        // The first onset is the dotted pair; the eighths after it are the second.
+        let firstColumn = noteheads(in: document).prefix(2)
+        let dots = dots(in: document)
+        try #require(dots.count == 2)
+        #expect(dots[0].x == dots[1].x)
+        #expect(dots[0].x > firstColumn.map(\.x).max()!)
+    }
+
+    @Test("Two dots that would land on one spot are split, the lower one below its note")
+    func clashingDotsSplitVertically() throws {
+        // `c` sits in a space and keeps its dot beside it; `B` is on the line below, whose dot
+        // would be lifted into that same space.  It goes into the space below instead — which
+        // is what `abcm2ps -g` draws for this bar.
+        let document = try svg(tune("c3/2 c/2", "B3/2 B/2"))
+        let firstColumn = noteheads(in: document).prefix(2).sorted { $0.y < $1.y }
+        let (c, b) = (firstColumn[0], firstColumn[1])
+        let dots = dots(in: document)
+        try #require(dots.count == 2)
+        #expect(dots[0].y == c.y)
+        #expect(dots[1].y == b.y + config.staffSize / 2)
+    }
+
+    @Test("A staff of one voice dots its notes exactly as it always has")
+    func singleVoiceDotsAreUnmoved() throws {
+        let document = try svg("X:1\nT:Alone\nM:4/4\nL:1/4\nK:C\nc3/2 c/2 c3/2 c/2 |\n")
+        let heads = noteheads(in: document)
+        let dots = dots(in: document)
+        try #require(heads.count == 4)
+        try #require(dots.count == 2)
+        // Notehead, then a fifth of one as a gap: the default the collision pass never touches.
+        let gap = try noteheadWidth() * 1.2
+        #expect(abs((dots[0].x - heads[0].x) - gap) < 0.01)
+        #expect(dots[0].y == heads[0].y)
+    }
+
+    // MARK: - Accidentals
+
+    @Test("Accidentals that would overlap are stacked, the lower one further left")
+    func accidentalsStackWhenTheyOverlap() throws {
+        // A third apart: the heads clear each other, and the accidental glyphs — nearly three
+        // staff spaces tall apiece — do not.
+        let document = try svg(tune("^e4", "^c4"))
+        let heads = noteheads(in: document)
+        let sharps = accidentals(in: document)
+        try #require(heads.count == 2)
+        try #require(sharps.count == 2)
+        #expect(heads[0].x == heads[1].x)
+        // Sorted by x: the further-left glyph is the lower note's.
+        #expect(sharps[0].y > sharps[1].y)
+        let metadata = try BravuraMetadata.load()
+        let sharpWidth = try #require(metadata.glyphBBoxes["accidentalSharp"]).width * config.staffSize
+        #expect(sharps[1].x - sharps[0].x >= sharpWidth)
+    }
+
+    @Test("Accidentals a seventh apart clear each other and are left where they were")
+    func distantAccidentalsAreNotStacked() throws {
+        let document = try svg(tune("^e4", "^F4"))
+        let sharps = accidentals(in: document)
+        try #require(sharps.count == 2)
+        #expect(sharps[0].x == sharps[1].x)
+    }
+
+    @Test("A displaced head's accidental hangs off the leftmost head, not its own")
+    func accidentalOfADisplacedHeadClearsTheColumn() throws {
+        // A second, so the lower voice's head moves right; its sharp stays left of *both*
+        // heads rather than following it into the gap between them, where it would be drawn
+        // over the upper voice's notehead.
+        let document = try svg(tune("e4", "^d4"))
+        let heads = noteheads(in: document)
+        let sharps = accidentals(in: document)
+        try #require(heads.count == 2)
+        try #require(sharps.count == 1)
+        #expect(sharps[0].x < heads.map(\.x).min()!)
+    }
+
+    // MARK: - What must not change
+
+    @Test("A shared staff whose voices never collide is drawn exactly as it was")
+    func nonCollidingSharedStaffIsUnchanged() throws {
+        // An octave apart, which is where ``SharedStaffVoiceDrawingTests`` keeps its parts:
+        // every head stays in the column the sizer put it in.
+        let document = try svg(tune("c d e f", "C D E F"))
+        let heads = noteheads(in: document)
+        try #require(heads.count == 8)
+        for column in stride(from: 0, to: 8, by: 2) {
+            #expect(heads[column].x == heads[column + 1].x)
+        }
+    }
+
+    @Test("Two voices on staves of their own collide with nothing")
+    func separateStavesAreUntouched() throws {
+        // The same unison, planned onto a staff each: two heads, one per staff, and neither
+        // of them another voice's to draw.
+        let document = try svg(tune("c c c c", "c c c c", plan: "%%score T1 T2"))
+        #expect(noteheads(in: document).count == 8)
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/SharedStaffVoiceDrawingTests.swift
+++ b/Tests/CeolKitSVGRendererTests/SharedStaffVoiceDrawingTests.swift
@@ -12,9 +12,9 @@ import CeolKitParser
 /// fix — the merge pass (#76) had the voices in one event stream and tagged (#75), and the
 /// emitter still read the pitch.
 ///
-/// Note collisions between the two voices — unisons, seconds, displaced dots — are #79's,
-/// not this suite's.  The tunes here keep the parts an octave or more apart so nothing in
-/// the assertions depends on collision handling that does not exist yet.
+/// Note collisions between the two voices — unisons, seconds, displaced dots — are
+/// ``SharedStaffCollisionTests``' (#79), not this suite's.  The tunes here keep the parts an
+/// octave or more apart, so nothing asserted below depends on what the collision pass does.
 @Suite("Shared staff: opposed stems and offset rests")
 struct SharedStaffVoiceDrawingTests {
 


### PR DESCRIPTION
Closes #79.

The merge (#76) puts every voice sounding at one onset at one x, which is what makes a shared staff readable as two parts and what makes its noteheads collide. Nothing downstream knew that: a unison drew two heads over each other, a second drew two heads half overlapping, and the dots and accidentals of both hung in the same strip of air — the last of the `%%score ( … )` staff's drawing problems, and the one #77 and #78 each said they were leaving.

## What it draws now

`NoteheadCollisions` resolves one column of one staff, the way `abcm2ps -g` does:

- **Unison.** Where both voices draw the same ink — same staff position, same notehead, same dot, same accidental — one head is drawn and both stems grow from it, which is what says two parts are sounding it. Where they would not, the heads go side by side, the stem-down voice's to the left, so each stem leaves the pair on its own side rather than through the other's head.
- **Second.** The lower-pitched head moves right by its own width. The two stems then nearly coincide, which is what a second between parts looks like in print.
- **Dots.** Every dot in the column is drawn in one strip right of the *rightmost* head, so a displaced head cannot be written over by its partner's dot; two that would then land on the same spot split, the lower taking the space below its note.
- **Accidentals.** All of them hang off the *leftmost* head rather than each off its own, and any two whose glyphs would overlap are stacked, the lower further left. Overlap is measured from the glyphs' own bounding boxes: accidentals differ in height as well as width, and a fixed threshold would stack pairs that clear each other and pass pairs that do not.

## The sizer has to hear about it

A head displaced by its own width into a column sized for one is drawn over whatever stands next to it. `SharedStaffMerger` asks for the room a column's collisions need on each side — right into the principal sub-column, left by starting the column further along, which is what keeps a leftward unison off the bar line it would otherwise sit on. Which of two heads gives way depends on how they stem, but that one of them does, and which way it goes, does not, so the sizer can ask before stem directions exist.

## Where this parts company with abcm2ps

abcm2ps displaces a unison the voices cannot share to the *right* when what differs is the accidental, and then draws that accidental on top of the displaced notehead. A unison separates leftward here whatever stopped the voices sharing, and the accidental stays somewhere a reader can see it.

Chord-internal seconds are still nobody's: a chord's own heads have never been displaced against each other, and this changes nothing about that. A chord *does* take part in its column, head by head, against the other voice.

## Verification

- 943 tests pass, including 14 new ones in `SharedStaffCollisionTests` — end to end, source in and SVG out, like the other shared-staff suites.
- Every rule was checked against `abcm2ps -g` on constructed collision cases first, and the emitted geometry matches it (bar the deviation above).
- Staves carrying one voice are byte-identical, as are two staves of well-formed music and a shared staff whose voices never collide: the 16-page `tunebook.abc`, a two-staff tune, and an octave-apart `( … )` staff all diff clean against a build of the base commit — tunebook's only difference is the glyph its `$D` footer timestamp resolves to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G82eK1fXZg7kiBqsKuWezv