### PR TITLE
Fix #81 — route the & voice overlay through the shared-staff merge

### DIFF
--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -572,3 +572,99 @@ V:M middle=e
 ```
 
 which puts the split at E5 and sends the same four notes downstairs.
+
+---
+
+## Voice overlay — where an `&` winds back to
+
+**Applies to:** the `&` operator in the tune body (ABC v2.2 §7.4)
+
+### What the standard says, and does not say
+
+§7.4:
+
+> The `&` operator may be used to temporarily overlay several voices within one measure. Each
+> `&` operator sets the time point of the music back by one bar line, and the notes which
+> follow it form a temporary voice in parallel with the preceding one. This may only be used
+> to add one complete bar's worth of music for each `&`.
+
+Two of its terms have to be pinned down before an implementation can exist, and the standard
+pins neither. CeolKit reads them as follows; the readings are ours, and they are what its own
+two examples need in order to work.
+
+### The rule
+
+**"Back by one bar line" means back to the last bar line crossed.** Where music has already
+been written in the bar now open, that is the head of *this* bar. Where none has — an `&` at
+the head of a line, or straight after a bar line — it is the head of the bar *before*. A run
+of `&`s winds back one further bar for each, so `&&` written at the head of a line overlays
+the two bars of the line above it, which is what the standard's own second example asks for.
+
+**An `&` layer lives for the rest of its source line.** A bar line does not close it: `&& (d8
+| c6) c2|` is one temporary voice across two bars, again per the second example. What ends it
+is the end of the line, and the first `&` of the next line reopens *the same* temporary
+voice — one `&` on each of two lines is two bars of one part, not two parts of one bar each.
+
+**A line that opens with `&` is a continuation of the line above.** It shares that line's
+stave — the overlay is printed on the same system as the music it overlays, not on the next
+one — and it leaves the lyric anchor alone, so a `w:` after it still matches the notes above.
+That is §7.4's own "disregarding any overlay in the accompanying music code", which CeolKit
+applies to `s:` lines equally.
+
+**A bar line closes the bar for every layer standing in it.** The bar line belongs to the
+staff, not to whichever layer was current when it was typed.
+
+**An overlay is a voice.** Its accidentals are scoped to its own bar (§4.2 scopes them to the
+voice that wrote them), its notes beam among themselves, and its ties and slurs pair only
+with its own. It is written in the key and against the unit note length of the voice it
+overlays, because it *is* that voice's music.
+
+### Recovery
+
+An overlay that supplies more bars than its `&`s wound back over breaks the standard's "one
+complete bar's worth of music for each `&`". CeolKit warns (`voiceOverlayTooLong`) and prints
+the extra bars anyway, giving the voice beneath them the empty bars it now needs: dropping
+music the author wrote to enforce a counting rule would be the worse failure.
+
+An `&` written where there is no bar to wind back to — at the very start of a voice — warns
+(`voiceOverlayWithoutBar`) and starts the overlay at the first bar.
+
+### What this looks like on the page
+
+Each layer joins its voice's staff as an ordinary extra voice, directly beneath it, so
+everything a `( … )` shared staff already does applies to it: the layers are merged onto a
+common onset grid, the outer two have their stems opposed, simultaneous rests are moved off
+centre, and unisons between them are pulled apart. A tune written with `&` and the same tune
+written as a `%%score ( … )` group of the same parts draw the same noteheads in the same
+places.
+
+The staff's clef, key and name stay those of the voice itself. An overlay never supplies
+them, and no `%%score` can name, place or leave one out: it belongs to its voice and goes
+wherever the plan sends that voice.
+
+### Example
+
+```abc
+X:1
+T:Voice overlay
+M:6/8
+L:1/8
+K:C
+A2 | cdefga &\
+     AAAAAA &\
+     FEDCB,A, |]
+```
+
+Three parts on one staff for the second bar, and one for the first. Written on separate
+lines instead, with the `&`s leading, it means the same thing:
+
+```abc
+X:1
+T:Voice overlay
+M:6/8
+L:1/8
+K:C
+A2 | cdefga |]
+   & AAAAAA |]
+   & FEDCB,A, |]
+```

--- a/Sources/CeolKitModel/Diagnostic.swift
+++ b/Sources/CeolKitModel/Diagnostic.swift
@@ -42,6 +42,15 @@ public enum DiagnosticCode: String, Codable, Sendable {
     /// so the staves of a system cannot be aligned from the source alone.  The renderer
     /// pads the short voice with invisible full-measure rests and carries on.
     case voiceLengthMismatch
+    /// An `&` overlay (§7.4) supplied more bars than the `&`s before it wound the clock
+    /// back over, so its last bars overlay nothing.  They are printed, and the voice under
+    /// them gains the empty bars they need — the alternative is dropping music the author
+    /// wrote.
+    case voiceOverlayTooLong
+    /// An `&` was written where there is no bar to wind back to — at the very start of a
+    /// voice, or further back than its first bar line.  The overlay starts at the first bar
+    /// instead.
+    case voiceOverlayWithoutBar
     // Fields
     case unknownField
     case malformedFieldPayload

--- a/Sources/CeolKitModel/Staff.swift
+++ b/Sources/CeolKitModel/Staff.swift
@@ -9,7 +9,12 @@ import Foundation
 
 public struct Staff: Sendable {
     public let measures: [Measure]               // bar-line-delimited
-    public let overlays: [VoiceOverlay]          // & overlays per §7.4 of the standard
+    /// The `&` overlays written on this stave (§7.4), outermost layer first.
+    ///
+    /// Every stave of one voice carries the same number of overlays, and every overlay holds
+    /// exactly as many measures as ``measures`` — see ``VoiceOverlay``.  A voice the body
+    /// never wrote an `&` in has none at all.
+    public let overlays: [VoiceOverlay]
 
     public init(measures: [Measure], overlays: [VoiceOverlay]) {
         self.measures = measures

--- a/Sources/CeolKitModel/VoiceOverlay.swift
+++ b/Sources/CeolKitModel/VoiceOverlay.swift
@@ -7,10 +7,25 @@
 
 import Foundation
 
-/// A secondary voice overlaid on the same staff via `&` (§7.4).
-/// Full voice overlay support is deferred to v0.2.
+/// One temporary voice an `&` opens on a stave (ABC v2.2 §7.4).
+///
+/// > The `&` operator may be used to temporarily overlay several voices within one measure.
+/// > Each `&` operator sets the time point of the music back by one bar line, and the notes
+/// > which follow it form a temporary voice in parallel with the preceding one.
+///
+/// An overlay is a second tenant of the staff its voice is drawn on, exactly as the voices of
+/// a `%%score ( … )` group are, and the renderer feeds it through the same onset-keyed merge.
+///
+/// **``measures`` is parallel to the stave's own.**  There is one entry per bar of
+/// ``Staff/measures``, in the same order, and a bar the overlay says nothing in is an entry
+/// with no events rather than a gap.  A layer that is silent for a whole stave is therefore
+/// still present there: an overlay's position in ``Staff/overlays`` is its identity — the
+/// *n*th layer of a voice is the same temporary voice on every stave of it — and a layer that
+/// came and went between staves would silently become a different one.
 public struct VoiceOverlay: Sendable {
+    /// One measure per measure of the stave this overlay belongs to.
     public let measures: [Measure]
+    /// The `&` that opened this layer.
     public let source: SourceRange
 
     public init(measures: [Measure], source: SourceRange) {

--- a/Sources/CeolKitParser/AST/MusicElement.swift
+++ b/Sources/CeolKitParser/AST/MusicElement.swift
@@ -14,6 +14,7 @@ enum MusicElement {
     case decoration(DecorationToken, source: SourceRange)
     case inlineField(InformationField, source: SourceRange)
     case space(source: SourceRange)
+    case voiceOverlay(source: SourceRange)
     case brokenRhythm(count: Int, direction: BrokenDirection, source: SourceRange)
     case chordSymbol(String, source: SourceRange)
     case annotation(AnnotationPosition, String, source: SourceRange)

--- a/Sources/CeolKitParser/AST/MusicLineParser.swift
+++ b/Sources/CeolKitParser/AST/MusicLineParser.swift
@@ -112,6 +112,11 @@ private struct ParseContext {
         case .space:
             advance(); return .space(source: source)
 
+        // §7.4: not a reserved character and not an error — the semantic pass winds the
+        // clock back a bar line and opens a temporary voice for whatever follows.
+        case .voiceOverlay:
+            advance(); return .voiceOverlay(source: source)
+
         case .brokenRight: return parseBrokenRhythm(direction: .right)
         case .brokenLeft:  return parseBrokenRhythm(direction: .left)
 
@@ -341,6 +346,7 @@ private struct ParseContext {
         case .restFullMeasure:          return "Z"
         case .restFullMeasureInvisible: return "X"
         case .backslash:                return "\\"
+        case .voiceOverlay:             return "&"
         default:                        return ""
         }
     }

--- a/Sources/CeolKitParser/Lexer/MusicLexer.swift
+++ b/Sources/CeolKitParser/Lexer/MusicLexer.swift
@@ -122,6 +122,7 @@ struct MusicLexer {
         case ":": return scanColon()
         case " ", "\t": return scanSpace()
         case "\\": return .backslash
+        case "&": return .voiceOverlay
         default: return .unknown(ch)
         }
     }

--- a/Sources/CeolKitParser/Lexer/Token.swift
+++ b/Sources/CeolKitParser/Lexer/Token.swift
@@ -52,6 +52,7 @@ enum Token {
     // Structural
     case space                    // whitespace run
     case backslash                // \
+    case voiceOverlay             // &  (§7.4)
 
     // Chord/annotation
     case quotedString(String)     // "..."

--- a/Sources/CeolKitParser/Semantic/BodyContext.swift
+++ b/Sources/CeolKitParser/Semantic/BodyContext.swift
@@ -46,6 +46,30 @@ struct VoiceAccumulator {
         }
     }
 
+    /// True when the measure now being written holds music, so the last bar line the voice
+    /// crossed is behind it rather than immediately before it.  What an `&` needs in order to
+    /// know whether winding back one bar line means "the start of this bar" or "the start of
+    /// the one before it" (§7.4).
+    var hasOpenMeasure: Bool {
+        currentEvents.contains {
+            if case .spacer = $0 { return false }
+            return true
+        }
+    }
+
+    /// Appends a bar with no music in it, to keep an `&` overlay's measures aligned with the
+    /// stave's own.  It draws nothing: the voice underneath owns the staff's furniture.
+    mutating func appendEmptyMeasure(source: SourceRange) {
+        closedMeasures.append(Measure(
+            openingBar: lastBarLine,
+            events: [],
+            closingBar: BarLine(kind: .single, source: source),
+            endingNumber: nil,
+            source: source,
+            meter: nil
+        ))
+    }
+
     mutating func markStaveBoundary() {
         let idx = closedMeasures.count
         guard idx != staveBreakIndices.last else { return }  // no new measures since last split
@@ -368,6 +392,40 @@ struct VoiceState {
     }
 }
 
+// MARK: - VoiceKey
+
+/// Which accumulating voice a piece of music belongs to.
+///
+/// Usually a voice a `V:` field named.  An `&` (§7.4) opens a *temporary* voice alongside it,
+/// and that one has no `V:`, no properties and no place in the print order — it is drawn as a
+/// second tenant of its base voice's staff.  Both kinds accumulate identically, so both are
+/// keyed the same way and the walker threads one type.
+struct VoiceKey: Hashable {
+    /// The id a `V:` gave, which is what the model calls the voice.
+    let base: String
+    /// `0` for the voice itself; *n* for the music after its *n*th `&`.
+    let overlay: Int
+
+    init(_ base: String, overlay: Int = 0) {
+        self.base = base
+        self.overlay = overlay
+    }
+
+    var isOverlay: Bool { overlay > 0 }
+
+    /// The voice this one overlays — itself, when it overlays nothing.
+    var primary: VoiceKey { VoiceKey(base) }
+
+    /// The layer an `&` written while standing in this one opens.
+    ///
+    /// The walker resets the cursor to the voice at the head of every line that does not
+    /// itself open with `&`, so the first `&` of an ordinary line reopens layer 1 and its
+    /// music joins what earlier lines put there — one `&` on each of two lines is one
+    /// temporary voice, not two — while a line that *begins* with `&` keeps the cursor and
+    /// so stacks a further layer over the same music.
+    var nextOverlay: VoiceKey { VoiceKey(base, overlay: overlay + 1) }
+}
+
 // MARK: - BodyContext
 
 /// Tune-wide state threaded through music body processing.
@@ -393,7 +451,7 @@ struct BodyContext {
     // Voice table — created on first musical content, never eagerly, so a voice that was
     // declared and never written to has no entry here.  `declaredVoices` is what keeps it
     // from being lost: a `V:` field is a declaration whether or not any note follows it.
-    private(set) var voices: [String: VoiceState] = [:]
+    private(set) var voices: [VoiceKey: VoiceState] = [:]
 
     /// Every voice this tune knows about, in print order: the header's `V:` declarations
     /// first, then any the body introduced, in the order each was first seen.
@@ -413,6 +471,9 @@ struct BodyContext {
     /// stave it governs from.
     var bodyStaffPlans: [StaffPlanChange] = []
     var hasExplicitVoice: Bool = false
+    /// The `&` that opened each temporary voice (§7.4).  Its presence is also what says a
+    /// layer exists at all: the states themselves live in `voices`, keyed by `VoiceKey`.
+    private(set) var overlaySources: [VoiceKey: SourceRange] = [:]
 
     // I:linebreak settings — ABC 2.2 §9.2 — default is I:linebreak <EOL> $
     let linebreakChars: Set<Character>  // $ and/or !
@@ -444,7 +505,7 @@ struct BodyContext {
 
     /// Mutating access to one voice, creating its state on first musical content.
     mutating func withVoice<R>(
-        _ id: String,
+        _ key: VoiceKey,
         source: @autoclosure () -> SourceRange,
         _ body: (inout VoiceState) -> R
     ) -> R {
@@ -457,8 +518,10 @@ struct BodyContext {
         // order.  Belt and braces — the walker's cursor only ever holds an id that is already
         // in `voiceOrder` — but it makes "has music" imply "is printed" true by construction
         // rather than by inspection of every path that can move the cursor.
-        if voices[id] == nil, !voiceOrder.contains(id) { voiceOrder.append(id) }
-        return body(&voices[id, default: VoiceState(
+        if voices[key] == nil, !key.isOverlay, !voiceOrder.contains(key.base) {
+            voiceOrder.append(key.base)
+        }
+        return body(&voices[key, default: VoiceState(
             accumulator: VoiceAccumulator(source: source(), unitNoteLength: unitLen),
             accidentals: AccidentalScope(keyAlterations: alterations)
         )])
@@ -467,10 +530,10 @@ struct BodyContext {
     /// The voice the walker starts in: the first the header declared, or the implicit `"1"`
     /// when it declared none.  Music written before the tune's first inline `[V:]` belongs to
     /// the first voice on the page, not to a voice the header never mentioned.
-    var initialVoice: String { voiceOrder.first ?? "1" }
+    var initialVoice: VoiceKey { VoiceKey(voiceOrder.first ?? "1") }
 
     /// Read-only access.  Never allocates, so a voice that writes nothing costs nothing.
-    func voice(_ id: String) -> VoiceState? { voices[id] }
+    func voice(_ key: VoiceKey) -> VoiceState? { voices[key] }
 
     /// Every voice of the tune in print order, paired with its state.
     ///
@@ -480,7 +543,7 @@ struct BodyContext {
     /// one declared and nothing wrote to.
     func orderedVoices() -> [(String, VoiceState?)] {
         voiceOrder.compactMap { id in
-            guard let state = voices[id] else {
+            guard let state = voices[VoiceKey(id)] else {
                 return declaredVoices.contains(id) ? (id, nil) : nil
             }
             return (id, state)
@@ -528,7 +591,7 @@ struct BodyContext {
     /// memory; every other voice keeps both, because a `K:` in the body belongs to the voice
     /// that carries it — §7.3 asks for such a field to be repeated in every voice it should
     /// affect, which is only meaningful if one voice's does not reach the rest.
-    mutating func setKey(_ newKey: KeySignature, in voice: String, source: SourceRange) {
+    mutating func setKey(_ newKey: KeySignature, in voice: VoiceKey, source: SourceRange) {
         let alterations = keyAlterations(for: newKey)
         withVoice(voice, source: source) {
             if !$0.accumulator.hasMusic { $0.openingKey = newKey }
@@ -539,7 +602,7 @@ struct BodyContext {
     /// Moves the unit note length for one voice, likewise — but only where it opens the
     /// voice.  A change part way through has nowhere to land: one length sizes the whole
     /// voice, in the beam resolver here and in the renderer's sizer alike.  Issue #85.
-    mutating func setUnitNoteLength(_ length: Fraction, in voice: String, source: SourceRange) {
+    mutating func setUnitNoteLength(_ length: Fraction, in voice: VoiceKey, source: SourceRange) {
         withVoice(voice, source: source) {
             guard !$0.accumulator.hasMusic else { return }
             $0.openingUnitNoteLength = length
@@ -552,7 +615,7 @@ struct BodyContext {
     /// The effective alteration for a pitch in `voice`: that voice's bar memory first, then the
     /// key signature.  A voice with no state yet has no bar memory, so it resolves straight to
     /// the key — no need to materialise anything here.
-    func resolveAccidental(step: DiatonicStep, octave: Int, in voice: String) -> Alteration {
+    func resolveAccidental(step: DiatonicStep, octave: Int, in voice: VoiceKey) -> Alteration {
         voices[voice]?.accidentals.resolve(step: step, octave: octave)
             ?? keySignatureAlterations[step]
             ?? .natural
@@ -560,27 +623,20 @@ struct BodyContext {
 
     mutating func recordAccidental(
         step: DiatonicStep, octave: Int, alteration: Alteration,
-        in voice: String, source: SourceRange
+        in voice: VoiceKey, source: SourceRange
     ) {
         withVoice(voice, source: source) {
             $0.accidentals.record(step: step, octave: octave, alteration: alteration)
         }
     }
 
-    /// Clears one voice's bar memory at a bar line.  Other voices keep theirs: they reach their
-    /// own bar lines on their own lines, and in a shared bar two voices do not necessarily
-    /// cross the bar at the same point in the source.
-    mutating func resetBarAccidentals(in voice: String) {
-        voices[voice]?.accidentals.resetBar()
-    }
-
     // MARK: Lyric anchors
 
     /// Marks, for every voice that exists, where the music line about to be walked begins.
     mutating func recordLyricAnchors() {
-        for id in Array(voices.keys) {
-            let anchor = voices[id]?.accumulator.closedMeasures.count ?? 0
-            voices[id]?.lyricAnchor = anchor
+        for key in Array(voices.keys) {
+            let anchor = voices[key]?.accumulator.closedMeasures.count ?? 0
+            voices[key]?.lyricAnchor = anchor
         }
     }
 
@@ -590,15 +646,15 @@ struct BodyContext {
     // caller.  They exist so the walker reads as `ctx.emit(event, in: voice)` rather than
     // spelling out a closure at every site.
 
-    mutating func emit(_ event: Event, in voice: String) {
+    mutating func emit(_ event: Event, in voice: VoiceKey) {
         withVoice(voice, source: eventSourceRange(event) ?? .emptySourceRange) { $0.emit(event) }
     }
 
-    mutating func emitSpaceBreak(source: SourceRange, in voice: String) {
+    mutating func emitSpaceBreak(source: SourceRange, in voice: VoiceKey) {
         withVoice(voice, source: source) { $0.emitSpaceBreak(source: source) }
     }
 
-    mutating func closeMeasure(barLine: BarLine, in voice: String) {
+    mutating func closeMeasure(barLine: BarLine, in voice: VoiceKey) {
         let currentMeter = meter
         let generation = meterGeneration
         withVoice(voice, source: barLine.source) {
@@ -606,7 +662,7 @@ struct BodyContext {
         }
     }
 
-    mutating func splitStave(in voice: String) {
+    mutating func splitStave(in voice: VoiceKey) {
         voices[voice]?.accumulator.markStaveBoundary()
     }
 
@@ -625,88 +681,153 @@ struct BodyContext {
         voices.values.contains(where: \.accumulator.hasStaveInProgress)
     }
 
-    func isInGrace(_ voice: String) -> Bool { voices[voice]?.isInGrace ?? false }
+    func isInGrace(_ voice: VoiceKey) -> Bool { voices[voice]?.isInGrace ?? false }
 
-    mutating func startGrace(acciaccatura: Bool, source: SourceRange, in voice: String) {
+    mutating func startGrace(acciaccatura: Bool, source: SourceRange, in voice: VoiceKey) {
         withVoice(voice, source: source) { $0.startGrace(acciaccatura: acciaccatura, source: source) }
     }
 
-    mutating func flushGrace(source: SourceRange? = nil, in voice: String) {
+    mutating func flushGrace(source: SourceRange? = nil, in voice: VoiceKey) {
         voices[voice]?.flushGrace(source: source)
     }
 
-    mutating func appendGraceNote(_ note: Note, in voice: String) {
+    mutating func appendGraceNote(_ note: Note, in voice: VoiceKey) {
         voices[voice]?.appendGraceNote(note)
     }
 
-    mutating func startTuplet(p: Int, q: Int, r: Int, source: SourceRange, in voice: String) {
+    mutating func startTuplet(p: Int, q: Int, r: Int, source: SourceRange, in voice: VoiceKey) {
         withVoice(voice, source: source) { $0.startTuplet(p: p, q: q, r: r, source: source) }
     }
 
-    func isInTuplet(_ voice: String) -> Bool { voices[voice]?.tuplet != nil }
+    func isInTuplet(_ voice: VoiceKey) -> Bool { voices[voice]?.tuplet != nil }
 
-    mutating func applyLyrics(_ tokens: [LyricToken], in voice: String) {
+    mutating func applyLyrics(_ tokens: [LyricToken], in voice: VoiceKey) {
         // No state means no music line to align against — nothing to do.
         voices[voice]?.applyLyrics(tokens)
     }
 
-    mutating func applyDecorationToLastNote(_ decoration: Decoration, in voice: String) -> Bool {
+    mutating func applyDecorationToLastNote(_ decoration: Decoration, in voice: VoiceKey) -> Bool {
         guard voices[voice] != nil else { return false }
         return voices[voice]!.applyDecorationToLastNote(decoration)
     }
 
-    mutating func addSlurCloseToLastNote(in voice: String) -> Bool {
+    mutating func addSlurCloseToLastNote(in voice: VoiceKey) -> Bool {
         guard voices[voice] != nil else { return false }
         return voices[voice]!.addSlurCloseToLastNote()
     }
 
-    mutating func addPendingDecoration(_ decoration: Decoration, in voice: String, source: SourceRange) {
+    mutating func addPendingDecoration(_ decoration: Decoration, in voice: VoiceKey, source: SourceRange) {
         withVoice(voice, source: source) { $0.pendingDecorations.append(decoration) }
     }
 
-    mutating func addPendingAnnotation(_ annotation: Annotation, in voice: String) {
+    mutating func addPendingAnnotation(_ annotation: Annotation, in voice: VoiceKey) {
         withVoice(voice, source: annotation.source) { $0.pendingAnnotations.append(annotation) }
     }
 
-    mutating func setPendingChordSymbol(_ symbol: ChordSymbol?, in voice: String, source: SourceRange) {
+    mutating func setPendingChordSymbol(_ symbol: ChordSymbol?, in voice: VoiceKey, source: SourceRange) {
         withVoice(voice, source: source) { $0.pendingChordSymbol = symbol }
     }
 
-    mutating func setPendingEndingNumber(_ nums: [Int], in voice: String, source: SourceRange) {
+    mutating func setPendingEndingNumber(_ nums: [Int], in voice: VoiceKey, source: SourceRange) {
         withVoice(voice, source: source) { $0.pendingEndingNumber = nums }
     }
 
-    mutating func openSlur(in voice: String, source: SourceRange) {
+    mutating func openSlur(in voice: VoiceKey, source: SourceRange) {
         withVoice(voice, source: source) { $0.openSlurs += 1 }
     }
 
-    mutating func carrySlurClose(in voice: String, source: SourceRange) {
+    mutating func carrySlurClose(in voice: VoiceKey, source: SourceRange) {
         withVoice(voice, source: source) { $0.closeSlurs += 1 }
     }
 
-    mutating func consumeSlurs(in voice: String, source: SourceRange) -> (opens: Int, closes: Int) {
+    mutating func consumeSlurs(in voice: VoiceKey, source: SourceRange) -> (opens: Int, closes: Int) {
         withVoice(voice, source: source) { $0.consumeSlurs() }
     }
 
-    mutating func flushDecorations(in voice: String, source: SourceRange) -> [Decoration] {
+    mutating func flushDecorations(in voice: VoiceKey, source: SourceRange) -> [Decoration] {
         withVoice(voice, source: source) { $0.flushDecorations() }
     }
 
-    mutating func flushAnnotations(in voice: String, source: SourceRange) -> [Annotation] {
+    mutating func flushAnnotations(in voice: VoiceKey, source: SourceRange) -> [Annotation] {
         withVoice(voice, source: source) { $0.flushAnnotations() }
     }
 
-    mutating func flushChordSymbol(in voice: String, source: SourceRange) -> ChordSymbol? {
+    mutating func flushChordSymbol(in voice: VoiceKey, source: SourceRange) -> ChordSymbol? {
         withVoice(voice, source: source) { $0.flushChordSymbol() }
     }
 
-    func lastElementWasSpace(in voice: String) -> Bool {
+    func lastElementWasSpace(in voice: VoiceKey) -> Bool {
         voices[voice]?.lastElementWasSpace ?? false
     }
 
-    mutating func setLastElementWasSpace(_ value: Bool, in voice: String) {
+    mutating func setLastElementWasSpace(_ value: Bool, in voice: VoiceKey) {
         // Only meaningful once the voice exists; a voice with no state has nothing to decorate.
         voices[voice]?.lastElementWasSpace = value
+    }
+
+    // MARK: Voice overlay (§7.4)
+
+    /// Closes the bar `cursor` is writing, and with it the same bar of every `&` layer of the
+    /// same voice that is standing in it.
+    ///
+    /// A bar line belongs to the staff, not to the layer that happened to be current when it
+    /// was written: `c d e f & A A A A |` ends that bar for the voice and for its overlay
+    /// alike, and closing only one of them would leave the other's bar hanging open until the
+    /// end of the tune.  What decides is the bar each layer is *in*: an overlay written under
+    /// an earlier line — the standard's own `&&` example — has wound the clock back behind
+    /// the voice, and its bar lines are its own.
+    mutating func closeBar(barLine: BarLine, in cursor: VoiceKey) {
+        let bar = voices[cursor]?.accumulator.closedMeasures.count ?? 0
+        // The cursor first, and by name rather than by lookup: a bar line can be the very
+        // first thing in a voice, and that voice has no state to find yet.
+        let together = [cursor] + voices.keys.filter {
+            $0 != cursor && $0.base == cursor.base
+                && voices[$0]?.accumulator.closedMeasures.count == bar
+        }
+        for key in together {
+            closeMeasure(barLine: barLine, in: key)
+            voices[key]?.accidentals.resetBar()
+        }
+    }
+
+    /// Opens the temporary voice an `&` starts, with its first bar at `startMeasure` of the
+    /// voice underneath.
+    ///
+    /// A layer that already exists — because an earlier line wound back into it — is brought
+    /// forward to `startMeasure` rather than created again: two `&`s on two lines are the
+    /// same temporary voice, and drawing them as two would put a third part on the staff that
+    /// nobody wrote.  Where it has already written past `startMeasure` it stays where it is;
+    /// the overrun is caught once, when the staves are built.
+    mutating func openOverlay(_ key: VoiceKey, startingAt startMeasure: Int, source: SourceRange) {
+        precondition(key.isOverlay, "openOverlay is for `&` layers, not for a voice itself")
+        // The voice underneath exists from here on even if it never gets a note of its own:
+        // the overlay is *its* music, and a voice with no state is a voice the model drops.
+        withVoice(key.primary, source: source) { _ in }
+        // A temporary voice is written in the same key and against the same unit as the
+        // voice it overlays: it is that voice's own music, sounding at the same time.
+        let unitLen = voices[key.primary]?.accumulator.unitNoteLength ?? unitNoteLength
+        let alterations = voices[key.primary]?.accidentals.keyAlterations ?? keySignatureAlterations
+        if voices[key] == nil {
+            overlaySources[key] = source
+            voices[key] = VoiceState(
+                accumulator: VoiceAccumulator(source: source, unitNoteLength: unitLen),
+                accidentals: AccidentalScope(keyAlterations: alterations)
+            )
+        }
+        while voices[key]!.accumulator.closedMeasures.count < startMeasure {
+            voices[key]!.accumulator.appendEmptyMeasure(source: source)
+        }
+        // §4.2 scopes an accidental to the bar in the voice that wrote it, and winding the
+        // clock back starts a new bar in a new voice.
+        voices[key]!.accidentals.resetBar()
+    }
+
+    /// Every `&` layer of one voice, outermost first, each with the `&` that opened it.
+    func overlays(of base: String) -> [(source: SourceRange, state: VoiceState)] {
+        overlaySources.keys
+            .filter { $0.base == base }
+            .sorted { $0.overlay < $1.overlay }
+            .compactMap { key in voices[key].map { (overlaySources[key]!, $0) } }
     }
 }
 

--- a/Sources/CeolKitParser/Semantic/SemanticPass.swift
+++ b/Sources/CeolKitParser/Semantic/SemanticPass.swift
@@ -294,32 +294,81 @@ struct SemanticPass {
         // The one cursor in the pass, threaded from here down.  It is a parameter rather than
         // a field on BodyContext so nothing can read "the current voice" implicitly.
         var voice = ctx.initialVoice
+        // Whether the line just walked asked for the system to break after it.  Held rather
+        // than acted on, because the *next* line gets to cancel it: §7.4 writes an overlay
+        // under the music it overlays, and a line beginning `&` is a continuation of the one
+        // above, not a stave of its own.
+        var breakPending = false
         for line in body {
             // Check if this is a single-field lyric line
             if line.count == 1, case .inlineField(let f, _) = line[0], case .lyric(let tokens, _) = f {
-                ctx.applyLyrics(tokens, in: voice)
+                // §7.4: "disregarding any overlay in the accompanying music code" — the
+                // syllables belong to the voice, not to whichever `&` layer the line above
+                // left the cursor standing in.
+                ctx.applyLyrics(tokens, in: voice.primary)
                 continue
             }
-            // Record lyric anchors before processing this music line
-            ctx.recordLyricAnchors()
+            if continuesOverlay(line) {
+                // A line beginning `&` overlays the line above it, so it takes neither a
+                // stave of its own nor a lyric anchor of its own: §7.4 matches `w:` to the
+                // notes "disregarding any overlay in the accompanying music code", and the
+                // notes it means are the ones above.  The cursor stays where that line left
+                // it too, so this line's leading `&` opens the *next* layer over the same
+                // music: three parts written as three lines and three parts written on one
+                // line with two `&`s are the same tune.
+                breakPending = false
+            } else {
+                if breakPending { ctx.splitStave(in: voice.primary) }
+                ctx.recordLyricAnchors()
+                // An ordinary line opens in the voice itself: an `&` layer lives to the end
+                // of the line that opened it, and the next line's first `&` reopens layer one.
+                voice = voice.primary
+            }
             walkLine(line, voice: &voice, ctx: &ctx, diagnostics: &diagnostics)
-            if ctx.linebreakOnEOL {
-                ctx.splitStave(in: voice)
+            breakPending = ctx.linebreakOnEOL
+        }
+        if breakPending { ctx.splitStave(in: voice.primary) }
+    }
+
+    /// Whether `line` is the continuation of the one before it — an `&` overlay written on
+    /// its own source line, which shares a stave and a lyric anchor with what it overlays.
+    private func continuesOverlay(_ line: [MusicElement]) -> Bool {
+        for element in line {
+            switch element {
+            case .space: continue
+            case .voiceOverlay: return true
+            default: return false
             }
         }
+        return false
     }
 
     private func walkLine(
         _ elements: [MusicElement],
-        voice: inout String,
+        voice: inout VoiceKey,
         ctx: inout BodyContext,
         diagnostics: inout [Diagnostic]
     ) {
         // Pre-pass: resolve broken rhythms so note durations are correct
         let resolved = resolveBrokenRhythms(elements)
 
-        for elem in resolved {
-            walkElement(elem, voice: &voice, ctx: &ctx, diagnostics: &diagnostics)
+        var index = resolved.startIndex
+        while index < resolved.endIndex {
+            // §7.4: each `&` sets the time point back by one bar line, so a run of them winds
+            // back that many — `&&` under a two-bar line overlays both of its bars.  Read here
+            // rather than in the parser: the count is an interpretation of the syntax, and the
+            // AST keeps one node per character the source wrote.
+            guard case .voiceOverlay(let src) = resolved[index] else {
+                walkElement(resolved[index], voice: &voice, ctx: &ctx, diagnostics: &diagnostics)
+                index += 1
+                continue
+            }
+            var bars = 1
+            while index + bars < resolved.endIndex,
+                  case .voiceOverlay = resolved[index + bars] { bars += 1 }
+            openOverlay(rewinding: bars, source: src, voice: &voice, ctx: &ctx,
+                        diagnostics: &diagnostics)
+            index += bars
         }
         // Finish any open grace group (malformed; just close it)
         if ctx.isInGrace(voice) {
@@ -327,9 +376,43 @@ struct SemanticPass {
         }
     }
 
+    /// Moves the cursor into the temporary voice a run of `bars` `&`s opens (§7.4).
+    ///
+    /// The clock is wound back over `bars` bar lines: back to the head of the bar now being
+    /// written, and then one whole bar further for each `&` after the first.  A `&` written
+    /// where no bar has begun — at the head of a line, or of the tune — winds back from the
+    /// last bar line instead, which is what makes the standard's own `&&` example overlay the
+    /// two bars of the line above rather than the two after them.
+    private func openOverlay(
+        rewinding bars: Int,
+        source: SourceRange,
+        voice: inout VoiceKey,
+        ctx: inout BodyContext,
+        diagnostics: inout [Diagnostic]
+    ) {
+        // Whatever the layer being left holds open is finished before the clock moves.
+        if ctx.isInGrace(voice) { ctx.flushGrace(source: source, in: voice) }
+
+        let primary = ctx.voice(voice.primary)?.accumulator
+        let closed = primary?.closedMeasures.count ?? 0
+        let openBar = primary?.hasOpenMeasure ?? false
+        let start = closed - (bars - 1) - (openBar ? 0 : 1)
+        if start < 0 {
+            diagnostics.append(Diagnostic(
+                severity: .warning, code: .voiceOverlayWithoutBar,
+                message: "\(bars == 1 ? "an &" : "\(bars) &s") here would set the time point "
+                       + "back before the first bar of this voice; the overlay starts at that bar",
+                source: source,
+                hint: "each & sets the time point back by one bar line (§7.4), so there must be "
+                    + "at least that many bars of music before it."))
+        }
+        voice = voice.nextOverlay
+        ctx.openOverlay(voice, startingAt: max(0, start), source: source)
+    }
+
     private func walkElement(
         _ elem: MusicElement,
-        voice: inout String,
+        voice: inout VoiceKey,
         ctx: inout BodyContext,
         diagnostics: inout [Diagnostic]
     ) {
@@ -352,8 +435,9 @@ struct SemanticPass {
             ctx.emit(.rest(rest), in: voice)
 
         case .barLine(let kind, let src):
-            ctx.closeMeasure(barLine: BarLine(kind: kind, source: src), in: voice)
-            ctx.resetBarAccidentals(in: voice)
+            // Closes this bar for every `&` layer standing in it, not just the current one:
+            // the bar line is the staff's, and §7.4 overlays share the bar it ends.
+            ctx.closeBar(barLine: BarLine(kind: kind, source: src), in: voice)
 
         case .inlineField(let field, let src):
             applyInlineField(field, source: src, voice: &voice, ctx: &ctx, diagnostics: &diagnostics)
@@ -407,12 +491,15 @@ struct SemanticPass {
             ctx.emitSpaceBreak(source: src, in: voice)
             ctx.setLastElementWasSpace(true, in: voice)
 
+        case .voiceOverlay:
+            break  // read as a run by `walkLine`, which never hands one down here
+
         case .brokenRhythm:
             break  // already handled in resolveBrokenRhythms pre-pass
 
         case .unknown(let ch, let src):
             if ctx.linebreakChars.contains(ch) {
-                ctx.splitStave(in: voice)
+                ctx.splitStave(in: voice.primary)
             } else {
                 let severity: Diagnostic.Severity = options.strictRecovery ? .error : .warning
                 diagnostics.append(Diagnostic(
@@ -426,7 +513,7 @@ struct SemanticPass {
 
     // MARK: - Note / chord building
 
-    private func buildNoteEvent(_ tok: NoteToken, voice: String, ctx: inout BodyContext) -> Event {
+    private func buildNoteEvent(_ tok: NoteToken, voice: VoiceKey, ctx: inout BodyContext) -> Event {
         let step = diatonicStep(from: tok.pitchLetter)
         // ABC octave convention: uppercase C..B = octave 4 (middle C = C4), lowercase c..b = octave 5
         let baseOctave = tok.pitchLetter.isUppercase ? 4 : 5
@@ -479,7 +566,7 @@ struct SemanticPass {
     private func buildChordEvent(
         _ notes: [NoteToken],
         source: SourceRange,
-        voice: String,
+        voice: VoiceKey,
         ctx: inout BodyContext
     ) -> Event {
         let resolvedNotes: [Note] = notes.map { tok in
@@ -543,7 +630,7 @@ struct SemanticPass {
     private func applyInlineField(
         _ field: InformationField,
         source: SourceRange,
-        voice: inout String,
+        voice: inout VoiceKey,
         ctx: inout BodyContext,
         diagnostics: inout [Diagnostic]
     ) {
@@ -558,9 +645,13 @@ struct SemanticPass {
             ctx.emit(.tempoChange(t), in: voice)
         case .voice(let id, let props, _):
             ctx.registerVoice(id: id, properties: props)
-            voice = id          // the one place the cursor moves
+            // The one place the cursor moves between voices.  It lands on the voice itself,
+            // never on one of its `&` layers: those belong to the line that opened them.
+            voice = VoiceKey(id)
         case .lyric(let tokens, _):
-            ctx.applyLyrics(tokens, in: voice)
+            // §7.4: syllables match the notes "disregarding any overlay in the accompanying
+            // music code", so they land on the voice even when an `&` layer is being written.
+            ctx.applyLyrics(tokens, in: voice.primary)
         case .userSymbol(let ch, let dec, _):
             ctx.userSymbols[ch] = dec
         case .instruction(let t)
@@ -578,7 +669,7 @@ struct SemanticPass {
             let dirPayload = parts.count > 1 ? String(parts[1]) : ""
             applyBodyDirective(
                 name: dirName, payload: dirPayload, source: src,
-                voice: voice, ctx: &ctx, diagnostics: &diagnostics
+                voice: voice.base, ctx: &ctx, diagnostics: &diagnostics
             )
         default:
             break
@@ -1022,21 +1113,43 @@ struct SemanticPass {
             var staves: [Staff] = []
             if let state {
                 let accumulator = state.accumulator
-                let (measures, voiceDiags) = finaliseAccumulator(accumulator, meter: bodyCtx.meter)
+                var (measures, voiceDiags) = finaliseAccumulator(accumulator, meter: bodyCtx.meter)
                 diagnostics += voiceDiags
 
+                // §7.4: each `&` layer of this voice, finished the same way and then squared
+                // off against it, so a stave and its overlays hold the same bars.
+                var layers: [(source: SourceRange, measures: [Measure])] = []
+                for overlay in bodyCtx.overlays(of: voiceId) {
+                    let (overlayMeasures, overlayDiags) =
+                        finaliseAccumulator(overlay.state.accumulator, meter: bodyCtx.meter)
+                    diagnostics += overlayDiags
+                    layers.append((overlay.source, overlayMeasures))
+                }
+                let barsWritten = measures.count
+                diagnostics += reconcileOverlays(&measures, with: &layers, voiceId: voiceId)
+                // An overlay that overran gives the voice bars past the end of its last line.
+                // They are that line's — the source wrote them there — so the boundary
+                // recorded at what used to be the end is no longer a boundary at all.
+                let breaks = measures.count > barsWritten
+                    ? accumulator.staveBreakIndices.filter { $0 < barsWritten }
+                    : accumulator.staveBreakIndices
+
                 var start = 0
-                for breakIdx in accumulator.staveBreakIndices where breakIdx <= measures.count {
-                    let slice = Array(measures[start..<breakIdx])
-                    if !slice.isEmpty {
-                        staves.append(Staff(measures: slice, overlays: []))
-                    }
+                func appendStaff(through end: Int) {
+                    let slice = Array(measures[start..<end])
+                    guard !slice.isEmpty || (staves.isEmpty && end == measures.count) else { return }
+                    staves.append(Staff(
+                        measures: slice,
+                        overlays: layers.map {
+                            VoiceOverlay(measures: Array($0.measures[start..<end]),
+                                         source: $0.source)
+                        }))
+                }
+                for breakIdx in breaks where breakIdx <= measures.count {
+                    appendStaff(through: breakIdx)
                     start = breakIdx
                 }
-                let tail = Array(measures[start...])
-                if !tail.isEmpty || staves.isEmpty {
-                    staves.append(Staff(measures: tail, overlays: []))
-                }
+                appendStaff(through: measures.count)
             } else {
                 staves = [Staff(measures: [], overlays: [])]
             }
@@ -1068,12 +1181,65 @@ struct SemanticPass {
         return (voices, diagnostics)
     }
 
+    /// Squares a voice's `&` layers off against the voice itself, so every layer holds
+    /// exactly one measure per measure of the voice (§7.4, and see ``VoiceOverlay``).
+    ///
+    /// A layer that says nothing in a bar gets an empty measure there; the merge draws
+    /// nothing from it and the voice underneath keeps the bar's furniture.  A layer that runs
+    /// *past* the voice is the standard's "one complete bar's worth of music for each `&`"
+    /// broken: the voice is given the bars it is missing and a warning says so, because the
+    /// alternative is dropping bars the author wrote.
+    private func reconcileOverlays(
+        _ measures: inout [Measure],
+        with layers: inout [(source: SourceRange, measures: [Measure])],
+        voiceId: String
+    ) -> [Diagnostic] {
+        guard !layers.isEmpty else { return [] }
+        var diagnostics: [Diagnostic] = []
+
+        for layer in layers where layer.measures.count > measures.count {
+            diagnostics.append(Diagnostic(
+                severity: .warning, code: .voiceOverlayTooLong,
+                message: "the & overlay in voice \(voiceId) has \(layer.measures.count) bars "
+                       + "where the music it overlays has \(measures.count); §7.4 allows one "
+                       + "bar for each &. The extra bars are printed, and the voice under them "
+                       + "is left empty.",
+                source: layer.source,
+                hint: "write one & for each bar the overlay covers, or close the overlay with "
+                    + "a bar line before the extra music."))
+        }
+
+        let width = max(measures.count, layers.map(\.measures.count).max() ?? 0)
+        let tail = measures.last
+        measures += (measures.count..<width).map { _ in emptyMeasure(after: tail) }
+        for index in layers.indices {
+            let source = layers[index].source
+            layers[index].measures += (layers[index].measures.count..<width).map { _ in
+                emptyMeasure(after: nil, at: source)
+            }
+        }
+        return diagnostics
+    }
+
+    /// A bar with no music in it, for a voice or an overlay that has nothing to say here.
+    private func emptyMeasure(after previous: Measure?, at source: SourceRange? = nil) -> Measure {
+        let src = source ?? previous?.source ?? .emptySourceRange
+        return Measure(openingBar: previous?.closingBar,
+                       events: [],
+                       closingBar: BarLine(kind: .single, source: src),
+                       endingNumber: nil,
+                       source: src,
+                       meter: nil)
+    }
+
     private func finaliseAccumulator(_ acc: VoiceAccumulator, meter: Meter) -> ([Measure], [Diagnostic]) {
         var measures = acc.closedMeasures
         var diagnostics: [Diagnostic] = []
 
-        // Close the final open measure if it has events
-        if !acc.currentEvents.isEmpty {
+        // Close the final open measure if it holds music.  Spacer-only content is not music
+        // and not a measure — `closeWith` says the same at every bar line, and the leading
+        // whitespace of an `&` continuation line would otherwise close a bar of nothing.
+        if acc.hasOpenMeasure {
             let finalBar = BarLine(
                 kind: .final,
                 source: acc.currentEvents.reversed().lazy

--- a/Sources/CeolKitSVGRenderer/Layout/OverlayExpander.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/OverlayExpander.swift
@@ -1,0 +1,67 @@
+import CeolKitModel
+
+/// Turns the `&` overlays of ABC v2.2 §7.4 into the ordinary voices the rest of the layout
+/// draws, each a further tenant of the staff its voice is already on.
+///
+/// Nothing downstream of here knows what an overlay is, and it does not have to.  A staff
+/// already carries more than one voice — that is what a `%%score ( … )` group is — so an
+/// overlay becomes a second (or third) tenant of the one staff, and the merge onto a common
+/// onset grid (#76), the opposed stems (#77), the per-voice beams, ties and slurs (#78) and
+/// the displaced unisons (#79) all apply to it unchanged.  It is the same trick
+/// ``FloatingVoiceSplitter`` plays for a floating voice, from the other direction.
+///
+/// **A layer keeps its voice's id, key, unit note length and properties.**  It *is* that
+/// voice — §7.4 calls it a temporary voice of the same music — so a diagnostic that names it
+/// should name the voice the reader wrote, and its notes must be read against the same `L:`
+/// and drawn under the same clef.  Its stem direction is left as the voice stated it, `.auto`
+/// included: a shared staff opposes its tenants by position rather than by pitch (#77), and
+/// an overlay is exactly a tenant below the voice it overlays.
+///
+/// **A layer is present on every stave of its voice**, empty where it is silent, so its
+/// position in the staff is the same from one system to the next.  That is the invariant
+/// ``VoiceOverlay`` states, and it is what lets the expansion be this simple: the layer count
+/// is a property of the voice, not of the line.
+enum OverlayExpander {
+
+    /// Expands every voice of one staff in place: each voice, then its overlays, outermost
+    /// first, so the voice itself stays the staff's lead and the layers stack under it.
+    static func expand(_ voices: [Voice]) -> [Voice] {
+        voices.flatMap { voice -> [Voice] in
+            let layers = voice.staves.map(\.overlays.count).max() ?? 0
+            guard layers > 0 else { return [voice] }
+            return [stripped(voice)] + (0..<layers).map { layer(voice, at: $0) }
+        }
+    }
+
+    /// The voice without its overlays — the same music, drawn as it always was.
+    private static func stripped(_ voice: Voice) -> Voice {
+        rebuilt(voice, staves: voice.staves.map { Staff(measures: $0.measures, overlays: []) })
+    }
+
+    /// One `&` layer of `voice`, as a voice of its own.
+    ///
+    /// A stave that does not reach this layer contributes bars with no music rather than no
+    /// bars: ``VoiceAligner`` aligns voices stave by stave, and a layer short of a stave would
+    /// be padded and warned about for music the source never claimed to have written.
+    private static func layer(_ voice: Voice, at index: Int) -> Voice {
+        rebuilt(voice, staves: voice.staves.map { stave in
+            guard index < stave.overlays.count else {
+                return Staff(measures: stave.measures.map(silent(like:)), overlays: [])
+            }
+            return Staff(measures: stave.overlays[index].measures, overlays: [])
+        })
+    }
+
+    /// A bar the layer says nothing in, keeping the bar lines of the one it stands beside so
+    /// the two staves still measure the line the same way.
+    private static func silent(like measure: Measure) -> Measure {
+        Measure(openingBar: measure.openingBar, events: [], closingBar: measure.closingBar,
+                endingNumber: nil, source: measure.source, meter: measure.meter)
+    }
+
+    private static func rebuilt(_ voice: Voice, staves: [Staff]) -> Voice {
+        Voice(id: voice.id, properties: voice.properties, key: voice.key,
+              unitNoteLength: voice.unitNoteLength, staves: staves,
+              directives: voice.directives, source: voice.source)
+    }
+}

--- a/Sources/CeolKitSVGRenderer/Layout/VoiceSelector.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VoiceSelector.swift
@@ -18,6 +18,12 @@ import CeolKitModel
 /// only one neighbour there is no split to make, and it becomes an ordinary tenant of that
 /// staff with a `staffPlanNotFullyApplied` warning to say so.
 ///
+/// **An `&` overlay is a voice too, by the time this pass is done.**  ``OverlayExpander``
+/// gives every `&` layer (§7.4) a place on the staff of the voice that wrote it, directly
+/// under it, so a staff with overlays is a shared staff like any other.  This is the last
+/// pass that adds a voice to a staff, and it does it after the plan has been resolved: an
+/// overlay is not something a `%%score` can name, place or leave out.
+///
 /// **It also translates the plan's grouping into printed staff indices.**  `StaffPlanLayout`
 /// counts staves in the *plan*, and a dropped voice or a floating one means those are not the
 /// staves that reach the page.  This is the only pass that sees both numberings at once, so
@@ -44,12 +50,6 @@ enum VoiceSelector {
             (0..<staffCount).map { staff in voices.indices.filter { staffOfVoice[$0] == staff } }
         }
 
-        /// One staff per voice, in the order given — the shape every tune without a `( … )`
-        /// group has.
-        init(voices: [Voice], grouping: StaffGrouping?) {
-            self.init(voices: voices, staffOfVoice: Array(voices.indices), grouping: grouping)
-        }
-
         init(voices: [Voice], staffOfVoice: [Int], grouping: StaffGrouping?) {
             self.voices = voices
             self.staffOfVoice = staffOfVoice
@@ -70,7 +70,7 @@ enum VoiceSelector {
         into diagnostics: inout [Diagnostic]
     ) -> Selection {
         let printable = voices.filter { !$0.isEmpty }
-        guard let plan else { return Selection(voices: printable, grouping: nil) }
+        guard let plan else { return selection(of: printable.map { [$0] }, grouping: nil) }
 
         let layout = plan.layout
         let byId = Dictionary(voices.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
@@ -163,28 +163,34 @@ enum VoiceSelector {
             }
         }
 
-        let printed = staffed.flatMap { $0 }
-        let staffOfVoice = staffed.enumerated().flatMap {
-            [Int](repeating: $0.offset, count: $0.element.count)
-        }
-
         // Printed staff indices contributed by each staff of the plan: at most one now, and
         // none where every voice of a plan staff was dropped.
         let printedByPlanStaff = layout.staves.indices.map { staffForPlanStaff[$0].map { [$0] } ?? [] }
 
-        guard !printed.isEmpty else {
+        guard !staffed.isEmpty else {
             // Reporting each voice as unprinted would be a lie: the fallback prints them all.
             diagnostics.append(Diagnostic(
                 severity: .warning, code: .staffPlanEmpty,
                 message: "staff plan selects none of this tune's voices; "
                        + "laying the tune out as though it had no plan",
                 source: plan.source))
-            return Selection(voices: printable, grouping: nil)
+            return selection(of: printable.map { [$0] }, grouping: nil)
         }
 
         diagnostics += omissions(from: printable, namedBy: layout, plan: plan)
-        return Selection(voices: printed, staffOfVoice: staffOfVoice,
-                         grouping: grouping(of: layout, printedBy: printedByPlanStaff))
+        return selection(of: staffed, grouping: grouping(of: layout, printedBy: printedByPlanStaff))
+    }
+
+    /// The selection the staves add up to, with each voice's `&` overlays given their place
+    /// on the staff beneath it (§7.4).
+    private static func selection(of staffed: [[Voice]], grouping: StaffGrouping?) -> Selection {
+        let expanded = staffed.map(OverlayExpander.expand)
+        return Selection(
+            voices: expanded.flatMap { $0 },
+            staffOfVoice: expanded.enumerated().flatMap {
+                [Int](repeating: $0.offset, count: $0.element.count)
+            },
+            grouping: grouping)
     }
 
     // MARK: - Order

--- a/Tests/CeolKitParserTests/VoiceOverlayTests.swift
+++ b/Tests/CeolKitParserTests/VoiceOverlayTests.swift
@@ -1,0 +1,208 @@
+import Testing
+import CeolKitModel
+@testable import CeolKitParser
+
+/// Issue #81: the `&` voice overlay of ABC v2.2 §7.4.
+///
+/// `&` used to reach the semantic pass as an unrecognised character, so the music after it
+/// was appended to the bar it was supposed to overlay and `Staff.overlays` was always empty.
+/// It is a temporary voice now, wound back over as many bar lines as there were `&`s, and
+/// squared off against the stave so a renderer can put it on the same staff.
+@Suite("& voice overlay")
+struct VoiceOverlayTests {
+
+    private func parse(_ body: String) -> ParseResult {
+        CeolKitParser().parse("""
+        X:1
+        M:6/8
+        L:1/8
+        K:C
+        \(body)
+        """, options: .default)
+    }
+
+    private func voice(_ body: String) -> Voice {
+        parse(body).score.tunes[0].voices[0]
+    }
+
+    /// The number of sounding events in each measure — noteheads, rests and the like, with
+    /// the spacers a space between notes leaves behind left out.
+    private func shape(_ measures: [Measure]) -> [Int] {
+        measures.map { measure in
+            measure.events.count {
+                switch $0 {
+                case .note, .chord, .rest, .tuplet: true
+                default: false
+                }
+            }
+        }
+    }
+
+    // MARK: - The standard's own examples
+
+    @Test("§7.4: two &s on one line make two temporary voices over the bar they follow")
+    func specExampleOne() {
+        let voice = voice("""
+        A2 | c d e f g  a  &\\
+             A A A A A  A  &\\
+             F E D C B, A, |]
+        """)
+
+        #expect(voice.staves.count == 1)
+        let stave = voice.staves[0]
+        #expect(shape(stave.measures) == [1, 6])
+        #expect(stave.overlays.count == 2)
+        // Neither overlay says anything in the first bar: the `&`s wound back only as far as
+        // the bar the notes before them were in.
+        #expect(shape(stave.overlays[0].measures) == [0, 6])
+        #expect(shape(stave.overlays[1].measures) == [0, 6])
+    }
+
+    @Test("§7.4: && on its own line overlays the two bars of the line above it")
+    func specExampleTwo() {
+        let voice = voice("""
+            g4 f4 | e6 e2 |
+        && (d8    | c6) c2|
+        """)
+
+        // One stave, not two: the `&&` line is the line above it, overlaid.
+        #expect(voice.staves.count == 1)
+        let stave = voice.staves[0]
+        #expect(shape(stave.measures) == [2, 2])
+        #expect(stave.overlays.count == 1)
+        #expect(shape(stave.overlays[0].measures) == [1, 2])
+    }
+
+    @Test("§7.4: w: matches the notes disregarding the overlay")
+    func lyricsIgnoreTheOverlay() {
+        let voice = voice("""
+            g4 f4 | e6 e2 |
+        && (d8    | c6) c2|
+        w: ha-la-| lu-yoh
+        """)
+        let syllables = text(in: voice.staves[0].measures)
+        #expect(syllables == ["ha", "la", "lu", "yoh"])
+
+        // And nothing landed on the overlay, which is the half of the rule that would go
+        // unnoticed: the syllables would still read correctly above.
+        let overlaid = text(in: voice.staves[0].overlays[0].measures)
+        #expect(overlaid.isEmpty)
+    }
+
+    /// The syllables `w:` put on the notes of `measures`, in order.
+    private func text(in measures: [Measure]) -> [String] {
+        measures.flatMap { $0.events }.compactMap { event in
+            guard case .note(let note) = event, case .text(let string, _) = note.lyric else {
+                return nil
+            }
+            return string.value
+        }
+    }
+
+    // MARK: - Winding the clock back
+
+    @Test("an & mid-bar overlays the bar it is in, not the one before")
+    func windsBackToTheOpenBar() {
+        let stave = voice("C D E | F G A & c e g |").staves[0]
+        #expect(shape(stave.measures) == [3, 3])
+        #expect(shape(stave.overlays[0].measures) == [0, 3])
+    }
+
+    @Test("an & straight after a bar line overlays the bar that line closed")
+    func windsBackOverTheBarLine() {
+        let stave = voice("C D E | & c e g |").staves[0]
+        #expect(shape(stave.measures) == [3])
+        #expect(shape(stave.overlays[0].measures) == [3])
+    }
+
+    @Test("one & on each of two lines is one temporary voice, not two")
+    func layersAreReopenedNotRemade() {
+        let voice = voice("""
+        C D E & c e g |
+        F G A & d f a |
+        """)
+        #expect(voice.staves.count == 2)
+        let oneEach = voice.staves.allSatisfy { $0.overlays.count == 1 }
+        #expect(oneEach)
+        #expect(shape(voice.staves[0].overlays[0].measures) == [3])
+        #expect(shape(voice.staves[1].overlays[0].measures) == [3])
+    }
+
+    @Test("A leading & opens the next layer, so three lines make the three parts one line does")
+    func leadingAmpersandsStack() {
+        let split = voice("""
+        A2 | cdefga |]
+           & AAAAAA |]
+           & FEDCB,A, |]
+        """)
+        let joined = voice("""
+        A2 | cdefga &\
+             AAAAAA &\
+             FEDCB,A, |]
+        """)
+        #expect(split.staves.count == 1)
+        #expect(shape(split.staves[0].measures) == shape(joined.staves[0].measures))
+        #expect(split.staves[0].overlays.count == 2)
+        #expect(shape(split.staves[0].overlays[0].measures) == [0, 6])
+        #expect(shape(split.staves[0].overlays[1].measures) == [0, 6])
+    }
+
+    // MARK: - The overlay is its own voice
+
+    @Test("an accidental in an overlay does not reach the voice under it")
+    func accidentalsAreScopedToTheLayer() {
+        let stave = voice("^FF & =FF |").staves[0]
+        func sounding(_ events: [Event]) -> [Alteration] {
+            events.compactMap { if case .note(let n) = $0 { n.pitch.alteration } else { nil } }
+        }
+        // §4.2 scopes an accidental to the bar in the voice that wrote it, and a temporary
+        // voice is a voice: the overlay's `=F` says nothing about the `F` above it, and the
+        // `^F` above says nothing about the overlay's.
+        #expect(sounding(stave.measures[0].events) == [.sharp, .sharp])
+        #expect(sounding(stave.overlays[0].measures[0].events) == [.natural, .natural])
+    }
+
+    @Test("an overlay's notes are beamed among themselves")
+    func beamsStayWithinTheLayer() {
+        let stave = voice("CDE & ceg |").staves[0]
+        func beams(_ events: [Event]) -> [BeamState] {
+            events.compactMap { if case .note(let n) = $0 { n.beam } else { nil } }
+        }
+        #expect(beams(stave.measures[0].events) == [.start, .middle, .end])
+        #expect(beams(stave.overlays[0].measures[0].events) == [.start, .middle, .end])
+    }
+
+    // MARK: - Recovery
+
+    @Test("an overlay longer than the music it overlays is diagnosed, and still printed")
+    func tooLongIsDiagnosed() {
+        let result = parse("C D E | F G A & c e g | d f a |")
+        let overlay = result.score.tunes[0].voices[0].staves[0].overlays[0]
+        #expect(result.diagnostics.contains { $0.code == .voiceOverlayTooLong })
+        // Three bars now, because the overlay claimed one the voice never wrote.
+        #expect(shape(result.score.tunes[0].voices[0].staves[0].measures) == [3, 3, 0])
+        #expect(shape(overlay.measures) == [0, 3, 3])
+    }
+
+    @Test("an & with no bar to wind back to is diagnosed, and starts at the first bar")
+    func withoutABarIsDiagnosed() {
+        let result = parse("& c e g |")
+        let stave = result.score.tunes[0].voices[0].staves[0]
+        #expect(result.diagnostics.contains { $0.code == .voiceOverlayWithoutBar })
+        #expect(shape(stave.overlays[0].measures) == [3])
+    }
+
+    @Test("& is not a reserved character")
+    func notAReservedCharacter() {
+        let result = parse("C D E & c e g |")
+        #expect(!result.diagnostics.contains { $0.code == .reservedCharacter })
+    }
+
+    @Test("a tune with no & has no overlays at all")
+    func nothingChangesWithoutOne() {
+        let voice = voice("C D E | F G A |")
+        let bare = voice.staves.allSatisfy { $0.overlays.isEmpty }
+        #expect(bare)
+        #expect(shape(voice.staves[0].measures) == [3, 3])
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/VoiceOverlayLayoutTests.swift
+++ b/Tests/CeolKitSVGRendererTests/VoiceOverlayLayoutTests.swift
@@ -1,0 +1,219 @@
+import Testing
+import CeolKitModel
+import CeolKitParser
+@testable import CeolKitSVGRenderer
+
+/// Issue #81: the `&` voice overlay of §7.4, drawn through the shared-staff machinery built
+/// for `%%score ( … )`.
+///
+/// An overlay is a further tenant of the staff its voice is already on, so nothing below
+/// ``OverlayExpander`` needs to know it exists — the merge onto a common onset grid (#76),
+/// the opposed stems (#77), the per-voice arcs (#78) and the displaced heads (#79) all apply
+/// unchanged.  What these assert is that it really does arrive there: one staff, three parts
+/// on it, sharing columns and opposing stems.
+@Suite("& voice overlay: laid out on one staff")
+struct VoiceOverlayLayoutTests {
+
+    private let config = SVGRenderConfig()
+
+    private func svg(_ abc: String) throws -> String {
+        let score = CeolKitParser().parse(abc, options: .default).score
+        var diagnostics: [Diagnostic] = []
+        return try textProbeRenderer(config).render(score, diagnostics: &diagnostics).joined()
+    }
+
+    /// The standard's own §7.4 example: one bar, then a bar carrying three overlaid parts.
+    private let specExample = """
+    X:1
+    T:Overlay
+    M:6/8
+    L:1/8
+    K:C
+    A2 | cdefga &\\
+         AAAAAA &\\
+         FEDCB,A, |]
+    """
+
+    // MARK: - Probes
+
+    /// Every notehead drawn, as (x, y).
+    private func noteheads(in svg: String) -> [(x: Double, y: Double)] {
+        svg.matches(
+            of: /<text x="([-0-9.]+)" y="([-0-9.]+)" font-family="Bravura"[^>]*>(.)<\/text>/
+        ).compactMap { match in
+            let heads: Set<Character> = [SMuFLGlyph.noteheadBlack.character,
+                                         SMuFLGlyph.noteheadHalf.character,
+                                         SMuFLGlyph.noteheadWhole.character]
+            guard let x = Double(match.1), let y = Double(match.2),
+                  let ch = String(match.3).first, heads.contains(ch) else { return nil }
+            return (x, y)
+        }
+    }
+
+    /// How many staves the document draws, counted from the five-line groups.
+    private func staffCount(in svg: String) -> Int {
+        let lines = svg.matches(
+            of: /<line x1="([-0-9.]+)" y1="([-0-9.]+)" x2="([-0-9.]+)" y2="([-0-9.]+)" stroke="black" stroke-width="([-0-9.]+)"\/>/
+        ).compactMap { match -> (y: Double, span: Double)? in
+            guard let x1 = Double(match.1), let y1 = Double(match.2), let x2 = Double(match.3),
+                  let y2 = Double(match.4), y1 == y2 else { return nil }
+            return (y1, x2 - x1)
+        }
+        guard let widest = lines.map(\.span).max() else { return 0 }
+        return lines.filter { $0.span == widest }.count / 5
+    }
+
+    // MARK: - One staff, three parts
+
+    @Test("§7.4: two &s put three parts on one staff, not three staves")
+    func overlaidPartsShareAStaff() throws {
+        let svg = try svg(specExample)
+        #expect(staffCount(in: svg) == 1)
+        // A2, then three parts of six eighths each.
+        #expect(noteheads(in: svg).count == 19)
+    }
+
+    @Test("The three parts sound together, so they share six columns")
+    func partsShareTheirColumns() throws {
+        let heads = noteheads(in: try svg(specExample))
+        // The opening bar's single note is the leftmost; the overlaid bar is everything to
+        // the right of it, and its heads stand in six columns of three.
+        let opening = try #require(heads.map(\.x).min())
+        let overlaid = heads.filter { $0.x > opening + 1 }
+        let columns = Set(overlaid.map { ($0.x * 100).rounded() })
+        #expect(columns.count == 6)
+        #expect(overlaid.count == 18)
+    }
+
+    @Test("The staff opposes the outer parts' stems, as a ( … ) group's are opposed")
+    func stemsAreOpposed() throws {
+        let metadata = try BravuraMetadata.load()
+        // The overlaid bar alone, so the three parts do not cross and the pitch buckets are
+        // exactly the parts.  Every note of the middle part sits between the outer two.
+        let stems = probedStemsByPitchGroup(
+            in: try svg("X:1\nM:6/8\nL:1/8\nK:C\ncdefga & AAAAAA & FEDCB,A, |]\n"),
+            staffSize: config.staffSize, metadata: metadata, bucketCount: 3)
+        try #require(stems.count == 3)
+        // Highest part up, lowest down; the middle one keeps the pitch rule (#77).
+        #expect(stems[0].allSatisfy { $0.isUp })
+        #expect(stems[2].allSatisfy { !$0.isUp })
+    }
+
+    @Test("An & overlay draws the page the equivalent ( … ) group draws")
+    func overlayMatchesTheGroupThatSaysTheSameThing() throws {
+        // The whole claim of #81 in one assertion: `&` is routed through the machinery
+        // §11.1 already had, so the two spellings of three parts on one staff cannot
+        // disagree about anything — columns, beams, stems, bar lines or page.
+        let metadata = try BravuraMetadata.load()
+        let overlaid = try svg("""
+        X:1
+        M:6/8
+        L:1/8
+        K:C
+        cdefga & AAAAAA & FEDCB,A, |]
+        """)
+        let grouped = try svg("""
+        X:1
+        M:6/8
+        L:1/8
+        %%score (T1 T2 T3)
+        K:C
+        V:T1
+        V:T2
+        V:T3
+        [V:T1] cdefga |]
+        [V:T2] AAAAAA |]
+        [V:T3] FEDCB,A, |]
+        """)
+        // Everything the music draws, not the whole document: the two sources sit on
+        // different lines of their files, and the scroll-sync anchor says so.
+        func drawn(_ svg: String) -> ([String], [String]) {
+            (noteheads(in: svg).map { "\($0.x),\($0.y)" }.sorted(),
+             probedStems(in: svg, staffSize: config.staffSize, metadata: metadata)
+                 .map { "\($0.x),\($0.noteheadY),\($0.tipY)" }.sorted())
+        }
+        let (heads, stems) = drawn(overlaid)
+        try #require(heads.count == 18)
+        try #require(stems.count == 18)
+        #expect(heads == drawn(grouped).0)
+        #expect(stems == drawn(grouped).1)
+    }
+
+    // MARK: - The expansion itself
+
+    @Test("A voice with overlays becomes that many voices, all on its own staff")
+    func selectorPutsEveryLayerOnTheOneStaff() {
+        let score = CeolKitParser().parse(specExample, options: .default).score
+        var diagnostics: [Diagnostic] = []
+        let selection = VoiceSelector.select(from: score.tunes[0].voices, plan: nil,
+                                             into: &diagnostics)
+        #expect(selection.staffCount == 1)
+        #expect(selection.voices.count == 3)
+        #expect(selection.staffOfVoice == [0, 0, 0])
+        // Every layer is the voice it overlays, so it answers to the same name, key and clef.
+        let ids = Set(selection.voices.map(\.id))
+        #expect(ids == [.named("1")])
+    }
+
+    @Test("An overlay stays on its voice's staff when a %%score plan places that voice")
+    func overlaysSurviveAStaffPlan() {
+        let score = CeolKitParser().parse("""
+        X:1
+        M:4/4
+        L:1/4
+        %%score [T1 T2]
+        K:C
+        V:T1
+        V:T2
+        [V:T1] cdef & CDEF |
+        [V:T2] GABc |
+        """, options: .default).score
+        var diagnostics: [Diagnostic] = []
+        let tune = score.tunes[0]
+        let plan = tune.staffPlans.last { $0.effectiveFromStave == 0 }?.plan
+        let selection = VoiceSelector.select(from: tune.voices, plan: plan, into: &diagnostics)
+        // Two staves still: T1's overlay joins T1, and T2 is left alone.
+        #expect(selection.staffCount == 2)
+        #expect(selection.staffOfVoice == [0, 0, 1])
+        let ids: [VoiceId] = selection.voices.map(\.id)
+        #expect(ids == [.named("T1"), .named("T1"), .named("T2")])
+    }
+
+    @Test("A tune with no & is selected exactly as it was")
+    func nothingChangesWithoutAnOverlay() {
+        let score = CeolKitParser().parse("""
+        X:1
+        M:4/4
+        L:1/4
+        K:C
+        cdef | gabc' |
+        """, options: .default).score
+        var diagnostics: [Diagnostic] = []
+        let selection = VoiceSelector.select(from: score.tunes[0].voices, plan: nil,
+                                             into: &diagnostics)
+        #expect(selection.voices.count == 1)
+        #expect(selection.staffOfVoice == [0])
+        #expect(diagnostics.isEmpty)
+    }
+
+    @Test("A layer silent on a whole stave is still that stave's layer, and warns about nothing")
+    func aSilentStaveIsPaddedNotMisaligned() throws {
+        // The overlay is written on the first line only; the second line has none.  The
+        // aligner must not see a voice that is a stave short.
+        let score = CeolKitParser().parse("""
+        X:1
+        M:4/4
+        L:1/4
+        K:C
+        cdef & CDEF |
+        gabc' |
+        """, options: .default).score
+        var diagnostics: [Diagnostic] = []
+        let selection = VoiceSelector.select(from: score.tunes[0].voices, plan: nil,
+                                             into: &diagnostics)
+        let aligned = VoiceAligner.align(selection.voices, into: &diagnostics)
+        #expect(aligned.count == 2)
+        #expect(aligned.allSatisfy { $0.measures.allSatisfy { $0.count == 1 } })
+        #expect(!diagnostics.contains { $0.code == .voiceLengthMismatch })
+    }
+}


### PR DESCRIPTION
Closes #81.

`&` (§7.4) reached the semantic pass as an unrecognised character, so the music after it was appended to the bar it was supposed to overlay, `Staff.overlays` was always empty and nothing in the renderer read it. It is a temporary voice now, and it becomes a further tenant of its voice's staff — so the onset-keyed merge (#76), the opposed stems (#77), the per-part beams, ties and slurs (#78) and the displaced unisons (#79) all apply to it unchanged. A tune written with `&` and the same tune written as a `%%score ( … )` group of the same parts draw the same noteheads in the same places, and a test says so.

## Where §7.4 is silent, and what we chose

§7.4 leaves two of its own terms undefined; `EXTENSIONS.md` records the readings:

- **"Back by one bar line"** is back to the last bar line crossed — the head of the bar now open, or of the bar before it where none is. A run of `&`s winds back one further bar each, which is what the standard's own `&&` example needs.
- **An `&` layer lives past a bar line**, to the end of its source line: `&& (d8 | c6) c2|` is one temporary voice across two bars, per that same example.
- **A line that *opens* with `&`** continues the line above — same stave, same lyric anchor, and a further layer over the same music rather than a reopening of the first. So `w:` matches the notes "disregarding any overlay", as §7.4 asks.
- **A bar line closes the bar for every layer** standing in it: it belongs to the staff, not to whichever layer was current when it was typed.
- An overlay longer than the music it overlays warns (`voiceOverlayTooLong`) and prints anyway; an `&` with no bar to wind back to warns and starts at the first.

## Shape of the change

`VoiceKey` is the walker's cursor now — a voice id and a layer number — so a layer accumulates through exactly the machinery a voice does and gets its own accidental scope, beams and ties for nothing. `VoiceOverlay.measures` is stored parallel to the stave's own, one entry per bar, which is what lets `OverlayExpander` hand the layout an ordinary voice.

## Tests

New `VoiceOverlayTests` (parser) and `VoiceOverlayLayoutTests` (renderer), including the equivalence between `&` and the `%%score` group of the same parts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fp5U7cPR9uyzM6XNRfgbBo
