### PR TITLE
Fix #83 — Zocharti Loch (§7) conformance fixture and §11.1 documentation

### DIFF
--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -1,0 +1,142 @@
+# Conformance notes
+
+How CeolKit reads the parts of the [ABC 2.2 standard](https://abcnotation.com/wiki/abc:standard:v2.2)
+where the standard leaves a choice to the software, and where CeolKit's answer differs from
+the one `abcm2ps` gives.
+
+Non-standard `%%ceolkit:*` directives are documented separately, in
+[EXTENSIONS.md](EXTENSIONS.md).
+
+---
+
+## §11.1 Voice grouping — `%%score` and `%%staves`
+
+`V:` says which voice a line of music belongs to. It does not say what staff that voice is
+drawn on, or what furniture stands to the left of it. `%%score` does.
+
+```abc
+%%score Solo  [(S A) (T B)]  {RH | (LH1 LH2)}
+```
+
+### The grammar
+
+| Written | Means |
+| --- | --- |
+| `T1` | a voice, by the id its `V:` gave it |
+| `(T1 T2)` | a **voice group** — these voices share one staff |
+| `[ … ]` | a **bracket** joins the staves of everything inside it |
+| `{ … }` | a **brace** joins them instead — keyboard music |
+| `A \| B` | continued bar lines are drawn across the boundary between A and B |
+| `*M` | a **floating** voice: no staff of its own, each note drawn on the staff above or below |
+
+Brackets and braces nest, and a group may hold groups: `[{Vln1 | Vln2} | Vla | Vc | DB]` is
+the string-section plan §11.1 gives as an example, and CeolKit draws it as written — the
+outer bracket, the brace inside it, and continued bar lines at the three boundaries marked
+with `|`.
+
+`%%staves` accepts the same payload and inverts the sense of `|` alone, so `%%staves
+[S|A|T|B]` and `%%score [S A T B]` are the same plan. Nothing downstream can tell which
+spelling was used.
+
+A payload CeolKit cannot parse — an unclosed group, a stray delimiter, something left over
+after the end — produces a warning and the **whole directive is dropped**, which leaves the
+tune laid out as though it had no plan. A partial plan would be a layout nobody wrote.
+
+### Where a plan may be written
+
+| Written in | Governs |
+| --- | --- |
+| the file header | every tune in the file, unless that tune writes its own |
+| the tune header | the whole tune |
+| the tune body | that stave onwards — §11.1's "resets the music generator" |
+
+A body plan takes effect from the start of the **stave** (one source line of music, the unit
+`Voice.staves` is indexed in) it is written in. A plan written half way through a stave is
+snapped back to the start of it, with a `staffPlanSnappedToStave` warning. The staves of a
+system are laid out together, so a plan cannot change part way through one without splitting
+it, and snapping is more predictable than an implicit system break the source never asked
+for. Each plan change starts a new system.
+
+### Which voices are printed
+
+§11.1: *"Any voices appearing in the tune body will only be printed if it is mentioned in the
+score directive."* A plan therefore both filters and orders, and its order wins over `V:`
+declaration order.
+
+| Case | What happens |
+| --- | --- |
+| a voice the plan does not name | not printed; `voiceNotInStaffPlan` info diagnostic |
+| a voice the plan names twice | printed once, where it is first named; `staffPlanVoiceRepeated` warning |
+| a voice the plan names that the tune does not have | `staffPlanVoiceNotFound` warning, nothing drawn |
+| a voice the plan names that is declared but never written to | quietly skipped — the plan is right and the body has nothing to say |
+| a plan that selects no voice at all | `staffPlanEmpty` warning, and the tune is laid out as though it had no plan |
+
+The last of those is the recovery contract at work: a `Score` always comes back, and a tune
+whose plan selects nothing is more usefully drawn wrongly than not drawn at all.
+
+---
+
+## What the standard leaves open
+
+### With no directive at all, every voice gets a staff — and the bar lines are continued
+
+§11.1 says only that *"all voices that appear in the tune body are printed on separate
+staves"*. It does not say whether their bar lines join.
+
+CeolKit joins them. This is what `abcm2ps` draws, and it is what CeolKit drew before it
+understood `%%score` at all, so no existing page moved when the directive arrived. Written
+out, the default is `%%score [1|2|3]` rather than `%%score [1 2 3]`.
+
+A `%%score` with no `|` in it therefore *removes* the continued bar lines a plainer tune
+would have had. That is the standard's sense of `|` and not a CeolKit choice, but it
+surprises people, and `%%staves` exists precisely because it surprised people before.
+
+### The staves of a system are joined at the left edge, plan or no plan
+
+Independently of any bracket or brace, a system of more than one staff is closed at its left
+edge by a rule running from the top staff's top line to the bottom staff's bottom line. It
+is drawn at the staff lines' own weight, so it reads as the staves' shared left edge rather
+than as furniture, and `%%score` neither adds it nor takes it away.
+
+### A shared staff takes its clef, key and name from the voice written first
+
+Where `( … )` puts several voices on one staff, each of them may carry its own `V:` clef and
+its own per-voice `K:`. Only one of those can be drawn at the head of the staff.
+
+CeolKit draws the first-written voice's, throughout: the clef at the head of every system,
+the key signature, and the `name=` / `snm=` in the gutter. The other tenants contribute their
+notes, their `stem=` and their own `L:` — durations are read per voice, so a tenant written
+at a different unit note length still lasts as long as it says it does — and nothing else.
+
+**This differs from `abcm2ps`, which stacks the names** — it prints `Tenore I` over
+`Tenore II` beside the shared tenor staff, where CeolKit prints `Tenore I` alone. Both are
+conforming; §4.1 says the name is *"printed on the left of the first staff of the voice in
+question"* and says nothing about what to do when two voices claim the same staff. CeolKit's
+gutter reserves one line per staff, which is the choice this follows from.
+
+### Everything about a floating voice
+
+The standard names the outcome — each note on the staff above or the staff below — and gives
+no rule for reaching it, and it explicitly permits software to give up and print the whole
+voice on the preceding staff. CeolKit does the real thing, by a rule of its own invention:
+the split pitch, the atom, the hysteresis. It is written up in
+[EXTENSIONS.md → Floating voices](EXTENSIONS.md#floating-voices--how-the-staff-is-chosen)
+because the rule is ours, not the standard's.
+
+### Overlays and `%%score`
+
+An `&` voice overlay (§7.4) is placed on the staff of the voice that wrote it, directly under
+it, after the plan has been resolved. No `%%score` can name, place or leave out an overlay:
+it belongs to its voice and goes wherever that voice goes.
+
+---
+
+## Worked examples in the test suite
+
+The standard's own multi-voice examples are checked in end to end, parser and renderer, so
+that what this document claims is what the code does:
+
+| Example | Fixture |
+| --- | --- |
+| §7 Zocharti Loch — `%%score (T1 T2) (B1 B2)`, two voices to a staff | `ZochartiLochTests`, `ZochartiLochConformanceTests` |
+| §14.4 Canzonetta — `%%score [1 2 3]`, three voices bracketed, two verses of lyrics | `CanzonettaTests`, `CanzonettaConformanceTests` |

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ This package is inspired by [abcm2ps](https://github.com/lewdlime/abcm2ps) and c
 sheet music for [Silicon Valley Pipe Band](https://siliconvalleypipeband.org). So, features and capabilities
 have largely been driven by the needs of the pipe band musicians.
 
+[CONFORMANCE.md](CONFORMANCE.md) covers how CeolKit reads the parts of the standard that
+leave a choice to the software — voice grouping (§11.1) above all — and where it diverges
+from `abcm2ps`. [EXTENSIONS.md](EXTENSIONS.md) documents the non-standard `%%ceolkit:*`
+directives.
+
 ## Libraries
 
 | Product | Purpose |

--- a/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
@@ -757,11 +757,13 @@ struct SVGEmitter: Sendable {
     // MARK: - Clef
 
     private func emitClef(_ system: ResolvedSystem, builder: inout SVGBuilder) {
-        guard let glyph = clefGlyph(for: system.clef.clef) else { return }
+        guard let glyph = clefGlyph(for: system.clef) else { return }
         let s = config.staffSize
         let bottomStaffY = system.origin.y + system.staffOrigin + system.staffHeight
         let fontSize = 4.0 * s
         let x = system.origin.x + 0.25 * s
+        // The octave numeral hangs off the same origin the plain clef has, so a shifted
+        // clef still names the same staff line and there is nothing extra to place here.
         let y: Double
         switch system.clef.clef {
         case .none:                 return
@@ -788,7 +790,7 @@ struct SVGEmitter: Sendable {
         let bottomStaffY = system.origin.y + system.staffOrigin + system.staffHeight
         let glyphW       = metadata.glyphBBoxes["accidentalSharp"].map { $0.width * s } ?? s * 0.75
         let gap          = s * 0.1
-        let startX       = system.origin.x + clefWidth(for: system.clef.clef)
+        let startX       = system.origin.x + clefWidth(for: system.clef)
 
         for (i, acc) in accs.enumerated() {
             let x = startX + Double(i) * (glyphW + gap)
@@ -805,7 +807,7 @@ struct SVGEmitter: Sendable {
         let keySigW = system.keySignature.map {
             keySignatureWidth(for: $0, metadata: metadata, staffSize: s)
         } ?? 0
-        let startX = system.origin.x + clefWidth(for: system.clef.clef) + keySigW
+        let startX = system.origin.x + clefWidth(for: system.clef) + keySigW
         emitTimeSignatureGlyph(meter, atX: startX, system: system, builder: &builder)
     }
 
@@ -859,29 +861,12 @@ struct SVGEmitter: Sendable {
         }
     }
 
-    /// Width consumed by the clef glyph plus its right-side padding.
-    private func clefWidth(for clef: Clef) -> Double {
-        let name: String
-        switch clef {
-        case .none:                              return 0
-        case .treble:                            name = "gClef"
-        case .bass, .baritone:                  name = "fClef"
-        case .alto, .tenor, .soprano, .mezzoSoprano: name = "cClef"
-        case .percussion:                        name = "unpitchedPercussionClef1"
-        }
-        let glyphWidth = metadata.glyphBBoxes[name].map { $0.width * config.staffSize }
-            ?? (2.8 * config.staffSize)
-        return glyphWidth + 0.5 * config.staffSize
-    }
-
-    private func clefGlyph(for clef: Clef) -> SMuFLGlyph? {
-        switch clef {
-        case .none:                 return nil
-        case .treble:               return .gClef
-        case .bass, .baritone:      return .fClef
-        case .alto, .tenor, .soprano, .mezzoSoprano: return .cClef
-        case .percussion:           return .unpitchedPercussionClef1
-        }
+    /// Width consumed by the clef glyph plus its right-side padding.  Delegates to
+    /// `clefHeaderWidth`, which is the same number the line breaker and the justifier
+    /// reserved — an octave clef (`clef=treble-8`) is wider than its plain form, and the
+    /// key signature drawn after it has to start where the space was actually kept.
+    private func clefWidth(for spec: ClefSpec) -> Double {
+        clefHeaderWidth(for: spec, metadata: metadata, staffSize: config.staffSize)
     }
 
     // MARK: - Measure

--- a/Sources/CeolKitSVGRenderer/Emission/SystemHeaderLayout.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SystemHeaderLayout.swift
@@ -1,16 +1,48 @@
 import CeolKitModel
 
+/// The glyph a clef is drawn with, octave transposition included (ABC v2.2 §4.6:
+/// `clef=treble-8`, `clef=bass+8`, `clef=treble+15`).
+///
+/// SMuFL draws the numeral as part of the glyph, so an octave clef is a *substitution* for
+/// the plain one rather than a second thing to place — which is why this is one function and
+/// not a glyph plus an offset.  Both the width reserved for the clef and the drawing of it
+/// go through here, so the two cannot disagree about which glyph the header holds.
+///
+/// Where a font has no octave form of a clef — SMuFL defines `cClef8vb` and no other shifted
+/// C clef — the plain glyph is returned.  The transposition is a property of the voice and
+/// has already been applied to the notes; only the reader's reminder of it is missing.
+func clefGlyph(for spec: ClefSpec) -> SMuFLGlyph? {
+    switch spec.clef {
+    case .none:
+        return nil
+    case .treble:
+        switch spec.octaveShift {
+        case  8:  return .gClef8va
+        case -8:  return .gClef8vb
+        case  15: return .gClef15ma
+        case -15: return .gClef15mb
+        default:  return .gClef
+        }
+    case .bass, .baritone:
+        switch spec.octaveShift {
+        case  8:  return .fClef8va
+        case -8:  return .fClef8vb
+        case  15: return .fClef15ma
+        case -15: return .fClef15mb
+        default:  return .fClef
+        }
+    case .alto, .tenor, .soprano, .mezzoSoprano:
+        return spec.octaveShift == -8 ? .cClef8vb : .cClef
+    case .percussion:
+        return .unpitchedPercussionClef1
+    }
+}
+
 /// Horizontal space consumed by the clef glyph at the start of a system.
 func clefHeaderWidth(for spec: ClefSpec, metadata: BravuraMetadata, staffSize: Double) -> Double {
-    let name: String
-    switch spec.clef {
-    case .none:                                  return 0
-    case .treble:                                name = "gClef"
-    case .bass, .baritone:                       name = "fClef"
-    case .alto, .tenor, .soprano, .mezzoSoprano: name = "cClef"
-    case .percussion:                            name = "unpitchedPercussionClef1"
-    }
-    let glyphWidth = metadata.glyphBBoxes[name].map { $0.width * staffSize } ?? (2.8 * staffSize)
+    guard let glyph = clefGlyph(for: spec) else { return 0 }
+    let glyphWidth = metadata.glyphBBoxes[glyph.rawValue].map { $0.width * staffSize }
+        ?? (2.8 * staffSize)
     return glyphWidth + 0.5 * staffSize
 }
 

--- a/Sources/CeolKitSVGRenderer/Font/SMuFLGlyph.swift
+++ b/Sources/CeolKitSVGRenderer/Font/SMuFLGlyph.swift
@@ -20,6 +20,20 @@ public enum SMuFLGlyph: String, Sendable, CaseIterable {
     case cClef
     case unpitchedPercussionClef1
 
+    // Octave clefs (§4.6 `clef=treble-8`, `clef=bass+8`, …).  SMuFL draws the numeral as
+    // part of the glyph, so the octave form is a substitution for the plain one and needs
+    // no separate placement.  `cClef15ma`/`cClef15mb` and `fClef8vb`'s 15th are omitted
+    // where Bravura has no glyph for them; see `octaveClef(_:shift:)` in `SVGEmitter`.
+    case gClef8va
+    case gClef8vb
+    case gClef15ma
+    case gClef15mb
+    case fClef8va
+    case fClef8vb
+    case fClef15ma
+    case fClef15mb
+    case cClef8vb
+
     // Accidentals
     case accidentalSharp
     case accidentalFlat
@@ -90,6 +104,15 @@ public enum SMuFLGlyph: String, Sendable, CaseIterable {
         case .fClef:                       return 0xE062
         case .cClef:                       return 0xE05C
         case .unpitchedPercussionClef1:    return 0xE069
+        case .gClef8va:                    return 0xE053
+        case .gClef8vb:                    return 0xE052
+        case .gClef15ma:                   return 0xE054
+        case .gClef15mb:                   return 0xE051
+        case .fClef8va:                    return 0xE065
+        case .fClef8vb:                    return 0xE064
+        case .fClef15ma:                   return 0xE066
+        case .fClef15mb:                   return 0xE063
+        case .cClef8vb:                    return 0xE05D
         case .accidentalSharp:             return 0xE262
         case .accidentalFlat:              return 0xE260
         case .accidentalNatural:           return 0xE261

--- a/Tests/CeolKitParserTests/Conformance/ZochartiLochTests.swift
+++ b/Tests/CeolKitParserTests/Conformance/ZochartiLochTests.swift
@@ -1,0 +1,266 @@
+// §7 Zocharti Loch — the standard's own worked example of multi-voice abc: four voices,
+// two to a staff (`%%score (T1 T2) (B1 B2)`), octave clefs, `octave=` transposition, and a
+// part that waits out the opening with invisible rests.
+//
+// The engraved side of the same source is asserted in
+// `CeolKitSVGRendererTests/ZochartiLochConformanceTests.swift`.
+import Testing
+import CeolKitModel
+import CeolKitParser
+
+@Suite("§7 Zocharti Loch")
+struct ZochartiLochTests {
+
+    let result = parse(zochartiLochABC)
+    var score: Score { result.score }
+
+    /// The four voices in `V:` order, or `nil` if the tune did not parse at all.
+    private var voices: [Voice]? {
+        guard let voices = score.firstTune?.voices, voices.count == 4 else { return nil }
+        return voices
+    }
+
+    // MARK: - File level
+
+    @Test("The example parses to exactly one tune, without error")
+    func parsesCleanly() {
+        #expect(score.tunes.count == 1)
+        let errors = score.errorDiagnostics
+        #expect(errors.isEmpty, "Unexpected errors: \(errors.map(\.message))")
+    }
+
+    @Test("No version line, so the dialect is loose")
+    func dialectIsLoose() {
+        // §2.1: a file without `%abc-2.1` or higher is read loosely, whatever else it uses.
+        if case .loose = score.dialect {
+            // expected
+        } else {
+            Issue.record("Expected loose dialect, got \(score.dialect)")
+        }
+    }
+
+    // MARK: - Header fields
+
+    @Test("Title and composer")
+    func titleAndComposer() {
+        #expect(score.firstTune?.titles.first?.value == "Zocharti Loch")
+        #expect(score.firstTune?.metadata.composer?.value == "Louis Lewandowski (1821-1894)")
+    }
+
+    @Test("Meter is common time")
+    func meter() {
+        guard let tune = score.firstTune else { Issue.record("Parser prerequisite not met"); return }
+        if case .commonTime = tune.meter {
+            // expected
+        } else {
+            Issue.record("Expected .commonTime, got \(tune.meter)")
+        }
+    }
+
+    @Test("No L: field, so the unit note length comes from the meter: 1/8")
+    func unitNoteLength() {
+        // §3.1.7: C is 4/4, which is ≥ 0.75, so the default unit length is an eighth — the
+        // reason `x8` and `d6` in the body are a full bar and a dotted half.
+        #expect(score.firstTune?.unitNoteLength == Fraction(numerator: 1, denominator: 8))
+    }
+
+    @Test("Tempo is 76 to the quarter, with no prelude text")
+    func tempo() {
+        guard let tempo = score.firstTune?.tempo else { Issue.record("No tempo found"); return }
+        #expect(tempo.bpm == 76.0)
+        #expect(tempo.beats == [Fraction(numerator: 1, denominator: 4)])
+        #expect(tempo.prelude == nil)
+    }
+
+    @Test("Key is G minor")
+    func key() {
+        guard let tune = score.firstTune else { Issue.record("Parser prerequisite not met"); return }
+        #expect(tune.key.tonic?.step == .g)
+        #expect(tune.key.tonic?.alteration == Alteration(numerator: 0, denominator: 1))
+        #expect(tune.key.mode == .minor)
+    }
+
+    // MARK: - Voices
+
+    @Test("Four voices, in V: declaration order")
+    func voiceOrder() {
+        guard let voices else { Issue.record("Parser prerequisite not met"); return }
+        #expect(voices.map(\.id) == [.named("T1"), .named("T2"), .named("B1"), .named("B2")])
+    }
+
+    @Test("The tenors are on an octave-down treble clef")
+    func tenorClefs() {
+        guard let voices else { Issue.record("Parser prerequisite not met"); return }
+        for voice in voices.prefix(2) {
+            #expect(voice.properties.clef.clef == .treble)
+            #expect(voice.properties.clef.octaveShift == -8, "\(voice.id) lost its `-8`")
+        }
+    }
+
+    @Test("The basses are on a plain bass clef and sound an octave down")
+    func bassClefsAndTransposition() {
+        guard let voices else { Issue.record("Parser prerequisite not met"); return }
+        for voice in voices.suffix(2) {
+            #expect(voice.properties.clef.clef == .bass)
+            // `octave=-2` is a sounding transposition, not a clef: the notes are written
+            // where the bass clef puts them and the shift is carried beside them.
+            #expect(voice.properties.clef.octaveShift == 0)
+            #expect(voice.properties.transposition.octave == -2, "\(voice.id) lost its `octave=`")
+        }
+    }
+
+    @Test("Every voice carries the name and the abbreviated snm= it was given")
+    func namesAndSubnames() {
+        guard let voices else { Issue.record("Parser prerequisite not met"); return }
+        #expect(voices.map(\.properties.name) == ["Tenore I", "Tenore II", "Basso I", "Basso II"])
+        #expect(voices.map(\.properties.subname) == ["T.I", "T.II", "B.I", "B.II"])
+    }
+
+    // MARK: - Staff plan (§11.1)
+
+    @Test("%%score (T1 T2) (B1 B2) puts two voices on each of two staves")
+    func staffPlan() throws {
+        guard let tune = score.firstTune else { Issue.record("Parser prerequisite not met"); return }
+        let plan = tune.directives.compactMap { scoped -> StaffPlan? in
+            if case .staffPlan(let plan) = scoped.directive { return plan }
+            return nil
+        }
+        try #require(plan.count == 1)
+        let layout = plan[0].layout
+        #expect(layout.staves == [[.named("T1"), .named("T2")], [.named("B1"), .named("B2")]])
+        // `( … )` and nothing else: no brace, no bracket, and no `|`, so the staves are
+        // neither joined by furniture nor by their bar lines.
+        #expect(layout.spans.isEmpty)
+        #expect(layout.barlineJoins.isEmpty)
+        #expect(layout.floating.isEmpty)
+    }
+
+    @Test("The plan is tune-global, and takes effect from the first stave")
+    func staffPlanScope() throws {
+        guard let tune = score.firstTune else { Issue.record("Parser prerequisite not met"); return }
+        try #require(tune.staffPlans.count == 1)
+        // Written in the tune header, so it governs from the body's first stave.
+        #expect(tune.staffPlans[0].effectiveFromStave == 0)
+        let scoped = tune.directives.filter {
+            if case .staffPlan = $0.directive { return true }
+            return false
+        }
+        try #require(scoped.count == 1)
+        if case .tuneGlobal = scoped[0].scope {
+            // expected
+        } else {
+            Issue.record("The plan is scoped \(scoped[0].scope), not tune-global")
+        }
+    }
+
+    // MARK: - Body
+
+    @Test("Every voice is written as two staves of four bars")
+    func staveShape() {
+        guard let voices else { Issue.record("Parser prerequisite not met"); return }
+        for voice in voices {
+            #expect(voice.staves.map(\.measures.count) == [4, 4], "\(voice.id) is shaped wrong")
+        }
+    }
+
+    @Test("B2 waits out its first five bars on invisible rests")
+    func invisibleRests() {
+        guard let voices else { Issue.record("Parser prerequisite not met"); return }
+        let b2 = voices[3]
+        // `x8` fills the bar without drawing anything — the idiomatic way to keep a
+        // shared-staff voice's bar count right before it enters.
+        let openingBars = b2.allMeasures.prefix(5)
+        for (index, measure) in openingBars.enumerated() {
+            #expect(measure.noteEvents.isEmpty, "bar \(index + 1) of B2 has notes")
+            #expect(measure.restEvents.map(\.kind) == [.invisible],
+                    "bar \(index + 1) of B2 is not one invisible rest")
+        }
+        // And it does enter: bar 6 is `z2B2 c2d2`, so from there on B2 has notes.
+        #expect(!b2.allMeasures[5].noteEvents.isEmpty)
+    }
+
+    @Test("B1's rests before it enters are visible ones")
+    func visibleRests() {
+        guard let voices else { Issue.record("Parser prerequisite not met"); return }
+        // The distinction is the whole point of `x` against `z`: B1's `z8` is drawn as a
+        // whole-bar rest, B2's `x8` is not drawn at all.
+        #expect(voices[2].allMeasures[0].restEvents.map(\.kind) == [.normal])
+    }
+
+    @Test("The opening slur of each tenor spans its first four notes")
+    func openingSlurs() {
+        guard let voices else { Issue.record("Parser prerequisite not met"); return }
+        for voice in voices.prefix(2) {
+            guard let bar = voice.firstMeasure else { Issue.record("\(voice.id) has no bars"); return }
+            let notes = bar.noteEvents
+            #expect(notes.count == 4)
+            #expect(notes.first?.slurs.opens == 1, "\(voice.id) opens no slur")
+            #expect(notes.last?.slurs.closes == 1, "\(voice.id) closes no slur")
+        }
+    }
+
+    @Test("H is read as a fermata, on the last note of every voice")
+    func fermatas() {
+        guard let voices else { Issue.record("Parser prerequisite not met"); return }
+        for voice in voices {
+            guard let last = voice.allMeasures.last?.noteEvents.last else {
+                Issue.record("\(voice.id) ends on no note"); return
+            }
+            #expect(last.decorations.contains(.fermata), "\(voice.id) lost its H")
+        }
+    }
+
+    @Test("B1's ^f is an explicit sharp in G minor")
+    func explicitAccidental() {
+        guard let voices else { Issue.record("Parser prerequisite not met"); return }
+        guard let last = voices[2].allMeasures.last?.noteEvents.last else {
+            Issue.record("B1 ends on no note"); return
+        }
+        // The leading tone: written `^f`, and G minor's key signature does not supply it.
+        #expect(last.pitch.step == .f)
+        #expect(last.writtenAccidental == Alteration(numerator: 1, denominator: 1))
+        #expect(last.displayedAccidental == Alteration(numerator: 1, denominator: 1))
+    }
+
+    @Test("Each half closes on a double bar")
+    func closingBars() {
+        guard let voices else { Issue.record("Parser prerequisite not met"); return }
+        for voice in voices {
+            #expect(voice.allMeasures.last?.closingBar.kind == .double, "\(voice.id) ends wrong")
+        }
+    }
+
+    @Test("The bar numbering the % remarks describe is what parsed")
+    func barCount() {
+        guard let voices else { Issue.record("Parser prerequisite not met"); return }
+        // Eight bars per voice, thirty-two in all — the remark lines say 1 and 5, and the
+        // comments themselves leave no trace in the model.
+        #expect(voices.map(\.allMeasures.count) == [8, 8, 8, 8])
+    }
+}
+
+/// §7 of the ABC v2.2 standard, verbatim.
+let zochartiLochABC = """
+X:1
+T:Zocharti Loch
+C:Louis Lewandowski (1821-1894)
+M:C
+Q:1/4=76
+%%score (T1 T2) (B1 B2)
+V:T1  clef=treble-8  name="Tenore I"   snm="T.I"
+V:T2  clef=treble-8  name="Tenore II"  snm="T.II"
+V:B1  clef=bass      name="Basso I"    snm="B.I"  octave=-2
+V:B2  clef=bass      name="Basso II"   snm="B.II" octave=-2
+K:Gm
+%            End of header, start of tune body:
+% 1
+[V:T1]  (B2c2 d2g2)  | f6e2      | (d2c2 d2)e2 | d4 c2z2 |
+[V:T2]  (G2A2 B2e2)  | d6c2      | (B2A2 B2)c2 | B4 A2z2 |
+[V:B1]       z8      | z2f2 g2a2 | b2z2 z2 e2  | f4 f2z2 |
+[V:B2]       x8      |     x8    |      x8     |    x8   |
+% 5
+[V:T1]  (B2c2 d2g2)  | f8        | d3c (d2fe)  | H d6    ||
+[V:T2]       z8      |     z8    | B3A (B2c2)  | H A6    ||
+[V:B1]  (d2f2 b2e'2) | d'8       | g3g  g4     | H^f6    ||
+[V:B2]       x8      | z2B2 c2d2 | e3e (d2c2)  | H d6    ||
+"""

--- a/Tests/CeolKitSVGRendererTests/OctaveClefTests.swift
+++ b/Tests/CeolKitSVGRendererTests/OctaveClefTests.swift
@@ -1,0 +1,84 @@
+//
+//  OctaveClefTests.swift
+//  CeolKitSVGRendererTests
+//
+//  ABC v2.2 §4.6: `clef=treble-8` and its relatives are drawn with the octave numeral the
+//  reader needs to know the staff does not sound where it is written.
+//
+
+import Testing
+import CeolKitModel
+@testable import CeolKitSVGRenderer
+
+/// SMuFL draws the numeral as part of the clef glyph, so the whole feature is a choice of
+/// glyph — which is what these assert, together with the width that choice costs the header.
+///
+/// The codepoints behind the glyph names are checked against the specification's own table
+/// by `SMuFLGlyphConformanceTests`; nothing here needs to repeat that.
+@Suite("Octave clefs")
+struct OctaveClefTests {
+
+    private let metadata = try! BravuraMetadata.load()
+
+    private func spec(_ clef: Clef, _ shift: Int) -> ClefSpec {
+        ClefSpec(clef: clef, octaveShift: shift)
+    }
+
+    @Test("A G clef takes the numeral for every shift the standard allows")
+    func gClefShifts() {
+        #expect(clefGlyph(for: spec(.treble, 0)) == .gClef)
+        #expect(clefGlyph(for: spec(.treble, -8)) == .gClef8vb)
+        #expect(clefGlyph(for: spec(.treble, 8)) == .gClef8va)
+        #expect(clefGlyph(for: spec(.treble, -15)) == .gClef15mb)
+        #expect(clefGlyph(for: spec(.treble, 15)) == .gClef15ma)
+    }
+
+    @Test("So does an F clef, on both of the clefs drawn with one")
+    func fClefShifts() {
+        for clef in [Clef.bass, .baritone] {
+            #expect(clefGlyph(for: spec(clef, 0)) == .fClef)
+            #expect(clefGlyph(for: spec(clef, -8)) == .fClef8vb)
+            #expect(clefGlyph(for: spec(clef, 8)) == .fClef8va)
+            #expect(clefGlyph(for: spec(clef, -15)) == .fClef15mb)
+            #expect(clefGlyph(for: spec(clef, 15)) == .fClef15ma)
+        }
+    }
+
+    @Test("A C clef has only the octave-down form, and falls back to the plain glyph")
+    func cClefShifts() {
+        // SMuFL defines `cClef8vb` and no other shifted C clef.  Where there is no glyph the
+        // plain one is drawn: the transposition is a property of the voice and has already
+        // been applied to the notes — only the reader's reminder of it is missing.
+        for clef in [Clef.alto, .tenor, .soprano, .mezzoSoprano] {
+            #expect(clefGlyph(for: spec(clef, 0)) == .cClef)
+            #expect(clefGlyph(for: spec(clef, -8)) == .cClef8vb)
+            #expect(clefGlyph(for: spec(clef, 8)) == .cClef)
+            #expect(clefGlyph(for: spec(clef, -15)) == .cClef)
+        }
+    }
+
+    @Test("clef=none draws nothing, shifted or not")
+    func noClef() {
+        #expect(clefGlyph(for: spec(.none, 0)) == nil)
+        #expect(clefGlyph(for: spec(.none, -8)) == nil)
+    }
+
+    @Test("Percussion has no octave form to take")
+    func percussion() {
+        #expect(clefGlyph(for: spec(.percussion, 0)) == .unpitchedPercussionClef1)
+        #expect(clefGlyph(for: spec(.percussion, -8)) == .unpitchedPercussionClef1)
+    }
+
+    @Test("The header reserves the width of the glyph it will actually draw")
+    func headerWidthFollowsTheGlyph() {
+        // `gClef8vb` is no wider than `gClef` in Bravura but `fClef8vb` is not the same
+        // width as `fClef`, and either way the reservation has to be the *drawn* glyph's:
+        // the key signature after it starts where the space was kept.
+        for (clef, shift) in [(Clef.treble, -8), (.bass, -8), (.bass, 8), (.alto, -8)] {
+            let glyph = clefGlyph(for: spec(clef, shift))
+            let expected = (metadata.glyphBBoxes[glyph!.rawValue]!.width + 0.5) * 8
+            #expect(clefHeaderWidth(for: spec(clef, shift), metadata: metadata, staffSize: 8)
+                    == expected)
+        }
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/ZochartiLochConformanceTests.swift
+++ b/Tests/CeolKitSVGRendererTests/ZochartiLochConformanceTests.swift
@@ -1,0 +1,299 @@
+//
+//  ZochartiLochConformanceTests.swift
+//  CeolKitSVGRendererTests
+//
+//  §7 Zocharti Loch, engraved.  The parser side of the same source is asserted in
+//  `CeolKitParserTests/Conformance/ZochartiLochTests.swift`.
+//
+
+import Testing
+import SnapshotTesting
+import CeolKitModel
+import CeolKitParser
+import CeolKitSVGGeometry
+@testable import CeolKitSVGRenderer
+
+/// §7 Zocharti Loch — the standard's own worked example of multi-voice abc, and the hardest
+/// shape §11.1 can ask for: `%%score (T1 T2) (B1 B2)`, two voices on each of two staves,
+/// with no bracket, no brace and no `|`, so nothing joins the staves but the alignment of
+/// what is drawn on them.
+///
+/// Asserted through `CeolKitSVGGeometry`, which reads the emitted SVG rather than the layout
+/// engine's own beliefs, so a system that *thinks* it is aligned and one that is drawn
+/// aligned are told apart.
+@Suite("§7 Zocharti Loch — rendering")
+struct ZochartiLochConformanceTests {
+
+    private let config = SVGRenderConfig()
+
+    /// The weights the emitter drew with, read from the same metadata it read them from.
+    private let engravingDefaults = try! BravuraMetadata.load().engravingDefaults
+
+    /// One vertical stroke of the emitted drawing.
+    private struct Stroke {
+        let x: Double, y1: Double, y2: Double, width: Double?
+    }
+
+    private func render() throws -> (svg: String, staves: [SystemGeometry], diagnostics: [Diagnostic]) {
+        let result = CeolKitParser().parse(zochartiLochABC, options: .default)
+        var diagnostics = result.score.diagnostics
+        let pages = try SVGRenderer(config: config).render(result.score, diagnostics: &diagnostics)
+        #expect(pages.count == 1)
+        let geometry = try SVGGeometry.pages(from: pages)
+        return (pages.joined(), geometry.flatMap(\.systems), diagnostics)
+    }
+
+    /// The same page drawn as `<text>` rather than outlines, so the glyphs and words on it
+    /// can be read back.  Placement is identical either way.
+    private func textRender() throws -> (svg: String, staves: [SystemGeometry]) {
+        let result = CeolKitParser().parse(zochartiLochABC, options: .default)
+        var diagnostics = result.score.diagnostics
+        let pages = try textProbeRenderer(config).render(result.score, diagnostics: &diagnostics)
+        return (pages.joined(), try SVGGeometry.pages(from: pages).flatMap(\.systems))
+    }
+
+    private func verticalStrokes(in svg: String) -> [Stroke] {
+        svg.matches(of: /<line x1="([-0-9.]+)" y1="([-0-9.]+)" x2="([-0-9.]+)" y2="([-0-9.]+)"(?: stroke="[^"]*")?(?: stroke-width="([-0-9.]+)")?/)
+            .compactMap { match in
+                guard let x1 = Double(match.1), let y1 = Double(match.2),
+                      let x2 = Double(match.3), let y2 = Double(match.4),
+                      abs(x1 - x2) < 1e-9 else { return nil }
+                return Stroke(x: x1, y1: min(y1, y2), y2: max(y1, y2),
+                              width: match.5.flatMap { Double($0) })
+            }
+    }
+
+    /// Every `<text>` run drawn in a given font face, with where it landed.
+    private func runs(in svg: String, family: String) -> [(x: Double, y: Double, content: String)] {
+        svg.matches(of: /<text x="([-0-9.]+)" y="([-0-9.]+)" font-family="([^"]+)"[^>]*>([^<]*)<\/text>/)
+            .compactMap { match in
+                guard String(match.3) == family,
+                      let x = Double(match.1), let y = Double(match.2) else { return nil }
+                return (x: x, y: y, content: String(match.4))
+            }
+    }
+
+    /// The systems, as lists of the staves drawn on them.  Recovered from the page rather
+    /// than assumed: the plan says two staves per system, and that is what is being checked.
+    private func systems(_ staves: [SystemGeometry]) -> [[SystemGeometry]] {
+        Dictionary(grouping: staves) { $0.left }
+            .values
+            .map { $0.sorted { $0.topY < $1.topY } }
+            .sorted { ($0.first?.topY ?? 0) < ($1.first?.topY ?? 0) }
+    }
+
+    // MARK: - Diagnostics
+
+    @Test("§7 renders without a single warning or error")
+    func rendersClean() throws {
+        let complaints = try render().diagnostics.filter { $0.severity != .info }
+        #expect(complaints.isEmpty,
+                "Unexpected diagnostics: \(complaints.map { "line \($0.source.line): \($0.message)" })")
+    }
+
+    // MARK: - Systems
+
+    @Test("Four voices are drawn on two staves, twice: two systems of two")
+    func twoStavesPerSystem() throws {
+        let (_, staves, _) = try render()
+        // Two source line-sets, each broken nowhere: four staves in all, not eight.  A
+        // shared staff that failed to merge would show up here first, as four staves per
+        // system rather than two.
+        #expect(staves.count == 4)
+        #expect(systems(staves).map(\.count) == [2, 2])
+    }
+
+    @Test("The staves of a system share one x-span")
+    func stavesOfASystemShareAnXSpan() throws {
+        let (_, staves, _) = try render()
+        for system in systems(staves) {
+            #expect(Set(system.map(\.left)).count == 1)
+            #expect(Set(system.map(\.right)).count == 1)
+        }
+    }
+
+    @Test("Bar lines are aligned across both staves of a system")
+    func barLinesAlignAcrossTheSystem() throws {
+        let (_, staves, _) = try render()
+        for (index, system) in systems(staves).enumerated() {
+            guard let top = system.first, let bottom = system.last else {
+                Issue.record("System \(index) has no staves"); return
+            }
+            #expect(top.barlineXs.count == 4, "System \(index) has \(top.barlineXs.count) bars")
+            #expect(bottom.barlineXs.count == top.barlineXs.count)
+            for (x, expected) in zip(bottom.barlineXs, top.barlineXs) {
+                #expect(abs(x - expected) < 0.5,
+                        "System \(index): bar line at \(x) against \(expected)")
+            }
+        }
+    }
+
+    @Test("The abcLine anchors run down the page")
+    func abcLineAnchorsAreMonotonic() throws {
+        let result = CeolKitParser().parse(zochartiLochABC, options: .default)
+        var diagnostics: [Diagnostic] = []
+        let pages = try SVGRenderer(config: config).render(result.score, diagnostics: &diagnostics)
+        for page in try SVGGeometry.pages(from: pages) {
+            let lines = page.systems.compactMap(\.abcLine)
+            #expect(lines.count == page.systems.count, "Some system carries no anchor")
+            #expect(lines == lines.sorted(), "Anchors out of order: \(lines)")
+        }
+    }
+
+    // MARK: - What the plan does *not* ask for
+
+    @Test("No bracket and no brace: the plan uses ( ) alone")
+    func noStaffFurniture() throws {
+        let (svg, staves, _) = try render()
+        // A bracket's spine is the one stroke that both opens flush with a staff's top line
+        // and stands left of that staff — the test `StaffBracketTests` and the Canzonetta
+        // fixture identify it by.  Here there should be none, and no brace glyph either.
+        let spines = verticalStrokes(in: svg).filter { stroke in
+            staves.contains { abs($0.topY - stroke.y1) < 1e-3 && stroke.x < $0.left - 1e-9 }
+        }
+        #expect(spines.isEmpty, "Something is drawn left of a staff: \(spines.map(\.x))")
+
+        let braces = runs(in: try textRender().svg, family: "Bravura")
+            .filter { $0.content.contains(SMuFLGlyph.brace.character) }
+        #expect(braces.isEmpty)
+    }
+
+    @Test("Bar lines stop at their own staff — no `|` in the plan, no continued bar lines")
+    func barLinesAreNotContinued() throws {
+        let (svg, staves, _) = try render()
+        let strokes = verticalStrokes(in: svg)
+        for (index, system) in systems(staves).enumerated() {
+            guard let top = system.first else { Issue.record("System \(index) is empty"); return }
+            let staffLineWidth = engravingDefaults.staffLineThickness * top.staffLineGap
+            let tolerance = top.staffLineGap * 0.1
+            for x in top.barlineXs {
+                let overrun = strokes
+                    .filter { abs($0.x - x) < tolerance && abs($0.y1 - top.topY) < tolerance }
+                    .filter { ($0.width ?? .infinity) > staffLineWidth }
+                    .map { $0.y2 - top.bottomY }
+                    .max()
+                guard let overrun else { Issue.record("No bar line at \(x)"); return }
+                #expect(overrun < tolerance,
+                        "System \(index): the bar line at \(x) runs \(overrun) past its staff")
+            }
+        }
+    }
+
+    // MARK: - Voice names (§4.1)
+
+    @Test("Each staff is named for the voice written at the top of it")
+    func staffNames() throws {
+        let (svg, staves) = try textRender()
+        let words = runs(in: svg, family: "Libertinus Serif")
+        // `name=` on the first system, `snm=` on the second (§4.1).  A shared staff takes
+        // both from the voice written first in it — see CONFORMANCE.md — so "Tenore II"
+        // and "Basso II" are nowhere on the page.
+        for (staff, expected) in zip(systems(staves).flatMap { $0 },
+                                     ["Tenore I", "Basso I", "T.I", "B.I"]) {
+            // The gutter's own baseline, so the tempo mark standing above the first staff
+            // — which is also set left of the music — is not mistaken for a voice name.
+            let baselineY = staff.topY + VoiceLabelGutter.baselineOffset(staffSize: staff.staffLineGap)
+            let onThisStaff = words.filter {
+                $0.x < staff.left && abs($0.y - baselineY) < 1e-6
+            }
+            #expect(onThisStaff.map(\.content) == [expected])
+        }
+        #expect(!words.contains { $0.content.contains("Tenore II") })
+        #expect(!words.contains { $0.content.contains("Basso II") })
+    }
+
+    // MARK: - Octave clefs (§4.6)
+
+    @Test("clef=treble-8 is drawn with its 8, and clef=bass without one")
+    func octaveClefs() throws {
+        let (svg, staves) = try textRender()
+        let clefs = runs(in: svg, family: "Bravura").filter {
+            $0.content.contains(SMuFLGlyph.gClef8vb.character)
+                || $0.content.contains(SMuFLGlyph.gClef.character)
+                || $0.content.contains(SMuFLGlyph.fClef.character)
+        }
+        // One clef per staff: the tenors' octave-down G clef, the basses' plain F clef.
+        #expect(clefs.filter { $0.content.contains(SMuFLGlyph.gClef8vb.character) }.count == 2)
+        #expect(clefs.filter { $0.content.contains(SMuFLGlyph.gClef.character) }.isEmpty,
+                "A plain G clef was drawn for a `treble-8` voice")
+        #expect(clefs.filter { $0.content.contains(SMuFLGlyph.fClef.character) }.count == 2)
+
+        // The wider glyph is paid for out of the header, not out of the music: whatever the
+        // clef costs, the staff still starts where the system's other staff starts.
+        for system in systems(staves) {
+            #expect(Set(system.map(\.left)).count == 1)
+        }
+    }
+
+    // MARK: - Invisible rests (§4.9)
+
+    @Test("B2's x8 bars draw nothing, while B1's z8 draws a whole rest")
+    func invisibleRestsAreNotDrawn() throws {
+        let (svg, staves) = try textRender()
+        guard let bassStaff = systems(staves).first?.last else {
+            Issue.record("Nothing was drawn"); return
+        }
+        // The opening system's bass staff carries B1's `z8 | z2f2 g2a2 | b2z2 z2 e2 | f4 f2z2`
+        // and B2's four bars of `x8`.  Every rest drawn there is therefore B1's: five in
+        // all — the opening whole bar, then one each in bars 2, 3 (two of them) and 4.
+        let restGlyphs: Set<Character> = [
+            SMuFLGlyph.restWhole.character, SMuFLGlyph.restHalf.character,
+            SMuFLGlyph.restQuarter.character, SMuFLGlyph.rest8th.character,
+        ]
+        let rests = runs(in: svg, family: "Bravura").filter { run in
+            run.content.contains { restGlyphs.contains($0) }
+                && abs(run.y - bassStaff.topY) < 6 * bassStaff.staffLineGap
+                && run.y > bassStaff.topY - 2 * bassStaff.staffLineGap
+        }
+        #expect(rests.count == 5, "Drew \(rests.map(\.content).count) rests on the bass staff")
+        // The first is the whole-bar rest that stands alone in bar 1 — B2's `x8` beside it
+        // is not drawn, and does not push it off centre either (see `SVGEmitter.inkedVoices`).
+        guard let first = rests.min(by: { $0.x < $1.x }) else { return }
+        #expect(first.content.contains(SMuFLGlyph.restWhole.character))
+        #expect(abs(first.y - (bassStaff.topY + bassStaff.staffLineGap)) < 1e-6,
+                "The lone whole rest is not hanging from the fourth line")
+    }
+
+    // MARK: - Snapshot
+
+    // The snapshot file's basename has to be unique across the whole test target:
+    // `__Snapshots__` is declared `.process(…)` in `Package.swift`, which flattens it, and
+    // `CanzonettaConformanceTests` already has a `pageMatchesSnapshot`.
+    @Test("The engraved page does not drift")
+    func zochartiPageMatchesSnapshot() throws {
+        // Outline data replaced for the reason `IntegrationTests` gives: this snapshot is
+        // about structure and placement, and a few thousand curve coordinates would bury
+        // it.  The outlines are checked against Bravura's own boxes in `OpenTypeFontTests`.
+        let sanitized = try render().svg.replacing(
+            /(<path id="[^"]+" d=")[^"]+"/,
+            with: { "\($0.output.1)<OUTLINE>\"" }
+        )
+        assertSnapshot(of: sanitized, as: .lines)
+    }
+}
+
+/// §7 of the ABC v2.2 standard, verbatim.
+private let zochartiLochABC = """
+X:1
+T:Zocharti Loch
+C:Louis Lewandowski (1821-1894)
+M:C
+Q:1/4=76
+%%score (T1 T2) (B1 B2)
+V:T1  clef=treble-8  name="Tenore I"   snm="T.I"
+V:T2  clef=treble-8  name="Tenore II"  snm="T.II"
+V:B1  clef=bass      name="Basso I"    snm="B.I"  octave=-2
+V:B2  clef=bass      name="Basso II"   snm="B.II" octave=-2
+K:Gm
+%            End of header, start of tune body:
+% 1
+[V:T1]  (B2c2 d2g2)  | f6e2      | (d2c2 d2)e2 | d4 c2z2 |
+[V:T2]  (G2A2 B2e2)  | d6c2      | (B2A2 B2)c2 | B4 A2z2 |
+[V:B1]       z8      | z2f2 g2a2 | b2z2 z2 e2  | f4 f2z2 |
+[V:B2]       x8      |     x8    |      x8     |    x8   |
+% 5
+[V:T1]  (B2c2 d2g2)  | f8        | d3c (d2fe)  | H d6    ||
+[V:T2]       z8      |     z8    | B3A (B2c2)  | H A6    ||
+[V:B1]  (d2f2 b2e'2) | d'8       | g3g  g4     | H^f6    ||
+[V:B2]       x8      | z2B2 c2d2 | e3e (d2c2)  | H d6    ||
+"""

--- a/Tests/CeolKitSVGRendererTests/__Snapshots__/ZochartiLochConformanceTests/zochartiPageMatchesSnapshot.1.txt
+++ b/Tests/CeolKitSVGRendererTests/__Snapshots__/ZochartiLochConformanceTests/zochartiPageMatchesSnapshot.1.txt
@@ -1,0 +1,347 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 612 792" width="612" height="792">
+  <defs>
+    <path id="libertinusSerif-g59" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g80" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g68" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g73" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g66" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g83" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g85" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g74" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g45" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g45" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g80" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g86" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g74" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g84" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g70" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g88" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g66" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g79" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g69" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g76" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g9" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g18" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g25" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g19" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g14" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g26" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g21" d="<OUTLINE>"/>
+    <path id="libertinusSerifItalic-g10" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g2261" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g30" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g24" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g23" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g53" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g70" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g79" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g42" d="<OUTLINE>"/>
+    <path id="bravura-g76" d="<OUTLINE>"/>
+    <path id="bravura-g535" d="<OUTLINE>"/>
+    <path id="bravura-g132" d="<OUTLINE>"/>
+    <path id="bravura-g158" d="<OUTLINE>"/>
+    <path id="bravura-g157" d="<OUTLINE>"/>
+    <path id="bravura-g459" d="<OUTLINE>"/>
+    <path id="bravura-g996" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g35" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g84" d="<OUTLINE>"/>
+    <path id="bravura-g92" d="<OUTLINE>"/>
+    <path id="bravura-g994" d="<OUTLINE>"/>
+    <path id="libertinusSerif-g15" d="<OUTLINE>"/>
+    <path id="bravura-g156" d="<OUTLINE>"/>
+    <path id="bravura-g517" d="<OUTLINE>"/>
+    <path id="bravura-g518" d="<OUTLINE>"/>
+    <path id="bravura-g968" d="<OUTLINE>"/>
+    <path id="bravura-g537" d="<OUTLINE>"/>
+  </defs>
+  <!-- ceolkit-meta: {"page": 1, "anchors": [{"abcLine": 14, "y": 87}, {"abcLine": 14, "y": 129}, {"abcLine": 19, "y": 183}, {"abcLine": 19, "y": 225}]} -->
+  <use href="#libertinusSerif-g59" xlink:href="#libertinusSerif-g59" transform="translate(254.358 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g80" xlink:href="#libertinusSerif-g80" transform="translate(265.23 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g68" xlink:href="#libertinusSerif-g68" transform="translate(274.302 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g73" xlink:href="#libertinusSerif-g73" transform="translate(282.006 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g66" xlink:href="#libertinusSerif-g66" transform="translate(291.69 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g83" xlink:href="#libertinusSerif-g83" transform="translate(299.916 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g85" xlink:href="#libertinusSerif-g85" transform="translate(306.612 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g74" xlink:href="#libertinusSerif-g74" transform="translate(312.3 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g45" xlink:href="#libertinusSerif-g45" transform="translate(321.678 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g80" xlink:href="#libertinusSerif-g80" transform="translate(331.182 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g68" xlink:href="#libertinusSerif-g68" transform="translate(340.254 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerif-g73" xlink:href="#libertinusSerif-g73" transform="translate(347.958 47.25) scale(0.018 -0.018)"/>
+  <use href="#libertinusSerifItalic-g45" xlink:href="#libertinusSerifItalic-g45" transform="translate(426.336 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g80" xlink:href="#libertinusSerifItalic-g80" transform="translate(432.564 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g86" xlink:href="#libertinusSerifItalic-g86" transform="translate(437.928 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g74" xlink:href="#libertinusSerifItalic-g74" transform="translate(444.18 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g84" xlink:href="#libertinusSerifItalic-g84" transform="translate(447.492 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g45" xlink:href="#libertinusSerifItalic-g45" transform="translate(454.728 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g70" xlink:href="#libertinusSerifItalic-g70" transform="translate(460.956 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g88" xlink:href="#libertinusSerifItalic-g88" transform="translate(465.768 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g66" xlink:href="#libertinusSerifItalic-g66" transform="translate(474.024 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g79" xlink:href="#libertinusSerifItalic-g79" transform="translate(479.856 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g69" xlink:href="#libertinusSerifItalic-g69" transform="translate(486.072 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g80" xlink:href="#libertinusSerifItalic-g80" transform="translate(491.94 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g88" xlink:href="#libertinusSerifItalic-g88" transform="translate(497.304 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g84" xlink:href="#libertinusSerifItalic-g84" transform="translate(505.56 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g76" xlink:href="#libertinusSerifItalic-g76" transform="translate(509.796 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g74" xlink:href="#libertinusSerifItalic-g74" transform="translate(515.628 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g9" xlink:href="#libertinusSerifItalic-g9" transform="translate(521.94 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g18" xlink:href="#libertinusSerifItalic-g18" transform="translate(525.612 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g25" xlink:href="#libertinusSerifItalic-g25" transform="translate(530.94 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g19" xlink:href="#libertinusSerifItalic-g19" transform="translate(536.268 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g18" xlink:href="#libertinusSerifItalic-g18" transform="translate(541.596 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g14" xlink:href="#libertinusSerifItalic-g14" transform="translate(546.924 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g18" xlink:href="#libertinusSerifItalic-g18" transform="translate(550.92 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g25" xlink:href="#libertinusSerifItalic-g25" transform="translate(556.248 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g26" xlink:href="#libertinusSerifItalic-g26" transform="translate(561.576 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g21" xlink:href="#libertinusSerifItalic-g21" transform="translate(566.904 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerifItalic-g10" xlink:href="#libertinusSerifItalic-g10" transform="translate(572.244 62.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g2261" xlink:href="#libertinusSerif-g2261" transform="translate(36 77.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g30" xlink:href="#libertinusSerif-g30" transform="translate(43.8 77.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g24" xlink:href="#libertinusSerif-g24" transform="translate(53.4 77.25) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g23" xlink:href="#libertinusSerif-g23" transform="translate(58.98 77.25) scale(0.012 -0.012)"/>
+  <line x1="83.472" y1="87" x2="576" y2="87" stroke="black" stroke-width="0.78"/>
+  <line x1="83.472" y1="93" x2="576" y2="93" stroke="black" stroke-width="0.78"/>
+  <line x1="83.472" y1="99" x2="576" y2="99" stroke="black" stroke-width="0.78"/>
+  <line x1="83.472" y1="105" x2="576" y2="105" stroke="black" stroke-width="0.78"/>
+  <line x1="83.472" y1="111" x2="576" y2="111" stroke="black" stroke-width="0.78"/>
+  <line x1="83.472" y1="87" x2="83.472" y2="159" stroke="black" stroke-width="0.78"/>
+  <use href="#libertinusSerif-g53" xlink:href="#libertinusSerif-g53" transform="translate(36 102.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g70" xlink:href="#libertinusSerif-g70" transform="translate(43.164 102.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g79" xlink:href="#libertinusSerif-g79" transform="translate(48.528 102.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g80" xlink:href="#libertinusSerif-g80" transform="translate(55.032 102.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g83" xlink:href="#libertinusSerif-g83" transform="translate(61.08 102.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g70" xlink:href="#libertinusSerif-g70" transform="translate(65.544 102.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g42" xlink:href="#libertinusSerif-g42" transform="translate(73.908 102.948) scale(0.012 -0.012)"/>
+  <use href="#bravura-g76" xlink:href="#bravura-g76" transform="translate(84.972 105) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(102.576 99) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(109.152 90) scale(0.024 -0.024)"/>
+  <use href="#bravura-g132" xlink:href="#bravura-g132" transform="translate(118.728 99) scale(0.024 -0.024)"/>
+  <line x1="252.279" y1="87" x2="252.279" y2="111" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(146.916 99) scale(0.024 -0.024)"/>
+  <line x1="153.996" y1="78" x2="153.996" y2="99" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(146.916 105) scale(0.024 -0.024)"/>
+  <line x1="146.916" y1="105" x2="146.916" y2="126" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(171.707 96) scale(0.024 -0.024)"/>
+  <line x1="178.787" y1="75" x2="178.787" y2="96" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(171.707 102) scale(0.024 -0.024)"/>
+  <line x1="171.707" y1="102" x2="171.707" y2="123" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(196.499 93) scale(0.024 -0.024)"/>
+  <line x1="203.579" y1="72" x2="203.579" y2="93" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(196.499 99) scale(0.024 -0.024)"/>
+  <line x1="196.499" y1="99" x2="196.499" y2="120" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(221.29 84) scale(0.024 -0.024)"/>
+  <line x1="228.37" y1="63" x2="228.37" y2="84" stroke="black" stroke-width="0.72"/>
+  <path d="M 153.996 105.3 C 176.427 110.28 198.859 95.28 221.29 90.3 L 221.29 89.7 C 198.859 93.72 176.427 108.72 153.996 104.7 Z" fill="black" stroke="none"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(221.29 90) scale(0.024 -0.024)"/>
+  <line x1="221.29" y1="90" x2="221.29" y2="111" stroke="black" stroke-width="0.72"/>
+  <path d="M 153.996 111.3 C 176.427 116.28 198.859 101.28 221.29 96.3 L 221.29 95.7 C 198.859 99.72 176.427 114.72 153.996 110.7 Z" fill="black" stroke="none"/>
+  <line x1="364.723" y1="87" x2="364.723" y2="111" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(259.359 87) scale(0.024 -0.024)"/>
+  <use href="#bravura-g459" xlink:href="#bravura-g459" transform="translate(267.855 84) scale(0.024 -0.024)"/>
+  <line x1="266.439" y1="66" x2="266.439" y2="87" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(259.359 93) scale(0.024 -0.024)"/>
+  <use href="#bravura-g459" xlink:href="#bravura-g459" transform="translate(267.855 90) scale(0.024 -0.024)"/>
+  <line x1="259.359" y1="93" x2="259.359" y2="114" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(320.557 90) scale(0.024 -0.024)"/>
+  <line x1="327.637" y1="69" x2="327.637" y2="90" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(320.557 96) scale(0.024 -0.024)"/>
+  <line x1="320.557" y1="96" x2="320.557" y2="117" stroke="black" stroke-width="0.72"/>
+  <line x1="477.166" y1="87" x2="477.166" y2="111" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(371.803 93) scale(0.024 -0.024)"/>
+  <line x1="378.883" y1="72" x2="378.883" y2="93" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(371.803 99) scale(0.024 -0.024)"/>
+  <line x1="371.803" y1="99" x2="371.803" y2="120" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(396.594 96) scale(0.024 -0.024)"/>
+  <line x1="403.674" y1="75" x2="403.674" y2="96" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(396.594 102) scale(0.024 -0.024)"/>
+  <line x1="396.594" y1="102" x2="396.594" y2="123" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(421.385 93) scale(0.024 -0.024)"/>
+  <line x1="428.465" y1="72" x2="428.465" y2="93" stroke="black" stroke-width="0.72"/>
+  <path d="M 378.883 87.3 C 393.05 83.28 407.218 83.28 421.385 87.3 L 421.385 86.7 C 407.218 81.72 393.05 81.72 378.883 86.7 Z" fill="black" stroke="none"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(421.385 99) scale(0.024 -0.024)"/>
+  <line x1="421.385" y1="99" x2="421.385" y2="120" stroke="black" stroke-width="0.72"/>
+  <path d="M 378.883 105.3 C 393.05 110.28 407.218 110.28 421.385 105.3 L 421.385 104.7 C 407.218 108.72 393.05 108.72 378.883 104.7 Z" fill="black" stroke="none"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(446.177 90) scale(0.024 -0.024)"/>
+  <line x1="453.257" y1="69" x2="453.257" y2="90" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(446.177 96) scale(0.024 -0.024)"/>
+  <line x1="446.177" y1="96" x2="446.177" y2="117" stroke="black" stroke-width="0.72"/>
+  <line x1="576" y1="87" x2="576" y2="111" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(484.246 93) scale(0.024 -0.024)"/>
+  <line x1="491.326" y1="72" x2="491.326" y2="93" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(484.246 99) scale(0.024 -0.024)"/>
+  <line x1="484.246" y1="99" x2="484.246" y2="120" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(519.659 96) scale(0.024 -0.024)"/>
+  <line x1="526.739" y1="75" x2="526.739" y2="96" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(519.659 102) scale(0.024 -0.024)"/>
+  <line x1="519.659" y1="102" x2="519.659" y2="123" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g996" xlink:href="#bravura-g996" transform="translate(544.699 93) scale(0.024 -0.024)"/>
+  <use href="#bravura-g996" xlink:href="#bravura-g996" transform="translate(544.699 105) scale(0.024 -0.024)"/>
+  <line x1="83.472" y1="135" x2="576" y2="135" stroke="black" stroke-width="0.78"/>
+  <line x1="83.472" y1="141" x2="576" y2="141" stroke="black" stroke-width="0.78"/>
+  <line x1="83.472" y1="147" x2="576" y2="147" stroke="black" stroke-width="0.78"/>
+  <line x1="83.472" y1="153" x2="576" y2="153" stroke="black" stroke-width="0.78"/>
+  <line x1="83.472" y1="159" x2="576" y2="159" stroke="black" stroke-width="0.78"/>
+  <use href="#libertinusSerif-g35" xlink:href="#libertinusSerif-g35" transform="translate(42.96 150.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g66" xlink:href="#libertinusSerif-g66" transform="translate(50.016 150.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g84" xlink:href="#libertinusSerif-g84" transform="translate(55.5 150.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g84" xlink:href="#libertinusSerif-g84" transform="translate(60.18 150.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g80" xlink:href="#libertinusSerif-g80" transform="translate(64.86 150.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g42" xlink:href="#libertinusSerif-g42" transform="translate(73.908 150.948) scale(0.012 -0.012)"/>
+  <use href="#bravura-g92" xlink:href="#bravura-g92" transform="translate(84.972 141) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(103.008 147) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(109.584 138) scale(0.024 -0.024)"/>
+  <use href="#bravura-g132" xlink:href="#bravura-g132" transform="translate(119.16 147) scale(0.024 -0.024)"/>
+  <line x1="252.279" y1="135" x2="252.279" y2="159" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g994" xlink:href="#bravura-g994" transform="translate(146.916 141) scale(0.024 -0.024)"/>
+  <line x1="364.723" y1="135" x2="364.723" y2="159" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g996" xlink:href="#bravura-g996" transform="translate(259.359 147) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(284.151 135) scale(0.024 -0.024)"/>
+  <line x1="291.231" y1="114" x2="291.231" y2="135" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(308.942 132) scale(0.024 -0.024)"/>
+  <line x1="316.022" y1="111" x2="316.022" y2="132" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(333.733 129) scale(0.024 -0.024)"/>
+  <line x1="340.813" y1="108" x2="340.813" y2="129" stroke="black" stroke-width="0.72"/>
+  <line x1="331.333" y1="129" x2="343.213" y2="129" stroke="black" stroke-width="0.96"/>
+  <line x1="477.166" y1="135" x2="477.166" y2="159" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(371.803 126) scale(0.024 -0.024)"/>
+  <line x1="378.883" y1="105" x2="378.883" y2="126" stroke="black" stroke-width="0.72"/>
+  <line x1="369.403" y1="129" x2="381.283" y2="129" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g996" xlink:href="#bravura-g996" transform="translate(396.594 147) scale(0.024 -0.024)"/>
+  <use href="#bravura-g996" xlink:href="#bravura-g996" transform="translate(421.385 147) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(446.177 138) scale(0.024 -0.024)"/>
+  <line x1="453.257" y1="117" x2="453.257" y2="138" stroke="black" stroke-width="0.72"/>
+  <line x1="576" y1="135" x2="576" y2="159" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(484.246 135) scale(0.024 -0.024)"/>
+  <line x1="491.326" y1="114" x2="491.326" y2="135" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(519.659 135) scale(0.024 -0.024)"/>
+  <line x1="526.739" y1="114" x2="526.739" y2="135" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g996" xlink:href="#bravura-g996" transform="translate(544.699 147) scale(0.024 -0.024)"/>
+  <line x1="55.368" y1="183" x2="313.489" y2="183" stroke="black" stroke-width="0.78"/>
+  <line x1="55.368" y1="189" x2="313.489" y2="189" stroke="black" stroke-width="0.78"/>
+  <line x1="55.368" y1="195" x2="313.489" y2="195" stroke="black" stroke-width="0.78"/>
+  <line x1="55.368" y1="201" x2="313.489" y2="201" stroke="black" stroke-width="0.78"/>
+  <line x1="55.368" y1="207" x2="313.489" y2="207" stroke="black" stroke-width="0.78"/>
+  <line x1="55.368" y1="183" x2="55.368" y2="267" stroke="black" stroke-width="0.78"/>
+  <use href="#libertinusSerif-g53" xlink:href="#libertinusSerif-g53" transform="translate(36 198.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g15" xlink:href="#libertinusSerif-g15" transform="translate(43.164 198.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g42" xlink:href="#libertinusSerif-g42" transform="translate(45.804 198.948) scale(0.012 -0.012)"/>
+  <use href="#bravura-g76" xlink:href="#bravura-g76" transform="translate(56.868 201) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(74.472 195) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(81.048 186) scale(0.024 -0.024)"/>
+  <line x1="153.216" y1="183" x2="153.216" y2="207" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(102.216 195) scale(0.024 -0.024)"/>
+  <line x1="109.296" y1="174" x2="109.296" y2="195" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g994" xlink:href="#bravura-g994" transform="translate(102.216 195) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(114.216 192) scale(0.024 -0.024)"/>
+  <line x1="121.296" y1="171" x2="121.296" y2="192" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(126.216 189) scale(0.024 -0.024)"/>
+  <line x1="133.296" y1="168" x2="133.296" y2="189" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(138.216 180) scale(0.024 -0.024)"/>
+  <line x1="145.296" y1="159" x2="145.296" y2="180" stroke="black" stroke-width="0.72"/>
+  <path d="M 109.296 201.3 C 118.936 206.28 128.576 191.28 138.216 186.3 L 138.216 185.7 C 128.576 189.72 118.936 204.72 109.296 200.7 Z" fill="black" stroke="none"/>
+  <line x1="211.296" y1="183" x2="211.296" y2="207" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g156" xlink:href="#bravura-g156" transform="translate(160.296 183) scale(0.024 -0.024)"/>
+  <use href="#bravura-g994" xlink:href="#bravura-g994" transform="translate(160.296 195) scale(0.024 -0.024)"/>
+  <line x1="273.529" y1="183" x2="273.529" y2="207" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(218.376 189) scale(0.024 -0.024)"/>
+  <use href="#bravura-g459" xlink:href="#bravura-g459" transform="translate(226.872 186) scale(0.024 -0.024)"/>
+  <line x1="225.456" y1="168" x2="225.456" y2="189" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(218.376 195) scale(0.024 -0.024)"/>
+  <use href="#bravura-g459" xlink:href="#bravura-g459" transform="translate(226.872 192) scale(0.024 -0.024)"/>
+  <line x1="218.376" y1="195" x2="218.376" y2="216" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(233.073 192) scale(0.024 -0.024)"/>
+  <line x1="240.153" y1="171" x2="240.153" y2="192" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g517" xlink:href="#bravura-g517" transform="translate(240.153 171) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(233.073 198) scale(0.024 -0.024)"/>
+  <line x1="233.073" y1="198" x2="233.073" y2="219" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g518" xlink:href="#bravura-g518" transform="translate(233.073 219) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(241.558 189) scale(0.024 -0.024)"/>
+  <line x1="248.638" y1="168" x2="248.638" y2="189" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(241.558 195) scale(0.024 -0.024)"/>
+  <line x1="241.558" y1="195" x2="241.558" y2="216" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(253.558 183) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(253.558 192) scale(0.024 -0.024)"/>
+  <line x1="253.558" y1="192" x2="253.558" y2="213" stroke="black" stroke-width="0.72"/>
+  <path d="M 248.638 201.3 C 250.278 206.28 251.918 203.28 253.558 198.3 L 253.558 197.7 C 251.918 201.72 250.278 204.72 248.638 200.7 Z" fill="black" stroke="none"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(262.044 186) scale(0.024 -0.024)"/>
+  <line x1="260.638" y1="162" x2="260.638" y2="183" stroke="black" stroke-width="0.72"/>
+  <line x1="269.124" y1="162" x2="269.124" y2="186" stroke="black" stroke-width="0.72"/>
+  <line x1="260.638" y1="162" x2="269.124" y2="162" stroke="black" stroke-width="3"/>
+  <path d="M 248.638 183.3 C 253.107 179.28 257.575 176.28 262.044 180.3 L 262.044 179.7 C 257.575 174.72 253.107 177.72 248.638 182.7 Z" fill="black" stroke="none"/>
+  <line x1="311.089" y1="183" x2="311.089" y2="207" stroke="black" stroke-width="0.96"/>
+  <line x1="313.489" y1="183" x2="313.489" y2="207" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(280.609 189) scale(0.024 -0.024)"/>
+  <use href="#bravura-g459" xlink:href="#bravura-g459" transform="translate(289.105 186) scale(0.024 -0.024)"/>
+  <use href="#bravura-g968" xlink:href="#bravura-g968" transform="translate(276.853 177) scale(0.024 -0.024)"/>
+  <line x1="287.689" y1="168" x2="287.689" y2="189" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(280.609 198) scale(0.024 -0.024)"/>
+  <use href="#bravura-g459" xlink:href="#bravura-g459" transform="translate(289.105 198) scale(0.024 -0.024)"/>
+  <use href="#bravura-g968" xlink:href="#bravura-g968" transform="translate(276.853 177) scale(0.024 -0.024)"/>
+  <line x1="280.609" y1="198" x2="280.609" y2="219" stroke="black" stroke-width="0.72"/>
+  <line x1="55.368" y1="243" x2="313.489" y2="243" stroke="black" stroke-width="0.78"/>
+  <line x1="55.368" y1="249" x2="313.489" y2="249" stroke="black" stroke-width="0.78"/>
+  <line x1="55.368" y1="255" x2="313.489" y2="255" stroke="black" stroke-width="0.78"/>
+  <line x1="55.368" y1="261" x2="313.489" y2="261" stroke="black" stroke-width="0.78"/>
+  <line x1="55.368" y1="267" x2="313.489" y2="267" stroke="black" stroke-width="0.78"/>
+  <use href="#libertinusSerif-g35" xlink:href="#libertinusSerif-g35" transform="translate(36.108 258.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g15" xlink:href="#libertinusSerif-g15" transform="translate(43.164 258.948) scale(0.012 -0.012)"/>
+  <use href="#libertinusSerif-g42" xlink:href="#libertinusSerif-g42" transform="translate(45.804 258.948) scale(0.012 -0.012)"/>
+  <use href="#bravura-g92" xlink:href="#bravura-g92" transform="translate(56.868 249) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(74.904 255) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(81.48 246) scale(0.024 -0.024)"/>
+  <line x1="153.216" y1="243" x2="153.216" y2="267" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(102.216 249) scale(0.024 -0.024)"/>
+  <line x1="109.296" y1="228" x2="109.296" y2="249" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(114.216 243) scale(0.024 -0.024)"/>
+  <line x1="121.296" y1="222" x2="121.296" y2="243" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(126.216 234) scale(0.024 -0.024)"/>
+  <line x1="133.296" y1="213" x2="133.296" y2="234" stroke="black" stroke-width="0.72"/>
+  <line x1="123.816" y1="237" x2="135.696" y2="237" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(138.216 225) scale(0.024 -0.024)"/>
+  <line x1="145.296" y1="204" x2="145.296" y2="225" stroke="black" stroke-width="0.72"/>
+  <line x1="135.816" y1="237" x2="147.696" y2="237" stroke="black" stroke-width="0.96"/>
+  <line x1="135.816" y1="231" x2="147.696" y2="231" stroke="black" stroke-width="0.96"/>
+  <line x1="135.816" y1="225" x2="147.696" y2="225" stroke="black" stroke-width="0.96"/>
+  <path d="M 109.296 243.3 C 118.936 239.28 128.576 215.28 138.216 219.3 L 138.216 218.7 C 128.576 213.72 118.936 237.72 109.296 242.7 Z" fill="black" stroke="none"/>
+  <line x1="211.296" y1="243" x2="211.296" y2="267" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g156" xlink:href="#bravura-g156" transform="translate(160.296 228) scale(0.024 -0.024)"/>
+  <line x1="157.896" y1="237" x2="169.776" y2="237" stroke="black" stroke-width="0.96"/>
+  <line x1="157.896" y1="231" x2="169.776" y2="231" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g996" xlink:href="#bravura-g996" transform="translate(160.296 261) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(172.296 255) scale(0.024 -0.024)"/>
+  <line x1="172.296" y1="255" x2="172.296" y2="276" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(184.296 252) scale(0.024 -0.024)"/>
+  <line x1="184.296" y1="252" x2="184.296" y2="273" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(196.296 249) scale(0.024 -0.024)"/>
+  <line x1="196.296" y1="249" x2="196.296" y2="270" stroke="black" stroke-width="0.72"/>
+  <line x1="273.529" y1="243" x2="273.529" y2="267" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(218.376 240) scale(0.024 -0.024)"/>
+  <use href="#bravura-g459" xlink:href="#bravura-g459" transform="translate(226.872 240) scale(0.024 -0.024)"/>
+  <line x1="225.456" y1="219" x2="225.456" y2="240" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(218.376 246) scale(0.024 -0.024)"/>
+  <use href="#bravura-g459" xlink:href="#bravura-g459" transform="translate(226.872 246) scale(0.024 -0.024)"/>
+  <line x1="218.376" y1="246" x2="218.376" y2="267" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(234.529 240) scale(0.024 -0.024)"/>
+  <line x1="241.609" y1="219" x2="241.609" y2="240" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g517" xlink:href="#bravura-g517" transform="translate(241.609 219) scale(0.024 -0.024)"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(234.529 246) scale(0.024 -0.024)"/>
+  <line x1="234.529" y1="246" x2="234.529" y2="267" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g518" xlink:href="#bravura-g518" transform="translate(234.529 267) scale(0.024 -0.024)"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(243.854 240) scale(0.024 -0.024)"/>
+  <line x1="250.934" y1="219" x2="250.934" y2="240" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(243.854 249) scale(0.024 -0.024)"/>
+  <line x1="243.854" y1="249" x2="243.854" y2="270" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(257.043 252) scale(0.024 -0.024)"/>
+  <line x1="257.043" y1="252" x2="257.043" y2="273" stroke="black" stroke-width="0.72"/>
+  <path d="M 250.934 243.3 C 252.971 239.28 255.007 242.28 257.043 246.3 L 257.043 245.7 C 255.007 240.72 252.971 237.72 250.934 242.7 Z" fill="black" stroke="none"/>
+  <line x1="311.089" y1="243" x2="311.089" y2="267" stroke="black" stroke-width="0.96"/>
+  <line x1="313.489" y1="243" x2="313.489" y2="267" stroke="black" stroke-width="0.96"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(280.609 243) scale(0.024 -0.024)"/>
+  <use href="#bravura-g537" xlink:href="#bravura-g537" transform="translate(273.913 243) scale(0.024 -0.024)"/>
+  <use href="#bravura-g459" xlink:href="#bravura-g459" transform="translate(289.105 240) scale(0.024 -0.024)"/>
+  <use href="#bravura-g968" xlink:href="#bravura-g968" transform="translate(276.853 237) scale(0.024 -0.024)"/>
+  <line x1="287.689" y1="222" x2="287.689" y2="243" stroke="black" stroke-width="0.72"/>
+  <use href="#bravura-g157" xlink:href="#bravura-g157" transform="translate(280.609 249) scale(0.024 -0.024)"/>
+  <use href="#bravura-g459" xlink:href="#bravura-g459" transform="translate(289.105 246) scale(0.024 -0.024)"/>
+  <use href="#bravura-g968" xlink:href="#bravura-g968" transform="translate(276.853 237) scale(0.024 -0.024)"/>
+  <line x1="280.609" y1="249" x2="280.609" y2="270" stroke="black" stroke-width="0.72"/>
+</svg>


### PR DESCRIPTION
Closes #83 — the closing fixture of the ABC 2.2 §11.1 milestone.

## The fixture

§7 Zocharti Loch, verbatim: four voices, two on each of two staves via `%%score (T1 T2) (B1 B2)`, octave clefs, `octave=` transposition, and a part that waits out its opening on invisible rests. The hardest shape §11.1 can ask for, and the standard's own worked example of multi-voice abc.

- **`ZochartiLochTests`** (21 tests, parser) — header fields, four voices in `V:` order, `clef=treble-8` → `octaveShift == -8`, `octave=-2` as a transposition rather than a clef, `name=` / `snm=`, the plan flattening to `[[T1,T2],[B1,B2]]` with no spans and no bar-line joins, B2's five bars of invisible `x8` against B1's visible `z8`, slurs, `H` → fermata, `^f` in G minor, and the closing `||`.
- **`ZochartiLochConformanceTests`** (11 tests, renderer) — read back through `CeolKitSVGGeometry` rather than from the layout engine's own beliefs: two systems of two staves (not four), shared x-spans, bar lines aligned across each system, no bracket and no brace, bar lines *not* continued (the plan has no `|`), staff names taken from the top voice, the octave clef glyph, B2's `x8` drawing nothing while B1's lone whole rest stays centred, plus a page snapshot.

## The renderer fix the fixture turned up

Rendering side by side with `abcm2ps -g` showed `clef=treble-8` parsed, carried all the way to the emitter, and then drawn as a plain treble clef. SMuFL draws the octave numeral as part of the glyph, so this is a choice of glyph and nothing else. `clefGlyph(for: ClefSpec)` now makes that choice in one place that both the width reservation and the drawing go through, which also removes the second copy of the clef-glyph table the emitter was keeping. `OctaveClefTests` covers the mapping, including the C-clef fallback — SMuFL defines `cClef8vb` and no other shifted C clef.

## The documentation

`CONFORMANCE.md` is new and linked from the README: the §11.1 grammar, where a plan may be written and what it governs, which voices get printed and with which diagnostic, and — the point of the exercise — the places the standard leaves the answer to the software. The no-directive bar-line default, the shared staff taking its clef, key and name from the voice written first, and a pointer to the floating-voice rule, which stays in `EXTENSIONS.md` because that rule is ours.

## Divergences from abcm2ps, documented rather than changed

- abcm2ps stacks both names beside a shared staff (`Tenore I` over `Tenore II`); CeolKit prints the first voice's alone, because the gutter reserves one line per staff.
- abcm2ps stretches the last system; CeolKit leaves it at natural width, which is the `%%ceolkit:justifylast` default.

1067 tests pass, up from 1029.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UZMQaxNhydatcZ6D281s5