### PR TITLE
Fix #80 — floating voices: per-atom staff assignment

### DIFF
--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -1,7 +1,9 @@
 # Extensions
 
-This file documents formatting directives that are implemented in this project but
-which are not part of the ABC v2.2 [standard](https://abcnotation.com/wiki/abc:standard:v2.2).
+This file documents formatting behaviour that is implemented in this project but is
+not dictated by the ABC v2.2 [standard](https://abcnotation.com/wiki/abc:standard:v2.2):
+the `%%ceolkit:*` directives, which the standard does not define at all, and the choices
+CeolKit makes where the standard asks for an outcome but names no rule for reaching it.
 
 ---
 
@@ -474,3 +476,99 @@ to zero:
 
 A voice-level reset of `%%ceolkit:stemalignment 0` restores that voice to the global
 setting.
+
+---
+
+## Floating voices — how the staff is chosen
+
+**Applies to:** a voice marked `*` in `%%score` / `%%staves` (ABC v2.2 §11.1)
+
+### What the standard says, and does not say
+
+§11.1:
+
+> If a single voice surrounded by two voice groups is preceded by a star (`*`), the voice is
+> marked to be floating. This means that the voice won't be printed on its own staff; rather
+> the software should automatically determine, for each note of the voice, whether it should
+> be printed on the preceding staff or on the following staff.
+
+It names the outcome and no rule for reaching it, and it permits software to give up and
+print the whole voice on the preceding staff. CeolKit does the real thing, by the rule
+below. The rule is ours; a different program will make different choices, and both are
+conforming.
+
+### The rule
+
+**A split pitch.** Everything at or above the split goes to the staff above, everything
+below it to the staff below.
+
+- Where the voice states `V: … middle=`, that pitch **is** the split.
+- Otherwise the split is the diatonic midpoint between the bottom line of the staff above
+  and the top line of the staff below, each read through its own clef. For the
+  treble-over-bass grand staff the directive was invented for, that is middle C.
+
+An octave-shifted clef (`clef=treble+8`) does not move the split: the shift changes what the
+staff sounds, not where its notes are written, and this is a question about where the ink
+goes.
+
+**The atom, not the note, is what is assigned.** A beam group, a tuplet, a chord and a tie
+chain each go somewhere whole — a beam drawn half on one staff and half on the other is not
+merely ugly, it is undrawable. Within an atom the majority of the noteheads decides, and a
+tie is broken toward the atom's first note. A grace group goes wherever the note it
+ornaments goes, and contributes no vote of its own. A rest goes where the music around it
+went.
+
+**Hysteresis, so a melody on the split does not flicker.** An atom whose mean pitch lies
+within **one diatonic step** of the split stays on the staff the previous atom went to.
+Without it, a phrase sitting on the split changes staff every time it crosses by a step,
+which is unreadable however defensible each individual choice was. The first atom of a
+voice has nothing to hold it, so its pitch decides.
+
+**Only one neighbour.** A floating voice written at the top or the bottom of a plan — or one
+whose neighbour on one side prints nothing — has no choice left to make. It is printed on
+the staff it does have, throughout, and a `staffPlanNotFullyApplied` warning says so. The
+music is never dropped.
+
+### What this looks like on the page
+
+Each half of a floating voice joins its host staff as an ordinary extra voice, so everything
+a `( … )` shared staff already does applies to it: the two are merged onto a common onset
+grid, their stems are opposed, and unisons between them are pulled apart. The half stems
+away from the staff its music came from — down on the staff above, up on the staff below —
+unless the voice stated its own `V: … stem=`, which is always obeyed.
+
+The host staff's clef, key and name stay those of the voice written at the top of it. A
+floating voice is at the top of neither staff and never supplies them.
+
+A slur that opens on one staff and closes on the other is drawn as two dangling arcs, one to
+each system edge, the way any slur left open across a break is drawn.
+
+### Example
+
+```abc
+X:1
+T:Floating voice
+M:4/4
+L:1/8
+%%score {RH *M| LH}
+V:RH clef=treble
+V:M
+V:LH clef=bass
+K:C
+V:RH
+c2e2g2e2|
+V:M
+G2A2B2c2|
+V:LH
+C,4G,,4|
+```
+
+`M`'s notes sit above middle C, so they are drawn on the right hand's staff. Written an
+octave lower they would be drawn on the left hand's. To move the boundary without moving the
+music, give the voice a middle note of its own:
+
+```abc
+V:M middle=e
+```
+
+which puts the split at E5 and sends the same four notes downstairs.

--- a/Sources/CeolKitModel/VoiceProperties.swift
+++ b/Sources/CeolKitModel/VoiceProperties.swift
@@ -14,7 +14,14 @@ public struct VoiceProperties: Hashable, Sendable {
     public let name: String?             // nm= — printed at start of first system
     public let subname: String?          // snm= — printed at subsequent systems
     public let stemDirection: StemDirection
-    public let middleNote: PitchClass?   // middle= — pitch on the middle staff line; nil = default
+    /// `middle=` — the pitch drawn on the middle staff line, or `nil` where the clef's own
+    /// answer stands.
+    ///
+    /// A pitch rather than a pitch class because the middle line names one octave and not
+    /// another: `middle=B` puts B4 there, which is where a treble clef already has it, and
+    /// `middle=d` puts D5 there, which is a sixth higher.  Without the octave the value
+    /// cannot say which.
+    public let middleNote: Pitch?
 
     public init(
         clef: ClefSpec,
@@ -23,7 +30,7 @@ public struct VoiceProperties: Hashable, Sendable {
         name: String?,
         subname: String?,
         stemDirection: StemDirection,
-        middleNote: PitchClass?
+        middleNote: Pitch?
     ) {
         self.clef = clef
         self.transposition = transposition

--- a/Sources/CeolKitParser/Fields/VoiceFieldParser.swift
+++ b/Sources/CeolKitParser/Fields/VoiceFieldParser.swift
@@ -16,6 +16,7 @@ enum VoiceFieldParser {
         var staffLines = 5
         var transposeSemitones = 0
         var transposeOctave = 0
+        var middleNote: Pitch? = nil
         var diagnostics: [Diagnostic] = []
 
         // key=value pairs
@@ -52,6 +53,21 @@ enum VoiceFieldParser {
                 if let n = lex.scanInt() { transposeOctave = sign * n }
             case "stafflines":
                 if let n = lex.scanInt() { staffLines = n }
+            case "middle", "m":
+                // A note in ABC pitch notation, so `middle=B` and `middle=d` are an octave
+                // apart and both say something the clef alone does not.
+                if let word = lex.scanWord() {
+                    if let pitch = parseMiddle(word) {
+                        middleNote = pitch
+                    } else {
+                        diagnostics.append(Diagnostic(
+                            severity: .warning,
+                            code: .malformedFieldPayload,
+                            message: "V: middle= expects a note, not '\(word)'",
+                            source: source
+                        ))
+                    }
+                }
             default:
                 _ = lex.scanWord()
                 diagnostics.append(Diagnostic(
@@ -71,8 +87,44 @@ enum VoiceFieldParser {
             name: name,
             subname: subname,
             stemDirection: stem,
-            middleNote: nil
+            middleNote: middleNote
         )
         return (id: id, props, diagnostics)
+    }
+
+    /// A `middle=` value read as an ABC pitch: an optional accidental, a letter, and octave
+    /// marks.  `C` is middle C, `c` the octave above it, `,` and `'` shift by an octave each.
+    ///
+    /// The accidental is kept because the value is a pitch and a pitch may be altered, but
+    /// nothing reads it yet: every use so far — the staff line the clef centres on, the split
+    /// a floating voice is assigned by (#80) — is a question about staff position, which is
+    /// diatonic.
+    private static func parseMiddle(_ text: String) -> Pitch? {
+        var rest = Substring(text)
+
+        var alteration = Alteration.natural
+        var accidentals = 0
+        while let ch = rest.first, ch == "^" || ch == "_" || ch == "=" {
+            switch ch {
+            case "^": accidentals += 1
+            case "_": accidentals -= 1
+            default:  accidentals = 0
+            }
+            rest = rest.dropFirst()
+        }
+        if accidentals != 0 { alteration = Alteration(numerator: accidentals, denominator: 1) }
+
+        guard let letter = rest.first, let step = diatonicStep(from: letter) else { return nil }
+        var octave = letter.isLowercase ? 5 : 4
+        rest = rest.dropFirst()
+
+        for ch in rest {
+            switch ch {
+            case ",":  octave -= 1
+            case "'":  octave += 1
+            default:   return nil
+            }
+        }
+        return Pitch(step: step, alteration: alteration, octave: octave)
     }
 }

--- a/Sources/CeolKitSVGRenderer/Layout/FloatingVoiceAssigner.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/FloatingVoiceAssigner.swift
@@ -1,0 +1,157 @@
+import Foundation
+import CeolKitModel
+
+/// Which of its two neighbouring staves each part of a **floating** voice is drawn on
+/// (ABC v2.2 §11.1, `%%score {RH *M| LH}`).
+///
+/// §11.1 says only that "the software should automatically determine, for each note of the
+/// voice, whether it should be printed on the preceding staff or on the following staff".
+/// It states no rule, so this is ours, and `EXTENSIONS.md` says so to the reader.  The three
+/// decisions it is made of:
+///
+/// **A split pitch, not a range.**  Everything at or above the split goes to the staff above,
+/// everything below it to the staff below.  Where the voice states `V:` `middle=` that pitch
+/// *is* the split; otherwise it is the diatonic midpoint between the bottom line of the staff
+/// above and the top line of the staff below — middle C for the treble-over-bass grand staff
+/// the directive was invented for.
+///
+/// **The atom, not the note, is what is assigned.**  A beam, a tuplet, a chord and a tie
+/// chain each go somewhere whole: a beam that spanned two staves is not merely ugly, it is
+/// undrawable — the emitter draws a beam within one staff and has nowhere to put the other
+/// half.  Within an atom the majority of its noteheads decides, and a tie is broken toward
+/// the atom's first note, which is the one a reader arrives at it by.
+///
+/// **Hysteresis, so a melody on the split does not flicker.**  A phrase sitting within
+/// ``hysteresis`` steps of the split would otherwise change staff every time it crossed by
+/// one step, which is unreadable however defensible each individual choice was.  An atom that
+/// close to the split stays where the last one went.
+enum FloatingVoiceAssigner {
+
+    /// Which of a floating voice's two neighbours an atom lands on.
+    enum Staff: Hashable, Sendable {
+        case above
+        case below
+    }
+
+    /// One run of a floating voice's events that has to be drawn on a single staff.
+    ///
+    /// Reduced to the only thing the decision turns on — where its noteheads sit — so that
+    /// the rule can be tested against a table of pitches with no model behind it.
+    struct Atom: Hashable, Sendable {
+        /// ``FloatingVoiceAssigner/diatonic(of:)`` of every notehead in the atom, in written
+        /// order.  Empty where the atom draws no head at all: a rest, a spacer, a bar of
+        /// nothing but directives.
+        let steps: [Int]
+
+        init(steps: [Int]) {
+            self.steps = steps
+        }
+    }
+
+    /// How near the split an atom may sit and still be left where the previous one went, in
+    /// diatonic steps.
+    ///
+    /// One step: near enough that the two staves are equally good, so continuity wins.  Two
+    /// would hold a voice on the wrong staff across a genuine third.
+    static let hysteresis = 1
+
+    /// The staff each of `atoms` is drawn on, parallel to `atoms`.
+    ///
+    /// - Parameters:
+    ///   - atoms: the voice's atoms in playing order.  Order matters: the hysteresis rule
+    ///     reads the choice made for the atom before.
+    ///   - split: the diatonic index at or above which an atom belongs on the staff above.
+    static func assign(atoms: [Atom], split: Int) -> [Staff] {
+        var result: [Staff?] = []
+        var previous: Staff?
+
+        for atom in atoms {
+            guard !atom.steps.isEmpty else {
+                // Nothing to weigh.  A rest goes where the music around it went — and where
+                // nothing has gone yet, it waits for the first atom that decides.
+                result.append(previous)
+                continue
+            }
+            let staff = decide(atom, split: split, previous: previous)
+            result.append(staff)
+            previous = staff
+        }
+
+        // Leading rests, resolved backwards: they belong to the phrase they introduce.
+        let first = result.compactMap { $0 }.first ?? .above
+        return result.map { $0 ?? first }
+    }
+
+    /// The staff one atom lands on, given where the atom before it went.
+    private static func decide(_ atom: Atom, split: Int, previous: Staff?) -> Staff {
+        // Hysteresis is asked first: an atom straddling the split has a majority like any
+        // other, and it is exactly that majority which would flicker.
+        let mean = Double(atom.steps.reduce(0, +)) / Double(atom.steps.count)
+        if let previous, abs(mean - Double(split)) <= Double(hysteresis) { return previous }
+
+        let above = atom.steps.filter { $0 >= split }.count
+        let below = atom.steps.count - above
+        if above != below { return above > below ? .above : .below }
+        return atom.steps[0] >= split ? .above : .below
+    }
+
+    // MARK: - The split
+
+    /// One per diatonic step, rising, with C0 at zero.
+    ///
+    /// Absolute rather than relative to a staff, because the two staves a floating voice sits
+    /// between need not read pitch the same way: the split is a pitch, and the clefs are what
+    /// turn it into a position on either staff.
+    static func diatonic(of pitch: Pitch) -> Int {
+        pitch.octave * 7 + pitch.step.rawValue
+    }
+
+    /// The split for a voice floating between two staves: what it said with `middle=`, or the
+    /// midpoint between the staves where it said nothing.
+    static func split(middle: Pitch?, above: ClefSpec, below: ClefSpec) -> Int {
+        middle.map(diatonic(of:)) ?? defaultSplit(above: above, below: below)
+    }
+
+    /// The diatonic midpoint between the bottom line of the staff above and the top line of
+    /// the staff below.
+    ///
+    /// Treble over bass — the pairing §11.1's own example uses — gives E4 and A3, whose
+    /// midpoint is middle C: the note a pianist's hands already divide at.  Any other pair of
+    /// clefs gets the same reasoning applied to it rather than a special case.
+    ///
+    /// The gap between the two staves is what makes this a *midpoint* rather than a boundary:
+    /// a note in it is equally far from both, and could as well be drawn on either.
+    static func defaultSplit(above: ClefSpec, below: ClefSpec) -> Int {
+        let low  = bottomLine(of: above.clef)
+        let high = bottomLine(of: below.clef) + 8   // five lines, two diatonic steps apart
+        // Rounded down, so an odd gap resolves toward the lower staff — the one whose top
+        // line is nearer the boundary in that case.
+        return (low + high) / 2
+    }
+
+    /// The written pitch on the bottom line of a staff carrying `clef`, as a diatonic index.
+    ///
+    /// `octaveShift` is deliberately not applied: `clef=treble+8` sounds an octave up but is
+    /// *written* exactly where a treble clef is, and this is a question about where the ink
+    /// goes.
+    private static func bottomLine(of clef: Clef) -> Int {
+        // Each staff line is two diatonic steps above the one below it, so a clef is fixed by
+        // the pitch it names and the line it names it on.
+        func line(_ pitch: Int, _ number: Int) -> Int { pitch - 2 * (number - 1) }
+        let g4 = 4 * 7 + 4      // G4, what a G clef names
+        let f3 = 3 * 7 + 3      // F3, what an F clef names
+        let c4 = 4 * 7 + 0      // C4, what a C clef names
+        switch clef {
+        case .treble:                    return line(g4, 2)
+        case .bass:                      return line(f3, 4)
+        case .baritone:                  return line(f3, 3)
+        case .soprano:                   return line(c4, 1)
+        case .mezzoSoprano:              return line(c4, 2)
+        case .alto:                      return line(c4, 3)
+        case .tenor:                     return line(c4, 4)
+        // Neither names a pitch.  A staff that does not say where its notes sit is read the
+        // way an unmarked staff is read, which is as a treble staff.
+        case .percussion, .none:         return line(g4, 2)
+        }
+    }
+}

--- a/Sources/CeolKitSVGRenderer/Layout/FloatingVoiceSplitter.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/FloatingVoiceSplitter.swift
@@ -1,0 +1,250 @@
+import Foundation
+import CeolKitModel
+
+/// Cuts a floating voice (`%%score {RH *M| LH}`, ABC v2.2 §11.1) into the two ordinary
+/// voices the rest of the layout can draw: one tenanting the staff above, one the staff
+/// below.
+///
+/// Nothing downstream of here knows what a floating voice is, and it does not have to.  A
+/// staff already carries more than one voice — that is what a `( … )` group is — so a
+/// floating voice becomes a second (or third) tenant of each of its neighbours, and the
+/// merge onto a common onset grid (#76), the opposed stems (#77) and the displaced unisons
+/// (#79) all apply to it unchanged.
+///
+/// **The silent half keeps the time.**  Where an atom goes to the staff below, the staff
+/// above gets an invisible rest of exactly that duration, so both halves still measure the
+/// bar the same way and every later onset lands where it sounds.  Adjacent displacements
+/// collapse into one rest, and a displacement that runs to the end of a bar gets none at all:
+/// nothing follows it to be pushed out of place, and an unneeded rest would claim a column
+/// the music never asked for.
+///
+/// **Both halves keep the voice's id.**  Selection has already finished with ids by the time
+/// this runs, and the two halves *are* one voice: the diagnostics that name it should name it
+/// once, whichever staff the note in question ended up on.
+enum FloatingVoiceSplitter {
+
+    /// The two voices a floating voice is drawn as.
+    struct Halves {
+        /// Drawn on the staff above, as its lowest part.
+        let above: Voice
+        /// Drawn on the staff below, as its highest part.
+        let below: Voice
+    }
+
+    /// - Parameters:
+    ///   - voice: the floating voice, whole.
+    ///   - split: the diatonic index at or above which music belongs on the staff above; see
+    ///     ``FloatingVoiceAssigner/split(middle:above:below:)``.
+    static func split(_ voice: Voice, at split: Int) -> Halves {
+        let atoms = atoms(of: voice)
+        let staves = FloatingVoiceAssigner.assign(
+            atoms: atoms.map { FloatingVoiceAssigner.Atom(steps: steps(at: $0, in: voice)) },
+            split: split)
+
+        // Per-event, in the shape the rebuild reads it: `placement[stave][measure][event]`.
+        var placement = voice.staves.map { stave in
+            stave.measures.map { [FloatingVoiceAssigner.Staff](repeating: .above,
+                                                               count: $0.events.count) }
+        }
+        for (atom, staff) in zip(atoms, staves) {
+            for at in atom { placement[at.stave][at.measure][at.event] = staff }
+        }
+
+        return Halves(
+            above: half(of: voice, keeping: .above, placement: placement, stem: .down),
+            below: half(of: voice, keeping: .below, placement: placement, stem: .up))
+    }
+
+    // MARK: - Atoms
+
+    /// Where one event of a floating voice is.
+    private struct Location {
+        let stave: Int
+        let measure: Int
+        let event: Int
+    }
+
+    /// The voice cut into the runs that have to stay together, in playing order.
+    ///
+    /// A run stays open across a beam (`.start` through `.end`), a tie chain, and anything
+    /// that attaches forward — a grace group, a directive anchor.  It runs across bar lines
+    /// and across staves where a tie does, which is the only way to keep a tie over a bar
+    /// line on one staff.
+    private static func atoms(of voice: Voice) -> [[Location]] {
+        var atoms: [[Location]] = []
+        var beamOpen = false
+        var tieOpen = false
+        var attachesForward = false
+
+        for (s, stave) in voice.staves.enumerated() {
+            for (m, measure) in stave.measures.enumerated() {
+                for (e, event) in measure.events.enumerated() {
+                    if !(beamOpen || tieOpen || attachesForward) { atoms.append([]) }
+                    atoms[atoms.count - 1].append(Location(stave: s, measure: m, event: e))
+
+                    switch event {
+                    case .grace, .directiveAnchor:
+                        attachesForward = true
+                    case .note(let n):
+                        attachesForward = false
+                        beamOpen = n.beam == .start || n.beam == .middle
+                        tieOpen = tiesForward(n.ties)
+                    case .chord(let c):
+                        attachesForward = false
+                        beamOpen = c.beam == .start || c.beam == .middle
+                        tieOpen = tiesForward(c.ties) || c.notes.contains { tiesForward($0.ties) }
+                    case .tuplet(let t):
+                        // A tuplet is one event and so is drawn whole wherever it lands; only
+                        // a tie out of its last note can hold the run open past it.
+                        attachesForward = false
+                        beamOpen = false
+                        tieOpen = t.events.last.map(tiesForwardOut(of:)) ?? false
+                    case .rest:
+                        attachesForward = false
+                        beamOpen = false
+                        tieOpen = false
+                    case .spacer, .tempoChange:
+                        // Neither ends a beam: `y` is written *inside* beamed runs to space
+                        // them, and an inline `Q:` is not music at all.
+                        attachesForward = false
+                    }
+                }
+            }
+        }
+        return atoms
+    }
+
+    private static func tiesForward(_ state: TieState) -> Bool {
+        state == .startsTie || state == .continuesTie
+    }
+
+    private static func tiesForwardOut(of event: Event) -> Bool {
+        switch event {
+        case .note(let n):  return tiesForward(n.ties)
+        case .chord(let c): return tiesForward(c.ties) || c.notes.contains { tiesForward($0.ties) }
+        default:            return false
+        }
+    }
+
+    /// Every notehead an atom draws, as diatonic indices in written order.
+    ///
+    /// Grace notes contribute none: an ornament decorates whatever staff its principal note
+    /// landed on, and letting a run of high grace notes carry a low note upstairs with them
+    /// would be exactly backwards.
+    private static func steps(at atom: [Location], in voice: Voice) -> [Int] {
+        atom.flatMap { steps(of: voice.staves[$0.stave].measures[$0.measure].events[$0.event]) }
+    }
+
+    private static func steps(of event: Event) -> [Int] {
+        switch event {
+        case .note(let n):   return [FloatingVoiceAssigner.diatonic(of: n.pitch)]
+        case .chord(let c):  return c.notes.map { FloatingVoiceAssigner.diatonic(of: $0.pitch) }
+        case .tuplet(let t): return t.events.flatMap(steps(of:))
+        default:             return []
+        }
+    }
+
+    // MARK: - Rebuilding
+
+    private static func half(
+        of voice: Voice,
+        keeping side: FloatingVoiceAssigner.Staff,
+        placement: [[[FloatingVoiceAssigner.Staff]]],
+        stem: StemDirection
+    ) -> Voice {
+        let staves = voice.staves.enumerated().map { s, stave in
+            Staff(measures: stave.measures.enumerated().map { m, measure in
+                self.measure(measure, keeping: side, placement: placement[s][m])
+            // Both halves keep the stave's `&` overlays (§7.4) whole.  Nothing in the
+            // renderer reads them yet; whatever does will have to split them the same way
+            // the measures are split here.
+            }, overlays: stave.overlays)
+        }
+        let properties = VoiceProperties(
+            clef: voice.properties.clef,
+            transposition: voice.properties.transposition,
+            staffProperties: voice.properties.staffProperties,
+            name: voice.properties.name,
+            subname: voice.properties.subname,
+            // The half is the lowest part of the staff above and the highest of the one
+            // below, so the opposition #77 draws is the same on both: stems point away from
+            // the staff the music came from.  A voice that stated `stem=` keeps its word.
+            stemDirection: voice.properties.stemDirection == .auto
+                ? stem : voice.properties.stemDirection,
+            middleNote: voice.properties.middleNote)
+        return Voice(id: voice.id, properties: properties, key: voice.key,
+                     unitNoteLength: voice.unitNoteLength, staves: staves,
+                     directives: voice.directives, source: voice.source)
+    }
+
+    private static func measure(
+        _ measure: Measure,
+        keeping side: FloatingVoiceAssigner.Staff,
+        placement: [FloatingVoiceAssigner.Staff]
+    ) -> Measure {
+        var events: [Event] = []
+        var displaced: Fraction?
+
+        for (index, event) in measure.events.enumerated() {
+            guard placement[index] == side else {
+                if let duration = sounding(event) {
+                    displaced = displaced.map { plus($0, duration) } ?? duration
+                }
+                continue
+            }
+            if let duration = displaced {
+                events.append(.rest(Rest(kind: .invisible, duration: duration,
+                                         decorations: [], source: .emptySourceRange)))
+                displaced = nil
+            }
+            events.append(event)
+        }
+        // Anything still displaced runs to the bar line, and silence at the end of a bar
+        // moves nothing.
+        return Measure(openingBar: measure.openingBar, events: events,
+                       closingBar: measure.closingBar, endingNumber: measure.endingNumber,
+                       source: measure.source, meter: measure.meter)
+    }
+
+    // MARK: - Durations
+
+    /// How long `event` sounds, in unit note lengths, or `nil` where it takes no time.
+    ///
+    /// Summed for tuplets exactly as ``Rational/quarters(of:unitNoteLength:)`` sums them, so
+    /// the rest that stands in for a displaced tuplet and the tuplet itself put the following
+    /// onset in the same place on both staves.  The voice's `L:` never enters into it: both
+    /// halves are the same voice and read every duration against the same unit.
+    private static func sounding(_ event: Event) -> Fraction? {
+        switch event {
+        case .note(let n):  return n.duration
+        case .rest(let r):  return r.duration
+        case .chord(let c): return c.duration
+        case .tuplet(let t):
+            let written = t.events.reduce(Fraction(numerator: 0, denominator: 1)) { total, inner in
+                sounding(inner).map { plus(total, $0) } ?? total
+            }
+            return times(written, Fraction(numerator: t.q, denominator: t.p))
+        default:
+            return nil
+        }
+    }
+
+    private static func plus(_ lhs: Fraction, _ rhs: Fraction) -> Fraction {
+        reduced(lhs.numerator * rhs.denominator + rhs.numerator * lhs.denominator,
+                lhs.denominator * rhs.denominator)
+    }
+
+    private static func times(_ lhs: Fraction, _ rhs: Fraction) -> Fraction {
+        reduced(lhs.numerator * rhs.numerator, lhs.denominator * rhs.denominator)
+    }
+
+    private static func reduced(_ numerator: Int, _ denominator: Int) -> Fraction {
+        let sign = denominator < 0 ? -1 : 1
+        let n = numerator * sign
+        let d = denominator * sign
+        var a = abs(n), b = d
+        while b != 0 { (a, b) = (b, a % b) }
+        guard a != 0 else { return Fraction(numerator: 0, denominator: 1) }
+        return Fraction(numerator: n / a, denominator: d / a)
+    }
+}

--- a/Sources/CeolKitSVGRenderer/Layout/VoiceSelector.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VoiceSelector.swift
@@ -9,12 +9,14 @@ import CeolKitModel
 ///
 /// **A `( … )` group is one staff.**  Its voices come back as several entries of ``voices``
 /// mapped by ``Selection/staffOfVoice`` onto a single printed staff, which the driver hands
-/// to ``SharedStaffMerger`` to lay out on a common onset grid.  A floating `*V` still gets a
-/// staff of its own at the position it was written, and says so in a
-/// `staffPlanNotFullyApplied` diagnostic: that is strictly better than ignoring the directive
-/// — the right voices print in the right order, and only the vertical placement is missing —
-/// and it keeps every voice the plan names on the page, which silently dropping the ones this
-/// pass cannot place would not.
+/// to ``SharedStaffMerger`` to lay out on a common onset grid.
+///
+/// **A floating `*V` is two voices by the time this pass is done.**  It has no staff of its
+/// own; ``FloatingVoiceSplitter`` cuts it along the split ``FloatingVoiceAssigner`` decides
+/// and hands each half to the staff on its side, as that staff's last tenant.  Everything
+/// downstream sees two ordinary voices sharing two ordinary staves.  Where the plan leaves it
+/// only one neighbour there is no split to make, and it becomes an ordinary tenant of that
+/// staff with a `staffPlanNotFullyApplied` warning to say so.
 ///
 /// **It also translates the plan's grouping into printed staff indices.**  `StaffPlanLayout`
 /// counts staves in the *plan*, and a dropped voice or a floating one means those are not the
@@ -73,15 +75,13 @@ enum VoiceSelector {
         let layout = plan.layout
         let byId = Dictionary(voices.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
 
-        var printed: [Voice] = []
-        var staffOfVoice: [Int] = []
+        // Pass one: which of the plan's voices print at all.  A floating voice's neighbours
+        // are staves of the *plan*, and a plan staff only becomes a printed one once
+        // something written on it survives — so the two numberings are resolved separately,
+        // and in that order.
+        var accepted: [(voice: Voice, placement: Placement)] = []
         var seen: Set<VoiceId> = []
-        // The printed staff each staff of the plan turned into.  Absent for a plan staff whose
-        // every voice was dropped; shared by every voice of a `( … )` group, which is what
-        // makes the group one staff.
-        var staffForPlanStaff: [Int: Int] = [:]
-        var nextStaff = 0
-        for (id, planStaff) in order(of: layout) {
+        for (id, placement) in order(of: layout) {
             guard seen.insert(id).inserted else {
                 diagnostics.append(Diagnostic(
                     severity: .warning, code: .staffPlanVoiceRepeated,
@@ -101,18 +101,73 @@ enum VoiceSelector {
             // the tune body, and this one does not appear there.  Not worth a diagnostic —
             // the plan is right and the body simply has nothing to say.
             guard !voice.isEmpty else { continue }
-            // A floating voice belongs to no staff of the plan, so it takes one of its own.
-            let staff: Int
-            if let planStaff, let existing = staffForPlanStaff[planStaff] {
-                staff = existing
-            } else {
-                staff = nextStaff
-                nextStaff += 1
-                if let planStaff { staffForPlanStaff[planStaff] = staff }
-            }
-            staffOfVoice.append(staff)
-            printed.append(voice)
+            accepted.append((voice, placement))
         }
+
+        // Pass two: the printed staff each staff of the plan turned into.  Absent for a plan
+        // staff whose every voice was dropped; shared by every voice of a `( … )` group,
+        // which is what makes the group one staff.
+        var staffForPlanStaff: [Int: Int] = [:]
+        var staffed: [[Voice]] = []
+        for (voice, placement) in accepted {
+            guard case .staff(let planStaff) = placement else { continue }
+            if let staff = staffForPlanStaff[planStaff] {
+                staffed[staff].append(voice)
+            } else {
+                staffForPlanStaff[planStaff] = staffed.count
+                staffed.append([voice])
+            }
+        }
+
+        // Pass three: each floating voice, cut in two and handed to the staves on either side
+        // of it (#80).  A half joins its staff *last*: the clef, key and name a staff draws
+        // are those of the voice written at the top of it, and a voice that floats between
+        // two staves is at the top of neither.
+        for (voice, placement) in accepted {
+            guard case .floating(let abovePlan, let belowPlan) = placement else { continue }
+            let above = abovePlan.flatMap { staffForPlanStaff[$0] }
+            let below = belowPlan.flatMap { staffForPlanStaff[$0] }
+            switch (above, below) {
+            case (let above?, let below?):
+                let split = FloatingVoiceAssigner.split(
+                    middle: voice.properties.middleNote,
+                    above: staffed[above][0].properties.clef,
+                    below: staffed[below][0].properties.clef)
+                let halves = FloatingVoiceSplitter.split(voice, at: split)
+                staffed[above].append(halves.above)
+                staffed[below].append(halves.below)
+
+            case (let only?, nil), (nil, let only?):
+                // §11.1 floats a voice *between* two groups, and this one has one neighbour:
+                // either it was written at an end of the plan, or the staff on its other side
+                // printed nothing.  There is no choice left to make, so it becomes an
+                // ordinary tenant of the staff it does have — dropping the music instead
+                // would lose what the author wrote to save a decision nobody needs.
+                diagnostics.append(Diagnostic(
+                    severity: .warning, code: .staffPlanNotFullyApplied,
+                    message: "voice \(label(voice.id)) floats, but the plan leaves it only one "
+                           + "neighbouring staff; it is printed on that staff throughout",
+                    source: plan.source))
+                staffed[only].append(voice)
+
+            case (nil, nil):
+                // No neighbour at all — `%%score {*M}`, or a plan whose other staves all
+                // dropped out.  It gets a staff of its own, at the bottom, because there is
+                // nothing left for it to be positioned relative to.
+                diagnostics.append(Diagnostic(
+                    severity: .warning, code: .staffPlanNotFullyApplied,
+                    message: "voice \(label(voice.id)) floats, but the plan gives it no "
+                           + "neighbouring staff at all; it is printed on a staff of its own",
+                    source: plan.source))
+                staffed.append([voice])
+            }
+        }
+
+        let printed = staffed.flatMap { $0 }
+        let staffOfVoice = staffed.enumerated().flatMap {
+            [Int](repeating: $0.offset, count: $0.element.count)
+        }
+
         // Printed staff indices contributed by each staff of the plan: at most one now, and
         // none where every voice of a plan staff was dropped.
         let printedByPlanStaff = layout.staves.indices.map { staffForPlanStaff[$0].map { [$0] } ?? [] }
@@ -128,28 +183,37 @@ enum VoiceSelector {
         }
 
         diagnostics += omissions(from: printable, namedBy: layout, plan: plan)
-        diagnostics += approximations(of: layout, printedBy: printed, plan: plan)
         return Selection(voices: printed, staffOfVoice: staffOfVoice,
                          grouping: grouping(of: layout, printedBy: printedByPlanStaff))
     }
 
     // MARK: - Order
 
-    /// The plan's voices, top to bottom, one entry per staff this pass will draw.
+    /// Where the plan puts one voice.
+    private enum Placement {
+        /// An index into ``StaffPlanLayout/staves``.
+        case staff(Int)
+        /// A `*V`, with the plan staves on either side of it — either `nil` where the plan
+        /// has none there.
+        case floating(above: Int?, below: Int?)
+    }
+
+    /// The plan's voices, top to bottom, in the order they were written.
     ///
-    /// A floating voice has no staff in the layout, so it is placed after the staff it floats
+    /// A floating voice has no staff in the layout, so it appears after the staff it floats
     /// below — or first, where the plan gives it nothing above.  That is where the author
-    /// wrote it, and it is the position `#80` will start from when it assigns such a voice
-    /// per note.
-    ///
-    /// The staff index is the plan's, and `nil` for a floating voice — it belongs to no
-    /// staff of the plan, so no span or joint is stated over it.
-    private static func order(of layout: StaffPlanLayout) -> [(id: VoiceId, planStaff: Int?)] {
+    /// wrote it, and it is where the reader of a diagnostic about it will look.
+    private static func order(of layout: StaffPlanLayout) -> [(id: VoiceId, placement: Placement)] {
         let floatingByStaffAbove = Dictionary(grouping: layout.floating, by: \.above)
-        var ordered = (floatingByStaffAbove[nil] ?? []).map { (id: $0.id, planStaff: Int?.none) }
+        func floats(below staff: Int?) -> [(id: VoiceId, placement: Placement)] {
+            (floatingByStaffAbove[staff] ?? []).map {
+                (id: $0.id, placement: Placement.floating(above: $0.above, below: $0.below))
+            }
+        }
+        var ordered = floats(below: nil)
         for (index, staff) in layout.staves.enumerated() {
-            ordered += staff.map { (id: $0, planStaff: Int?.some(index)) }
-            ordered += (floatingByStaffAbove[index] ?? []).map { (id: $0.id, planStaff: Int?.none) }
+            ordered += staff.map { (id: $0, placement: Placement.staff(index)) }
+            ordered += floats(below: index)
         }
         return ordered
     }
@@ -203,26 +267,6 @@ enum VoiceSelector {
                        + "the staff plan, so it is not printed",
                 source: plan.source)
         }
-    }
-
-    /// The parts of the plan this pass draws differently from what it asks for.
-    private static func approximations(
-        of layout: StaffPlanLayout,
-        printedBy printed: [Voice],
-        plan: StaffPlan
-    ) -> [Diagnostic] {
-        let ids = Set(printed.map(\.id))
-        var result: [Diagnostic] = []
-
-        for floating in layout.floating where ids.contains(floating.id) {
-            result.append(Diagnostic(
-                severity: .info, code: .staffPlanNotFullyApplied,
-                message: "voice \(label(floating.id)) floats between staves in the plan; "
-                       + "it is drawn on a staff of its own for now",
-                source: plan.source))
-        }
-
-        return result
     }
 
     // MARK: - Naming

--- a/Tests/CeolKitParserTests/VoiceMiddleFieldTests.swift
+++ b/Tests/CeolKitParserTests/VoiceMiddleFieldTests.swift
@@ -1,0 +1,106 @@
+import Testing
+import CeolKitModel
+@testable import CeolKitParser
+
+/// Issue #80: `V: … middle=` names the pitch on the middle staff line.
+///
+/// The parser used to drop it into the unknown-key branch, so `VoiceProperties.middleNote`
+/// was modelled and never set.  It is read now — as the split a floating voice is assigned
+/// by — so the value has to survive the field, octave and all.
+@Suite("V: middle=")
+struct VoiceMiddleFieldTests {
+
+    private func middle(_ header: String) -> Pitch? {
+        properties(header).middleNote
+    }
+
+    private func properties(_ header: String) -> VoiceProperties {
+        let tune = CeolKitParser().parse("""
+        X:1
+        L:1/4
+        \(header)
+        K:C
+        V:1
+        CDEF|
+        """, options: .default).score.tunes[0]
+        return tune.voices[0].properties
+    }
+
+    private func diagnostics(_ header: String) -> [Diagnostic] {
+        CeolKitParser().parse("""
+        X:1
+        L:1/4
+        \(header)
+        K:C
+        V:1
+        CDEF|
+        """, options: .default).score.diagnostics
+    }
+
+    private func pitch(_ step: DiatonicStep, _ octave: Int,
+                       _ alteration: Alteration = .natural) -> Pitch {
+        Pitch(step: step, alteration: alteration, octave: octave)
+    }
+
+    @Test("A voice that says nothing has no middle note")
+    func absent() {
+        #expect(middle("V:1 clef=treble") == nil)
+    }
+
+    @Test("An upper-case letter is the octave from middle C up")
+    func upperCaseIsOctaveFour() {
+        #expect(middle("V:1 middle=B") == pitch(.b, 4))
+        #expect(middle("V:1 middle=C") == pitch(.c, 4))
+    }
+
+    @Test("A lower-case letter is the octave above that")
+    func lowerCaseIsOctaveFive() {
+        #expect(middle("V:1 middle=d") == pitch(.d, 5))
+    }
+
+    @Test("Octave marks shift by an octave each, in either direction")
+    func octaveMarks() {
+        #expect(middle("V:1 middle=C,") == pitch(.c, 3))
+        #expect(middle("V:1 middle=C,,") == pitch(.c, 2))
+        #expect(middle("V:1 middle=c'") == pitch(.c, 6))
+    }
+
+    @Test("An accidental is kept, because the value is a pitch")
+    func accidentals() {
+        #expect(middle("V:1 middle=^F") == pitch(.f, 4, .sharp))
+        #expect(middle("V:1 middle=_B,") == pitch(.b, 3, .flat))
+        #expect(middle("V:1 middle==C") == pitch(.c, 4))
+    }
+
+    @Test("`m=` is the same key spelled short")
+    func abbreviation() {
+        #expect(middle("V:1 m=d") == pitch(.d, 5))
+    }
+
+    @Test("It sits alongside the other keys without disturbing them")
+    func alongsideOtherKeys() {
+        let props = properties("V:1 clef=bass middle=D name=\"Bass\" stem=down")
+        #expect(props.middleNote == pitch(.d, 4))
+        #expect(props.clef.clef == .bass)
+        #expect(props.name == "Bass")
+        #expect(props.stemDirection == .down)
+    }
+
+    @Test("It is no longer reported as an unknown key")
+    func noLongerUnknown() {
+        #expect(!diagnostics("V:1 middle=B").contains { $0.code == .unknownKey })
+    }
+
+    @Test("A value that is not a note is a warning, and the rest of the field stands")
+    func malformedValueWarns() {
+        let props = properties("V:1 middle=xyzzy clef=bass")
+        #expect(props.middleNote == nil)
+        #expect(props.clef.clef == .bass)
+
+        let warnings = diagnostics("V:1 middle=xyzzy").filter {
+            $0.code == .malformedFieldPayload
+        }
+        #expect(warnings.count == 1)
+        #expect(warnings.first?.severity == .warning)
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/FloatingVoiceTests.swift
+++ b/Tests/CeolKitSVGRendererTests/FloatingVoiceTests.swift
@@ -1,0 +1,340 @@
+import Testing
+import CeolKitModel
+import CeolKitParser
+import CeolKitSVGGeometry
+@testable import CeolKitSVGRenderer
+
+/// Issue #80: a voice written `*V` between two groups is printed on whichever of the two
+/// staves suits each part of it (ABC v2.2 §11.1).
+///
+/// §11.1 states no rule for choosing, so the rule is ours and `EXTENSIONS.md` documents it.
+/// These tests pin the three decisions it is made of — the split, the atom, the hysteresis —
+/// against the table the assigner is written as, and then check that the split survives the
+/// journey through selection to the page.
+@Suite("Floating Voices")
+struct FloatingVoiceTests {
+
+    // MARK: - Helpers
+
+    private typealias Assigner = FloatingVoiceAssigner
+    private typealias Atom = FloatingVoiceAssigner.Atom
+
+    /// The diatonic index of an ABC pitch name, written the way `middle=` writes it.
+    private func step(_ name: String) -> Int {
+        var octave = name.first!.isLowercase ? 5 : 4
+        for ch in name.dropFirst() { octave += ch == "," ? -1 : 1 }
+        let letters: [Character: DiatonicStep] = ["c": .c, "d": .d, "e": .e, "f": .f,
+                                                  "g": .g, "a": .a, "b": .b]
+        let letter = letters[Character(name.first!.lowercased())]!
+        return Assigner.diatonic(of: Pitch(step: letter, alteration: .natural, octave: octave))
+    }
+
+    private func atom(_ names: String...) -> Atom {
+        Atom(steps: names.map(step))
+    }
+
+    private func clef(_ clef: Clef) -> ClefSpec {
+        ClefSpec(clef: clef, octaveShift: 0)
+    }
+
+    private func select(_ abc: String)
+        -> (selection: VoiceSelector.Selection, diagnostics: [Diagnostic]) {
+        let tune = CeolKitParser().parse(abc, options: .default).score.tunes[0]
+        var diagnostics: [Diagnostic] = []
+        let plan = tune.staffPlans.last { $0.effectiveFromStave == 0 }?.plan
+        return (VoiceSelector.select(from: tune.voices, plan: plan, into: &diagnostics),
+                diagnostics)
+    }
+
+    /// The pitches each printed staff of `abc` draws, top to bottom, as diatonic indices.
+    ///
+    /// Read off the selection rather than the page: the geometry says where the noteheads
+    /// are, but only this says which staff carries which note, and that is the whole question.
+    private func staffPitches(_ abc: String) -> [[Int]] {
+        let selection = select(abc).selection
+        return selection.voicesByStaff.map { members in
+            members.flatMap { index in
+                selection.voices[index].staves.flatMap(\.measures).flatMap(\.events)
+                    .flatMap(pitches(of:))
+            }
+        }
+    }
+
+    private func pitches(of event: Event) -> [Int] {
+        switch event {
+        case .note(let n):   return [Assigner.diatonic(of: n.pitch)]
+        case .chord(let c):  return c.notes.map { Assigner.diatonic(of: $0.pitch) }
+        case .tuplet(let t): return t.events.flatMap(pitches(of:))
+        default:             return []
+        }
+    }
+
+    /// A grand staff with `M` floating between the hands.
+    private func grandStaff(_ melody: String, middle: String = "", plan: String = "{RH *M| LH}")
+        -> String {
+        """
+        X:1
+        L:1/8
+        %%score \(plan)
+        V:RH clef=treble
+        V:M\(middle.isEmpty ? "" : " middle=\(middle)")
+        V:LH clef=bass
+        K:C
+        V:RH
+        c8|
+        V:M
+        \(melody)
+        V:LH
+        C8|
+        """
+    }
+
+    // MARK: - The split
+
+    @Test("Treble over bass splits at middle C")
+    func defaultSplitOfAGrandStaff() {
+        #expect(Assigner.defaultSplit(above: clef(.treble), below: clef(.bass)) == step("C"))
+    }
+
+    @Test("Other clef pairs get the same reasoning, not a special case")
+    func defaultSplitOfOtherClefs() {
+        // Alto bottom line F3, tenor top line E4: the midpoint is B3, a fourth below the
+        // treble-over-bass answer, because both staves sit lower.
+        #expect(Assigner.defaultSplit(above: clef(.alto), below: clef(.tenor)) == step("B,"))
+        // Two treble staves: bottom line E4 against top line F5, midpoint B4.
+        #expect(Assigner.defaultSplit(above: clef(.treble), below: clef(.treble)) == step("B"))
+    }
+
+    @Test("`middle=` is the split where the voice states one")
+    func middleOverridesTheDefault() {
+        let split = Assigner.split(
+            middle: Pitch(step: .b, alteration: .natural, octave: 4),
+            above: clef(.treble), below: clef(.bass))
+        #expect(split == step("B"))
+    }
+
+    @Test("An octave-shifted clef splits where it is written, not where it sounds")
+    func octaveShiftDoesNotMoveTheSplit() {
+        let plain   = Assigner.defaultSplit(above: clef(.treble), below: clef(.bass))
+        let shifted = Assigner.defaultSplit(
+            above: ClefSpec(clef: .treble, octaveShift: 8),
+            below: ClefSpec(clef: .bass, octaveShift: -8))
+        #expect(shifted == plain)
+    }
+
+    // MARK: - The rule, as a table
+
+    @Test("A single note goes to the staff its pitch falls on")
+    func singleNotes() {
+        let split = step("C")
+        #expect(Assigner.assign(atoms: [atom("g")], split: split) == [.above])
+        #expect(Assigner.assign(atoms: [atom("G,")], split: split) == [.below])
+        // The split itself belongs to the staff above: it is the lowest pitch that staff owns.
+        #expect(Assigner.assign(atoms: [atom("C")], split: split) == [.above])
+    }
+
+    @Test("An atom goes where the majority of its noteheads go")
+    func majorityWithinAnAtom() {
+        let split = step("C")
+        // Three of four above the split; the low note comes along rather than break the beam.
+        #expect(Assigner.assign(atoms: [atom("e", "g", "G,", "c")], split: split) == [.above])
+        #expect(Assigner.assign(atoms: [atom("E,", "G,", "e", "C,")], split: split) == [.below])
+    }
+
+    @Test("A tie within an atom is broken toward its first note")
+    func tiesGoToTheFirstNote() {
+        let split = step("C")
+        #expect(Assigner.assign(atoms: [atom("e", "G,")], split: split) == [.above])
+        #expect(Assigner.assign(atoms: [atom("G,", "e")], split: split) == [.below])
+    }
+
+    @Test("A melody hovering at the split does not alternate staves")
+    func hysteresisHoldsAMelodyStill() {
+        let split = step("C")
+        // B3 and C4 lie either side of the split by one step each.  Without hysteresis this
+        // is .below, .above, .below, .above; with it the phrase stays where it started.
+        let atoms = [atom("G,"), atom("B,"), atom("C"), atom("B,"), atom("C")]
+        #expect(Assigner.assign(atoms: atoms, split: split)
+                == [.below, .below, .below, .below, .below])
+    }
+
+    @Test("Hysteresis yields to a real departure from the split")
+    func hysteresisYieldsToAClearMove() {
+        let split = step("C")
+        let atoms = [atom("G,"), atom("B,"), atom("g"), atom("C")]
+        #expect(Assigner.assign(atoms: atoms, split: split)
+                == [.below, .below, .above, .above])
+    }
+
+    @Test("Hysteresis is measured in diatonic steps from the split")
+    func hysteresisThreshold() {
+        let split = step("C")
+        // One step above the split holds; two steps above does not.
+        #expect(Assigner.assign(atoms: [atom("G,"), atom("D")], split: split)
+                == [.below, .below])
+        #expect(Assigner.assign(atoms: [atom("G,"), atom("E")], split: split)
+                == [.below, .above])
+        #expect(Assigner.hysteresis == 1)
+    }
+
+    @Test("The first atom has nothing to hold it, so it goes where its pitch says")
+    func firstAtomIgnoresHysteresis() {
+        #expect(Assigner.assign(atoms: [atom("B,")], split: step("C")) == [.below])
+    }
+
+    @Test("An atom that draws no notehead follows the music around it")
+    func restsFollowTheMusic() {
+        let split = step("C")
+        // A leading rest waits for the phrase it introduces; a rest inside one stays put.
+        let atoms = [Atom(steps: []), atom("G,"), Atom(steps: []), atom("g")]
+        #expect(Assigner.assign(atoms: atoms, split: split)
+                == [.below, .below, .below, .above])
+    }
+
+    @Test("A voice of nothing but rests is assigned somewhere rather than trapping")
+    func nothingButRests() {
+        #expect(Assigner.assign(atoms: [Atom(steps: []), Atom(steps: [])], split: step("C"))
+                == [.above, .above])
+        #expect(Assigner.assign(atoms: [], split: step("C")).isEmpty)
+    }
+
+    // MARK: - Splitting the voice
+
+    @Test("`%%score {RH *M| LH}` places each atom of M on RH or LH by pitch")
+    func atomsLandOnTheStaffTheirPitchChooses() {
+        let staves = staffPitches(grandStaff("c2 G,2 e2 E,2|"))
+        #expect(staves.count == 2)
+        #expect(staves[0] == [step("c"), step("c"), step("e")])
+        #expect(staves[1] == [step("C"), step("G,"), step("E,")])
+    }
+
+    @Test("A beamed run never splits across staves")
+    func beamedRunsStayWhole() {
+        // `C,EGc` beams as one group and straddles the split: C3 is a seventh below it and
+        // the other three are above.  The majority carries the low note upstairs with them,
+        // because a beam drawn half on each staff is not something the emitter can draw.
+        let staves = staffPitches(grandStaff("C,EGc c'4|"))
+        #expect(staves[0] == [step("c"), step("C,"), step("E"), step("G"), step("c"), step("c'")])
+        #expect(staves[1] == [step("C")])
+    }
+
+    @Test("A tie over a bar line keeps both its notes on one staff")
+    func tiedNotesStayWhole() {
+        // The tie opens in one bar and closes in the next, which is the only way the two
+        // halves of it could be handed to different staves.
+        let selection = select(grandStaff("e6 D-|D E,2 C,4|")).selection
+        let upper = selection.voices[selection.voicesByStaff[0].last!]
+        let lower = selection.voices[selection.voicesByStaff[1].last!]
+        func ds(_ voice: Voice) -> Int {
+            voice.staves.flatMap(\.measures).flatMap(\.events).flatMap(pitches(of:))
+                .filter { $0 == step("D") }.count
+        }
+        // Both D's on one staff, and neither on the other.
+        #expect([ds(upper), ds(lower)].contains(2))
+        #expect([ds(upper), ds(lower)].contains(0))
+    }
+
+    @Test("A chord is one atom, decided by the majority of its noteheads")
+    func chordsAreOneAtom() {
+        // G3 is below the split and the other two are well above it; the chord cannot be
+        // drawn across two staves, so it goes where its majority goes, whole.
+        let staves = staffPitches(grandStaff("[G,ce]8|"))
+        #expect(staves[0] == [step("c"), step("G,"), step("c"), step("e")])
+        #expect(staves[1] == [step("C")])
+    }
+
+    @Test("`V:M middle=B` moves the split, verifiably")
+    func middleMovesTheSplit() {
+        // With the default split at middle C, `c` is the upper staff's.  `middle=e` puts the
+        // split above it, and the same note goes downstairs instead.
+        #expect(staffPitches(grandStaff("c8|"))[0].contains(step("c")))
+        #expect(staffPitches(grandStaff("c8|", middle: "e"))[1].contains(step("c")))
+        // And it reaches the model on the way, so nothing else can be doing the work.
+        let tune = CeolKitParser().parse(grandStaff("c8|", middle: "e"), options: .default)
+            .score.tunes[0]
+        let melody = tune.voices.first { $0.id == .named("M") }
+        #expect(melody?.properties.middleNote == Pitch(step: .e, alteration: .natural, octave: 5))
+    }
+
+    @Test("The silent half keeps the time, so both halves measure the bar alike")
+    func displacedMusicIsPaddedWithInvisibleRests() {
+        let selection = select(grandStaff("C,2 c2 C,4|")).selection
+        // Staff 0's tenants are RH and the upper half of M; the half's own bar is the one to
+        // look at.  Only what sounds is examined: the whitespace spacers the source is
+        // written with take no time and claim no width.
+        let half = selection.voices[selection.voicesByStaff[0].last!]
+        let sounding = half.staves[0].measures[0].events.filter {
+            if case .spacer = $0 { return false }
+            return true
+        }
+        // A rest for the first two eighths, then the note that stayed.  The last four
+        // eighths went downstairs and get no rest at all: silence at the end of a bar moves
+        // nothing that follows it.
+        #expect(sounding.count == 2)
+        guard case .rest(let rest) = sounding.first else {
+            Issue.record("expected the displaced music to be stood in for by a rest")
+            return
+        }
+        #expect(rest.kind == .invisible)
+        #expect(rest.duration == Fraction(numerator: 2, denominator: 1))
+        if case .note = sounding.last {} else { Issue.record("expected the kept note to follow") }
+    }
+
+    @Test("Each half stems away from the staff its music came from")
+    func halvesOpposeTheirHosts() {
+        let selection = select(grandStaff("c4 C,4|")).selection
+        let upper = selection.voices[selection.voicesByStaff[0].last!]
+        let lower = selection.voices[selection.voicesByStaff[1].last!]
+        #expect(upper.properties.stemDirection == .down)
+        #expect(lower.properties.stemDirection == .up)
+    }
+
+    @Test("A voice that stated `stem=` keeps its word on both staves")
+    func statedStemDirectionSurvivesTheSplit() {
+        let abc = grandStaff("c4 C,4|").replacing("V:M\n", with: "V:M stem=up\n")
+        let selection = select(abc).selection
+        let upper = selection.voices[selection.voicesByStaff[0].last!]
+        let lower = selection.voices[selection.voicesByStaff[1].last!]
+        #expect(upper.properties.stemDirection == .up)
+        #expect(lower.properties.stemDirection == .up)
+    }
+
+    // MARK: - End to end
+
+    @Test("A grand staff with a floating voice draws two staves, and every note of it")
+    func rendersTwoStaves() throws {
+        let score = CeolKitParser().parse(grandStaff("c2 G,2 e2 E,2|"), options: .default).score
+        var diagnostics: [Diagnostic] = []
+        let pages = try SVGGeometry.pages(from: SVGRenderer().render(score,
+                                                                    diagnostics: &diagnostics))
+        #expect(pages.flatMap(\.systems).count == 2)
+        #expect(diagnostics.filter { $0.code == .staffPlanNotFullyApplied }.isEmpty)
+    }
+
+    @Test("A floating voice with no neighbour at all still gets printed")
+    func noNeighbourStillPrints() {
+        let result = select("""
+        X:1
+        L:1/4
+        %%score {*M}
+        V:M
+        K:C
+        V:M
+        CDEF|
+        """)
+        #expect(result.selection.voices.map(\.id) == [.named("M")])
+        #expect(result.selection.staffCount == 1)
+
+        let warnings = result.diagnostics.filter { $0.code == .staffPlanNotFullyApplied }
+        #expect(warnings.count == 1)
+        #expect(warnings.first?.message.contains("no neighbouring staff at all") == true)
+    }
+
+    @Test("A floating voice with only one neighbour prints on it rather than vanishing")
+    func oneNeighbourStillPrints() {
+        // `*M` at the bottom of the plan has a staff above it and none below.
+        let staves = staffPitches(grandStaff("c4 C,4|", plan: "{RH LH| *M}"))
+        #expect(staves.count == 2)
+        #expect(staves[1] == [step("C"), step("c"), step("C,")])
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/StaffPlanSelectionTests.swift
+++ b/Tests/CeolKitSVGRendererTests/StaffPlanSelectionTests.swift
@@ -121,14 +121,31 @@ struct StaffPlanSelectionTests {
         #expect(codes(result.diagnostics, .staffPlanNotFullyApplied).isEmpty)
     }
 
-    @Test("A floating voice keeps the position it was written at, and says so")
-    func floatingVoiceKeepsItsPosition() {
+    @Test("A floating voice is split between the staves on either side of it")
+    func floatingVoiceIsSplitBetweenItsNeighbours() {
         let result = select(threeVoices("%%score {1 *2| 3}"))
-        #expect(result.voices == [.named("1"), .named("2"), .named("3")])
+        // Two staves, and voice 2 twice: once as the lowest part of staff 0 and once as the
+        // highest of staff 1 (#80).  Both halves keep the id, because both are voice 2.
+        #expect(result.voices == [.named("1"), .named("2"), .named("3"), .named("2")])
+        #expect(result.selection.staffOfVoice == [0, 0, 1, 1])
+        #expect(result.selection.staffCount == 2)
+        // Nothing is approximated any more: the plan is applied as written.
+        #expect(codes(result.diagnostics, .staffPlanNotFullyApplied).isEmpty)
+    }
 
-        let notes = codes(result.diagnostics, .staffPlanNotFullyApplied)
-        #expect(notes.count == 1)
-        #expect(notes.first?.message.contains("floats between staves") == true)
+    @Test("A floating voice with only one neighbour prints on it, and warns")
+    func floatingVoiceWithOneNeighbour() {
+        // `*1` is at the top of the plan, so it has a staff below it and none above.
+        let result = select(threeVoices("%%score {*1 2| 3}"))
+        // It joins staff 0 as its last tenant, so the clef and name that staff draws stay
+        // voice 2's — the voice actually written at the top of it.
+        #expect(result.voices == [.named("2"), .named("1"), .named("3")])
+        #expect(result.selection.staffOfVoice == [0, 0, 1])
+
+        let warnings = codes(result.diagnostics, .staffPlanNotFullyApplied)
+        #expect(warnings.count == 1)
+        #expect(warnings.first?.severity == .warning)
+        #expect(warnings.first?.message.contains("only one") == true)
     }
 
     @Test("A body plan takes effect from its own stave, without complaint")

--- a/Tests/CeolKitSVGRendererTests/StaffSpanThreadingTests.swift
+++ b/Tests/CeolKitSVGRendererTests/StaffSpanThreadingTests.swift
@@ -92,13 +92,14 @@ struct StaffSpanThreadingTests {
         #expect(grouping.spans == [StaffGrouping.Span(bracket: .bracket, staves: 0...1, depth: 0)])
     }
 
-    @Test("A join reaches through the staff a floating voice was given")
-    func joinReachesThroughAFloatingVoice() throws {
-        // `*2` has no staff in the plan, but is drawn on one of its own for now, so the
-        // join written between staves 1 and 3 spans two printed boundaries, not one.
+    @Test("A floating voice adds no staff for the brace or the join to reach over")
+    func floatingVoiceAddsNoStaff() throws {
+        // `*2` has no staff in the plan and none on the page either: it is split between the
+        // two staves on either side of it (#80).  So the brace covers two staves, and the
+        // join written after it crosses the one boundary there is.
         let grouping = try #require(selectGrouping(threeVoices("%%score {1 *2| 3}")))
-        #expect(grouping.spans == [StaffGrouping.Span(bracket: .brace, staves: 0...2, depth: 0)])
-        #expect(grouping.barlineJoins == [0, 1])
+        #expect(grouping.spans == [StaffGrouping.Span(bracket: .brace, staves: 0...1, depth: 0)])
+        #expect(grouping.barlineJoins == [0])
     }
 
     @Test("A shared staff is one staff, so the span over it covers one")


### PR DESCRIPTION
Implements floating voices (`%%score {RH *M| LH}`, ABC v2.2 §11.1). A `*V` no longer takes a staff of its own with a `staffPlanNotFullyApplied` apology: it is cut in two along a split pitch, and each half joins the staff on its side as an ordinary extra voice — so the shared-staff merge (#76), the opposed stems (#77) and the displaced unisons (#79) all apply to it unchanged, and nothing downstream needs to know what a floating voice is.

§11.1 names the outcome and no rule for reaching it, so the rule is ours and `EXTENSIONS.md` documents it as such.

## The rule

- **Split pitch.** `V: … middle=` where the voice states one; otherwise the diatonic midpoint between the bottom line of the staff above and the top line of the staff below, each read through its own clef. Treble over bass gives middle C.
- **Assigned per atom.** A beam group, tuplet, chord or tie chain goes somewhere whole — a beam spanning staves is undrawable, not merely ugly. The majority of the atom's noteheads decides; ties break toward its first note. Grace notes cast no vote; rests follow the music around them.
- **Hysteresis.** An atom whose mean pitch is within one diatonic step of the split stays on the previous atom's staff, so a melody sitting on the split does not alternate bar to bar. `FloatingVoiceAssigner.hysteresis` is the named constant.
- **Degenerate cases.** One neighbour, or none: it prints on the staff it has (or one of its own) and warns. The music is never dropped.

## Shape

- `FloatingVoiceAssigner` — the rule alone: `assign(atoms:split:)` over a table of diatonic indices, with no model behind it.
- `FloatingVoiceSplitter` — the model surgery: atoms over the whole voice (so a tie over a bar line holds), then two `Voice`s, the displaced music stood in for by invisible rests so both halves measure the bar alike. Trailing silence gets no rest: nothing follows it to be pushed out of place.
- `VoiceSelector` resolves plan staves to printed staves first, then hands each floating voice to the two it sits between. A half joins its staff **last**, so the clef, key and name the staff draws stay those of the voice written at the top of it.

## Also

- `V: … middle=` is parsed for the first time — it used to fall into the unknown-key branch — and `VoiceProperties.middleNote` becomes a `Pitch`, an octave being exactly what the middle staff line needs and a pitch class cannot say.
- `EXTENSIONS.md` gains a "Floating voices — how the staff is chosen" section, and its preamble now covers behaviour the standard leaves undefined, not only `%%ceolkit:*` directives.

## Acceptance

| From the issue | Test |
| --- | --- |
| `%%score {RH *M\| LH}` places each atom on RH or LH by pitch | `atomsLandOnTheStaffTheirPitchChooses` |
| A beamed run never splits across staves | `beamedRunsStayWhole` (`C,EGc` straddles the split) |
| `V:M middle=` moves the split, verifiably | `middleMovesTheSplit` |
| A melody hovering at the split does not alternate | `hysteresisHoldsAMelodyStill` |
| A floating voice with only one neighbour warns and prints on it | `floatingVoiceWithOneNeighbour`, `oneNeighbourStillPrints` |

977 tests pass. Two existing tests changed to match the new behaviour: the floating voice no longer adds a printed staff, so the brace over `{1 *2| 3}` covers two staves and the join crosses one boundary.

## Known limits, unchanged by this PR

Notes are still drawn at treble staff positions whatever the clef (cf. #98 for key signatures), so a bass staff's notes sit below where they belong — the split itself is computed correctly through each clef, so the assignment is already right for when that is fixed. A slur that opens on one staff and closes on the other is drawn as two dangling arcs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G82eK1fXZg7kiBqsKuWezv