### PR TITLE
Fix #122 — mid-voice [L:] reaches the renderer

### DIFF
--- a/Sources/CeolKitModel/Measure.swift
+++ b/Sources/CeolKitModel/Measure.swift
@@ -23,15 +23,21 @@ public struct Measure: Sendable {
     /// Non-nil when an inline `[M:…]` field changed the meter before this measure.
     /// A renderer should draw the corresponding time-signature glyph before the first note.
     public let meter: Meter?
-    /// Non-nil when an `L:` field changed the unit note length at this measure, after the
-    /// voice had already begun. `nil` means "whatever was in force at the previous measure",
-    /// which for the first measure of a voice is `Voice.unitNoteLength` — the length the
-    /// voice opened in.
+    /// The unit note length this measure's durations are counted in — always the effective
+    /// value, on every measure, not only where an `L:` moved it.
     ///
-    /// `Event` durations are counted in unit note lengths, so this is what says what those
-    /// counts are worth from here on: it is the divisor beaming is decided against, and the
-    /// one a renderer needs to size a note head.
-    public let unitNoteLength: Fraction?
+    /// `Event.duration` is a multiple of this, so it is the divisor beaming is decided
+    /// against and the one a renderer needs to size a note head, a stem and a flag.
+    ///
+    /// This deliberately does not follow the convention `meter` uses, where non-nil means
+    /// "changed here": a renderer must draw a time signature exactly where the meter changes,
+    /// whereas a unit note length is never drawn, only used as a scale. "Always the effective
+    /// value" is the useful shape for a divisor; "only where it changed" is the useful shape
+    /// for something engraved at the point of change.
+    ///
+    /// "Did it change here?" is still recoverable as `m.unitNoteLength != previous`, with
+    /// `Voice.unitNoteLength` as the comparison for a voice's first measure.
+    public let unitNoteLength: Fraction
 
     public init(
         openingBar: BarLine?,
@@ -40,7 +46,7 @@ public struct Measure: Sendable {
         endingNumber: [Int]?,
         source: SourceRange,
         meter: Meter? = nil,
-        unitNoteLength: Fraction? = nil
+        unitNoteLength: Fraction
     ) {
         self.openingBar = openingBar
         self.events = events

--- a/Sources/CeolKitParser/Semantic/BodyContext.swift
+++ b/Sources/CeolKitParser/Semantic/BodyContext.swift
@@ -16,6 +16,13 @@ struct VoiceAccumulator {
     /// The unit note length in force now.  Seeds an `&` layer opened from here, and is what
     /// a further `L:` is measured against.
     var unitNoteLength: Fraction
+    /// The unit note length the measures being closed are counted in — what every closed
+    /// measure is stamped with.
+    ///
+    /// This lags `unitNoteLength` by exactly the deferral `pendingUnitNoteLength` describes:
+    /// an `L:` written against a bar line takes effect at the bar the next note falls in, and
+    /// until that bar closes the measures still being written are in the old unit.
+    var effectiveUnitNoteLength: Fraction
     // Set by VoiceState after a barline when the tune's meter has moved on since this voice
     // last reported it; consumed by the next closeWith to tag that measure for renderers.
     var pendingMeter: Meter? = nil
@@ -31,6 +38,7 @@ struct VoiceAccumulator {
         self.measureSource = source
         self.openingUnitNoteLength = unitNoteLength
         self.unitNoteLength = unitNoteLength
+        self.effectiveUnitNoteLength = unitNoteLength
     }
 
     /// How many staves of this voice are finished — the index of the stave now being
@@ -94,7 +102,8 @@ struct VoiceAccumulator {
             closingBar: BarLine(kind: .single, source: source),
             endingNumber: nil,
             source: source,
-            meter: nil
+            meter: nil,
+            unitNoteLength: effectiveUnitNoteLength
         ))
     }
 
@@ -127,10 +136,9 @@ struct VoiceAccumulator {
         )
         let meterTag = pendingMeter
         pendingMeter = nil
-        var unitTag: Fraction? = nil
         if let change = pendingUnitNoteLength {
             if musicalEventCount > change.after {
-                unitTag = change.length
+                effectiveUnitNoteLength = change.length
                 pendingUnitNoteLength = nil
             } else {
                 pendingUnitNoteLength = (change.length, 0)
@@ -143,7 +151,7 @@ struct VoiceAccumulator {
             endingNumber: endingNumber,
             source: src,
             meter: meterTag,
-            unitNoteLength: unitTag
+            unitNoteLength: effectiveUnitNoteLength
         )
         closedMeasures.append(measure)
         currentEvents = []
@@ -279,6 +287,7 @@ struct VoiceState {
         } else {
             openingUnitNoteLength = length
             accumulator.openingUnitNoteLength = length
+            accumulator.effectiveUnitNoteLength = length
         }
     }
 

--- a/Sources/CeolKitParser/Semantic/SemanticPass.swift
+++ b/Sources/CeolKitParser/Semantic/SemanticPass.swift
@@ -1126,7 +1126,9 @@ struct SemanticPass {
                     layers.append((overlay.source, overlayMeasures))
                 }
                 let barsWritten = measures.count
-                diagnostics += reconcileOverlays(&measures, with: &layers, voiceId: voiceId)
+                diagnostics += reconcileOverlays(
+                    &measures, with: &layers, voiceId: voiceId,
+                    unitNoteLength: accumulator.effectiveUnitNoteLength)
                 // An overlay that overran gives the voice bars past the end of its last line.
                 // They are that line's — the source wrote them there — so the boundary
                 // recorded at what used to be the end is no longer a boundary at all.
@@ -1192,7 +1194,8 @@ struct SemanticPass {
     private func reconcileOverlays(
         _ measures: inout [Measure],
         with layers: inout [(source: SourceRange, measures: [Measure])],
-        voiceId: String
+        voiceId: String,
+        unitNoteLength: Fraction
     ) -> [Diagnostic] {
         guard !layers.isEmpty else { return [] }
         var diagnostics: [Diagnostic] = []
@@ -1211,34 +1214,44 @@ struct SemanticPass {
 
         let width = max(measures.count, layers.map(\.measures.count).max() ?? 0)
         let tail = measures.last
-        measures += (measures.count..<width).map { _ in emptyMeasure(after: tail) }
+        let tailUnit = tail?.unitNoteLength ?? unitNoteLength
+        measures += (measures.count..<width).map { _ in
+            emptyMeasure(after: tail, unitNoteLength: tailUnit)
+        }
         for index in layers.indices {
             let source = layers[index].source
+            let layerUnit = layers[index].measures.last?.unitNoteLength ?? unitNoteLength
             layers[index].measures += (layers[index].measures.count..<width).map { _ in
-                emptyMeasure(after: nil, at: source)
+                emptyMeasure(after: nil, unitNoteLength: layerUnit, at: source)
             }
         }
         return diagnostics
     }
 
     /// A bar with no music in it, for a voice or an overlay that has nothing to say here.
-    private func emptyMeasure(after previous: Measure?, at source: SourceRange? = nil) -> Measure {
+    ///
+    /// `unitNoteLength` is the one in force where the bar is being added: the last real
+    /// measure's, or the voice's own where there is no real measure to follow.
+    private func emptyMeasure(after previous: Measure?, unitNoteLength: Fraction,
+                              at source: SourceRange? = nil) -> Measure {
         let src = source ?? previous?.source ?? .emptySourceRange
         return Measure(openingBar: previous?.closingBar,
                        events: [],
                        closingBar: BarLine(kind: .single, source: src),
                        endingNumber: nil,
                        source: src,
-                       meter: nil)
+                       meter: nil,
+                       unitNoteLength: unitNoteLength)
     }
 
     /// Closes a voice out into measures: the last open bar, tie resolution across the whole
     /// voice, and beaming.
     ///
     /// `openingMeter` is the meter the voice's *first* measure is in, not the one the body
-    /// ended in.  Meter and unit note length both move part way through a tune, and both are
-    /// recorded where they move — `Measure.meter`, `Measure.unitNoteLength` — so the beams are
-    /// grouped measure by measure against whatever was in force there (#85).
+    /// ended in.  Meter and unit note length both move part way through a tune, and every
+    /// measure knows which it is in — `Measure.meter` where the meter moved, and
+    /// `Measure.unitNoteLength` always — so the beams are grouped measure by measure against
+    /// whatever was in force there (#85, #122).
     private func finaliseAccumulator(
         _ acc: VoiceAccumulator, openingMeter: Meter
     ) -> ([Measure], [Diagnostic]) {
@@ -1260,6 +1273,12 @@ struct SemanticPass {
                 closingBar: finalBar,
                 fallback: acc.measureSource
             )
+            // An `L:` still pending at the end of the voice lands on this bar exactly where
+            // `closeWith` would have put it: on the bar the music after it fell in.
+            var finalUnit = acc.effectiveUnitNoteLength
+            if let change = acc.pendingUnitNoteLength, acc.musicalEventCount > change.after {
+                finalUnit = change.length
+            }
             let finalMeasure = Measure(
                 openingBar: acc.lastBarLine,
                 events: acc.currentEvents,
@@ -1267,9 +1286,7 @@ struct SemanticPass {
                 endingNumber: nil,
                 source: src,
                 meter: acc.pendingMeter,
-                unitNoteLength: acc.pendingUnitNoteLength.flatMap {
-                    acc.musicalEventCount > $0.after ? $0.length : nil
-                }
+                unitNoteLength: finalUnit
             )
             measures.append(finalMeasure)
         }
@@ -1319,17 +1336,18 @@ struct SemanticPass {
         }
 
         // Beam measure by measure, against the meter and unit note length in force *there*.
-        // Both start at what the voice opened in and move wherever a measure records a change;
-        // a tune that changes neither builds one resolver and uses it throughout.
+        // Both start at what the voice opened in; the meter moves where a measure records a
+        // change and the unit note length wherever a measure differs from the last.  A tune
+        // that changes neither builds one resolver and uses it throughout.
         var currentMeter = openingMeter
         var currentUnit = acc.openingUnitNoteLength
         var resolver = BeamResolver(meter: currentMeter, unitNoteLength: currentUnit)
         var beamResolved: [Measure] = []
         beamResolved.reserveCapacity(resolvedMeasures.count)
         for m in resolvedMeasures {
-            if m.meter != nil || m.unitNoteLength != nil {
+            if m.meter != nil || m.unitNoteLength != currentUnit {
                 currentMeter = m.meter ?? currentMeter
-                currentUnit = m.unitNoteLength ?? currentUnit
+                currentUnit = m.unitNoteLength
                 resolver = BeamResolver(meter: currentMeter, unitNoteLength: currentUnit)
             }
             beamResolved.append(Measure(

--- a/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
+++ b/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
@@ -106,12 +106,12 @@ public struct SVGRenderer: CeolKitRenderer {
                 let printedVoices = selection.voices
                 guard !printedVoices.isEmpty else { continue }
 
-                // §7.3: a voice states its own `K:` and `L:` where it needs them, and the
-                // tune's stand in where it does not.  Resolved once here — every measure of
-                // a voice is sized against the same unit note length, and its staff head
-                // draws the same key.
+                // §7.3: a voice states its own `K:` where it needs one, and the tune's stands
+                // in where it does not.  Resolved once here — every staff head of the voice
+                // draws the same key.  The unit note length is *not* resolved here: an `L:`
+                // moves it part way through a voice, so it is the measure that carries it
+                // (issue #122).
                 let voiceKeys = printedVoices.map { tune.effectiveKey(for: $0) }
-                let voiceUnitLengths = printedVoices.map { tune.effectiveUnitNoteLength(for: $0) }
 
                 // Bring the voices into agreement about how much music each source line
                 // holds, so the break points chosen below are legal for every one of them.
@@ -141,7 +141,6 @@ public struct SVGRenderer: CeolKitRenderer {
                                 sizer.size(sharedStaff: members.enumerated().map { position, voice in
                                     MeasureSizer.SharedVoice(
                                         measure: stave.measures[voice][column],
-                                        unitNoteLength: voiceUnitLengths[voice],
                                         voiceIndex: position,
                                         isPadding: stave.isPadding(voice: voice, column: column))
                                 }))

--- a/Sources/CeolKitSVGRenderer/Layout/MeasureSizer.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/MeasureSizer.swift
@@ -18,15 +18,15 @@ public struct MeasureSizer: Sendable {
     /// Sizes a single measure.
     ///
     /// - Parameters:
-    ///   - measure: The measure to size.
-    ///   - unitNoteLength: The voice's `L:` value (e.g. `Fraction(1, 8)` for eighth-note unit).
-    ///     Used to convert `Note.duration` multipliers to an absolute quarter-note reference.
+    ///   - measure: The measure to size.  Its own ``Measure/unitNoteLength`` is what converts
+    ///     `Note.duration` multipliers to an absolute quarter-note reference, so a bar after a
+    ///     mid-voice `L:` is sized in the unit it is actually written in (issue #122).
     ///   - voiceIndex: Which voice of its staff the measure belongs to.  Every event is
     ///     tagged with it, so the passes below can tell the voices of a shared staff apart
     ///     without the layout types growing a second dimension.  A staff with one voice —
     ///     which is every staff but a `( … )` group — passes `0`.
-    public func size(_ measure: Measure, unitNoteLength: Fraction,
-                     voiceIndex: Int = 0) -> SizedMeasure {
+    public func size(_ measure: Measure, voiceIndex: Int = 0) -> SizedMeasure {
+        let unitNoteLength = measure.unitNoteLength
         // Quarter-note duration expressed in unit-note-length units.
         // e.g. unitNoteLength = 1/8 → quarterInUnits = 2.0
         let unl = Double(unitNoteLength.numerator) / Double(unitNoteLength.denominator)
@@ -88,30 +88,27 @@ public struct MeasureSizer: Sendable {
     public func size(sharedStaff parts: [SharedVoice]) -> SizedMeasure {
         let sounding = parts.filter { !$0.isPadding }
         if let only = sounding.count == 1 ? sounding[0] : nil {
-            return size(only.measure, unitNoteLength: only.unitNoteLength,
-                        voiceIndex: only.voiceIndex)
+            return size(only.measure, voiceIndex: only.voiceIndex)
         }
         return merger.merge(parts.map {
-            SharedStaffMerger.VoicePart(measure: $0.measure, unitNoteLength: $0.unitNoteLength,
-                                        voiceIndex: $0.voiceIndex, isPadding: $0.isPadding)
+            SharedStaffMerger.VoicePart(measure: $0.measure, voiceIndex: $0.voiceIndex,
+                                        isPadding: $0.isPadding)
         })
     }
 
     /// One voice's contribution to one bar of a shared staff.
     public struct SharedVoice: Sendable {
+        /// The bar to size.  It carries the unit note length its own durations are counted
+        /// in, which §7.3 lets the voices of one staff differ over.
         public let measure: Measure
-        /// The voice's own `L:`; §7.3 lets the voices of one staff differ.
-        public let unitNoteLength: Fraction
         /// The voice's position within the staff, top to bottom.
         public let voiceIndex: Int
         /// `true` when ``VoiceAligner`` invented this measure to keep the staves the same
         /// length.  Padding is dropped by the merge, never spaced.
         public let isPadding: Bool
 
-        public init(measure: Measure, unitNoteLength: Fraction, voiceIndex: Int,
-                    isPadding: Bool) {
+        public init(measure: Measure, voiceIndex: Int, isPadding: Bool) {
             self.measure = measure
-            self.unitNoteLength = unitNoteLength
             self.voiceIndex = voiceIndex
             self.isPadding = isPadding
         }

--- a/Sources/CeolKitSVGRenderer/Layout/SharedStaffMerger.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/SharedStaffMerger.swift
@@ -47,9 +47,9 @@ struct SharedStaffMerger: Sendable {
 
     /// One voice's contribution to one bar of a shared staff.
     struct VoicePart {
+        /// The bar this voice contributes.  Its ``Measure/unitNoteLength`` is the voice's own
+        /// `L:` here, which its co-tenants need not share (§7.3).
         let measure: Measure
-        /// The voice's own `L:`, which its co-tenants need not share (§7.3).
-        let unitNoteLength: Fraction
         /// The voice's position within the staff, top to bottom.  This is what
         /// ``SizedMeasure/eventVoiceIndices`` carries.
         let voiceIndex: Int
@@ -78,6 +78,7 @@ struct SharedStaffMerger: Sendable {
         guard let primary = sounding.first ?? parts.first else {
             return SizedMeasure(measure: emptyMeasure(), naturalWidth: 0, eventOffsets: [])
         }
+        let unitNoteLength = primary.measure.unitNoteLength
         let voices = sounding.map { Prepared(part: $0, metrics: metrics) }
 
         // The bar's clock runs as far as its longest voice.  The last column is spaced for
@@ -152,10 +153,10 @@ struct SharedStaffMerger: Sendable {
                              closingBar: primary.measure.closingBar,
                              endingNumber: primary.measure.endingNumber,
                              source: primary.measure.source, meter: primary.measure.meter,
-                             unitNoteLength: primary.measure.unitNoteLength),
+                             unitNoteLength: unitNoteLength),
             naturalWidth: naturalWidth,
             eventOffsets: offsets,
-            unitNoteLength: primary.unitNoteLength,
+            unitNoteLength: unitNoteLength,
             graceEventIndices: graceEventIndices,
             eventVoiceIndices: voiceTags)
     }
@@ -164,7 +165,8 @@ struct SharedStaffMerger: Sendable {
     private func emptyMeasure() -> Measure {
         let bar = BarLine(kind: .single, source: .emptySourceRange)
         return Measure(openingBar: nil, events: [], closingBar: bar, endingNumber: nil,
-                       source: .emptySourceRange)
+                       source: .emptySourceRange,
+                       unitNoteLength: Fraction(numerator: 1, denominator: 8))
     }
 
     // MARK: - One voice, cut into onsets
@@ -188,14 +190,15 @@ struct SharedStaffMerger: Sendable {
 
         init(part: VoicePart, metrics: ColumnMetrics) {
             self.part = part
-            let unl = Double(part.unitNoteLength.numerator) / Double(part.unitNoteLength.denominator)
+            let unitNoteLength = part.measure.unitNoteLength
+            let unl = Double(unitNoteLength.numerator) / Double(unitNoteLength.denominator)
             self.quarterInUnits = 0.25 / unl
 
             var slots: [Slot] = []
             var pending: [Int] = []
             var onset = Rational.zero
             for (index, event) in part.measure.events.enumerated() {
-                let duration = Rational.quarters(of: event, unitNoteLength: part.unitNoteLength)
+                let duration = Rational.quarters(of: event, unitNoteLength: unitNoteLength)
                 guard duration > .zero else {
                     // Grace groups, spacers, directive anchors, tempo changes: they take
                     // width but no time, so they belong to the onset they lead up to.
@@ -272,7 +275,7 @@ struct SharedStaffMerger: Sendable {
         /// the whole of what the sizer is asking.
         private static func heads(of event: Event, voice: Prepared,
                                   metrics: ColumnMetrics) -> [CollisionHead] {
-            let unl = voice.part.unitNoteLength
+            let unl = voice.part.measure.unitNoteLength
             func head(_ note: Note) -> CollisionHead {
                 let duration = Double(note.duration.numerator) / Double(note.duration.denominator)
                     * Double(unl.numerator) / Double(unl.denominator)

--- a/Sources/CeolKitSVGRenderer/Layout/VoiceAligner.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VoiceAligner.swift
@@ -64,6 +64,13 @@ enum VoiceAligner {
         // Running measure index across the whole tune, so a diagnostic can name the bar the
         // reader would count to rather than a position within some line.
         var measureOrigin = 0
+        // The unit note length each voice's filler is written in, carried across staves so a
+        // voice that skips a line entirely still pads in the unit it was last in.
+        var fillUnits = voices.map { voice in
+            voice.staves.lazy.flatMap(\.measures).first?.unitNoteLength
+                ?? voice.unitNoteLength
+                ?? Fraction(numerator: 1, denominator: 8)
+        }
 
         for staveIndex in 0..<staveCount {
             let perVoice = voices.map { $0.staves.indices.contains(staveIndex) ? $0.staves[staveIndex].measures : [] }
@@ -74,7 +81,15 @@ enum VoiceAligner {
                 diagnostics.append(diagnostic)
             }
 
-            result.append(AlignedStave(measures: perVoice.map { pad($0, to: width) },
+            // Padding is written in whatever unit note length the voice is in here: the last
+            // real measure's, or — for a stave the voice supplied nothing for — the one it
+            // was in when it last had something to say (issue #122).
+            let padded = perVoice.indices.map { voice -> [Measure] in
+                let unit = perVoice[voice].last?.unitNoteLength ?? fillUnits[voice]
+                fillUnits[voice] = unit
+                return pad(perVoice[voice], to: width, unitNoteLength: unit)
+            }
+            result.append(AlignedStave(measures: padded,
                                        realMeasureCounts: perVoice.map(\.count)))
             measureOrigin += width
         }
@@ -125,7 +140,8 @@ enum VoiceAligner {
     /// The padding borrows the source range of the measure it follows so the padded bars
     /// still point somewhere real in the file; where there is nothing to follow — a voice
     /// that supplied no measures for this line at all — it falls back to the empty range.
-    private static func pad(_ measures: [Measure], to width: Int) -> [Measure] {
+    private static func pad(_ measures: [Measure], to width: Int,
+                            unitNoteLength: Fraction) -> [Measure] {
         guard measures.count < width else { return measures }
         let source = measures.last?.source ?? .emptySourceRange
         let bar = BarLine(kind: .single, source: source)
@@ -133,7 +149,8 @@ enum VoiceAligner {
                         duration: Fraction(numerator: 1, denominator: 1),
                         decorations: [], source: source)
         let filler = Measure(openingBar: bar, events: [.rest(rest)], closingBar: bar,
-                             endingNumber: nil, source: source)
+                             endingNumber: nil, source: source,
+                             unitNoteLength: unitNoteLength)
         return measures + Array(repeating: filler, count: width - measures.count)
     }
 }

--- a/Tests/CeolKitParserTests/InlineLengthAndMeterBeamingTests.swift
+++ b/Tests/CeolKitParserTests/InlineLengthAndMeterBeamingTests.swift
@@ -12,6 +12,9 @@ import CeolKitModel
 @Suite("Inline [L:] and [M:] reach the beam resolver")
 struct InlineLengthAndMeterBeamingTests {
 
+    private let quarter = Fraction(numerator: 1, denominator: 4)
+    private let eighth  = Fraction(numerator: 1, denominator: 8)
+
     private func measures(_ abc: String, voice: Int = 0) -> [Measure] {
         let score = CeolKitParser().parse(abc, options: .default).score
         return score.tunes[0].voices[voice].staves.flatMap(\.measures)
@@ -58,10 +61,11 @@ struct InlineLengthAndMeterBeamingTests {
         """)
         try #require(bars.count == 3)
 
-        #expect(bars[0].unitNoteLength == nil)
-        #expect(bars[1].unitNoteLength == Fraction(numerator: 1, denominator: 8))
-        // Not restated: the change carries forward on its own.
-        #expect(bars[2].unitNoteLength == nil)
+        #expect(bars[0].unitNoteLength == quarter)
+        #expect(bars[1].unitNoteLength == eighth)
+        // Not restated: every measure carries the effective value, so the change is simply
+        // still there in the next bar (#122).
+        #expect(bars[2].unitNoteLength == eighth)
         #expect(beams(bars[2]) == [.start, .middle, .middle, .end,
                                    .start, .middle, .middle, .end])
     }
@@ -76,7 +80,9 @@ struct InlineLengthAndMeterBeamingTests {
         [L:1/8] cdef gabc' |
         """)
         try #require(bars.count == 1)
-        #expect(bars[0].unitNoteLength == nil)
+        // Recorded as the measure's own unit either way; what makes it an opening rather
+        // than a change is that `Voice.unitNoteLength` moved with it.
+        #expect(bars[0].unitNoteLength == eighth)
         #expect(beams(bars[0]) == [.start, .middle, .middle, .end,
                                    .start, .middle, .middle, .end])
 
@@ -100,8 +106,8 @@ struct InlineLengthAndMeterBeamingTests {
         C D | E [L:1/8] cdef |
         """)
         try #require(bars.count == 2)
-        #expect(bars[0].unitNoteLength == nil)
-        #expect(bars[1].unitNoteLength == Fraction(numerator: 1, denominator: 8))
+        #expect(bars[0].unitNoteLength == quarter)
+        #expect(bars[1].unitNoteLength == eighth)
     }
 
     @Test("An [L:] written against the bar line governs the bar after it")
@@ -114,8 +120,8 @@ struct InlineLengthAndMeterBeamingTests {
         C D E F [L:1/8] | cdef gabc' |
         """)
         try #require(bars.count == 2)
-        #expect(bars[0].unitNoteLength == nil)
-        #expect(bars[1].unitNoteLength == Fraction(numerator: 1, denominator: 8))
+        #expect(bars[0].unitNoteLength == quarter)
+        #expect(bars[1].unitNoteLength == eighth)
 
         #expect(beams(bars[0]) == [.single, .single, .single, .single])
         #expect(beams(bars[1]) == [.start, .middle, .middle, .end,
@@ -176,8 +182,8 @@ struct InlineLengthAndMeterBeamingTests {
         try #require(one.count == 2)
         try #require(two.count == 2)
 
-        #expect(one[1].unitNoteLength == Fraction(numerator: 1, denominator: 8))
-        #expect(two[1].unitNoteLength == nil)
+        #expect(one[1].unitNoteLength == eighth)
+        #expect(two[1].unitNoteLength == quarter)
         #expect(beams(one[1]) == [.start, .middle, .middle, .end,
                                   .start, .middle, .middle, .end])
         #expect(beams(two[1]) == Array(repeating: .single, count: 8))
@@ -193,7 +199,7 @@ struct InlineLengthAndMeterBeamingTests {
         GAB cBA | GAB d3 |
         """)
         try #require(bars.count == 2)
-        #expect(bars.allSatisfy { $0.unitNoteLength == nil })
+        #expect(bars.allSatisfy { $0.unitNoteLength == eighth })
         #expect(beams(bars[0]) == [.start, .middle, .end, .start, .middle, .end])
         #expect(beams(bars[1]) == [.start, .middle, .end, .single])
     }

--- a/Tests/CeolKitSVGRendererTests/EventVoiceTagTests.swift
+++ b/Tests/CeolKitSVGRendererTests/EventVoiceTagTests.swift
@@ -28,8 +28,7 @@ struct EventVoiceTagTests {
     func sizerTagsEveryEvent() {
         let measure = parseMeasure("X:1\nL:1/8\nK:C\nCDEF GABc|\n")
         let sizer   = MeasureSizer(config: config, metadata: metadata)
-        let sized   = sizer.size(measure, unitNoteLength: Fraction(numerator: 1, denominator: 8),
-                                 voiceIndex: 3)
+        let sized   = sizer.size(measure, voiceIndex: 3)
 
         #expect(sized.eventVoiceIndices.count == sized.eventOffsets.count)
         #expect(sized.eventVoiceIndices.allSatisfy { $0 == 3 })
@@ -39,14 +38,15 @@ struct EventVoiceTagTests {
     func sizerDefaultsToVoiceZero() {
         let measure = parseMeasure("X:1\nL:1/8\nK:C\nCDEF|\n")
         let sized   = MeasureSizer(config: config, metadata: metadata)
-            .size(measure, unitNoteLength: Fraction(numerator: 1, denominator: 8))
+            .size(measure)
         #expect(sized.eventVoiceIndices == [0, 0, 0, 0])
     }
 
     @Test("A hand-built SizedMeasure gets a table parallel to its offsets")
     func handBuiltMeasureIsStillParallel() {
         let sized = SizedMeasure(measure: Measure(openingBar: nil, events: [], closingBar: dummyBar,
-                                                  endingNumber: nil, source: dummyRange),
+                                                  endingNumber: nil, source: dummyRange,
+                                                  unitNoteLength: Fraction(numerator: 1, denominator: 8)),
                                  naturalWidth: 100, eventOffsets: [0, 10, 20])
         #expect(sized.eventVoiceIndices == [0, 0, 0])
     }
@@ -61,7 +61,7 @@ struct EventVoiceTagTests {
     func justificationPreservesTags() {
         let measure = parseMeasure("X:1\nL:1/8\nK:C\n{g}A B {ge}c d|\n")
         let sized   = MeasureSizer(config: config, metadata: metadata)
-            .size(measure, unitNoteLength: Fraction(numerator: 1, denominator: 8), voiceIndex: 1)
+            .size(measure, voiceIndex: 1)
         #expect(!sized.graceEventIndices.isEmpty)
 
         let system = System(measures: [sized], isLastSystem: false, sourceForced: false)
@@ -80,7 +80,7 @@ struct EventVoiceTagTests {
     func resolvedEventsCarryTheTag() {
         let measure = parseMeasure("X:1\nL:1/8\nK:C\nCDEF GABc|\n")
         let sized   = MeasureSizer(config: config, metadata: metadata)
-            .size(measure, unitNoteLength: Fraction(numerator: 1, denominator: 8), voiceIndex: 2)
+            .size(measure, voiceIndex: 2)
         let jm = JustifiedMeasure(source: sized, finalWidth: sized.naturalWidth,
                                   eventOffsets: sized.eventOffsets)
         let system = JustifiedSystem(measures: [jm], isLastSystem: true, sourceForced: false)
@@ -122,9 +122,7 @@ struct EventVoiceTagTests {
                 breaks.append(nil)
                 for v in voices.indices {
                     columnsPerVoice[v].append(
-                        sizer.size(stave.measures[v][column],
-                                   unitNoteLength: tune.effectiveUnitNoteLength(for: voices[v]),
-                                   voiceIndex: v))
+                        sizer.size(stave.measures[v][column], voiceIndex: v))
                 }
             }
         }

--- a/Tests/CeolKitSVGRendererTests/IntegrationTests.swift
+++ b/Tests/CeolKitSVGRendererTests/IntegrationTests.swift
@@ -29,7 +29,7 @@ private func makeNote(step: DiatonicStep, octave: Int, duration: Fraction,
 
 private func makeMeasure(events: [Event], closing: BarLine = singleBar) -> Measure {
     Measure(openingBar: nil, events: events, closingBar: closing,
-            endingNumber: nil, source: dummyRange)
+            endingNumber: nil, source: dummyRange, unitNoteLength: Fraction(numerator: 1, denominator: 8))
 }
 
 private func makeVoice(id: String, measures: [Measure]) -> Voice {

--- a/Tests/CeolKitSVGRendererTests/JustifierTests.swift
+++ b/Tests/CeolKitSVGRendererTests/JustifierTests.swift
@@ -14,7 +14,8 @@ private func sizedMeasure(width: Double, offsets: [Double] = [],
         events: [],
         closingBar: dummyBar,
         endingNumber: nil,
-        source: dummyRange
+        source: dummyRange,
+        unitNoteLength: Fraction(numerator: 1, denominator: 8)
     )
     return SizedMeasure(measure: m, naturalWidth: width, eventOffsets: offsets,
                         graceEventIndices: graceEventIndices)
@@ -275,8 +276,9 @@ private let usableWidth: Double = 300
         )
         let m = Measure(openingBar: nil,
                         events: [.grace(grace), .note(principal)],
-                        closingBar: dummyBar, endingNumber: nil, source: dummyRange)
-        let sized = sizer.size(m, unitNoteLength: Fraction(numerator: 1, denominator: 8))
+                        closingBar: dummyBar, endingNumber: nil, source: dummyRange,
+                        unitNoteLength: Fraction(numerator: 1, denominator: 8))
+        let sized = sizer.size(m)
 
         // Grace is the first event (index 0); it must appear in graceEventIndices.
         #expect(sized.graceEventIndices.contains(0))

--- a/Tests/CeolKitSVGRendererTests/LineBreakBalanceTests.swift
+++ b/Tests/CeolKitSVGRendererTests/LineBreakBalanceTests.swift
@@ -59,7 +59,7 @@ struct LineBreakBalanceTests {
             let isLast = si == voice.staves.count - 1
             for (mi, m) in stave.measures.enumerated() {
                 pairs.append((
-                    measure: sizer.size(m, unitNoteLength: tune.unitNoteLength),
+                    measure: sizer.size(m),
                     breakAfter: (!isLast && mi == stave.measures.count - 1) ? .hard : nil
                 ))
             }

--- a/Tests/CeolKitSVGRendererTests/LineBreakerTests.swift
+++ b/Tests/CeolKitSVGRendererTests/LineBreakerTests.swift
@@ -13,7 +13,8 @@ private func sizedMeasure(width: Double) -> SizedMeasure {
         events: [],
         closingBar: dummyBar,
         endingNumber: nil,
-        source: dummyRange
+        source: dummyRange,
+        unitNoteLength: Fraction(numerator: 1, denominator: 8)
     )
     return SizedMeasure(measure: m, naturalWidth: width, eventOffsets: [])
 }

--- a/Tests/CeolKitSVGRendererTests/MeasureSizerTests.swift
+++ b/Tests/CeolKitSVGRendererTests/MeasureSizerTests.swift
@@ -34,7 +34,8 @@ private func measure(events: [Event]) -> Measure {
         events: events,
         closingBar: dummyBar,
         endingNumber: nil,
-        source: dummyRange
+        source: dummyRange,
+        unitNoteLength: unitNoteLength
     )
 }
 
@@ -51,21 +52,21 @@ private func measure(events: [Event]) -> Measure {
 
     @Test func wholeNoteHasPositiveNaturalWidth() {
         let m = measure(events: [.note(note(duration: Fraction(numerator: 8, denominator: 1)))])
-        let sized = sizer.size(m, unitNoteLength: unitNoteLength)
+        let sized = sizer.size(m)
         #expect(sized.naturalWidth > 0)
     }
 
     @Test func fourQuarterNotesProduceCorrectOffsetCount() {
         let quarter = Fraction(numerator: 2, denominator: 1)
         let events: [Event] = (0..<4).map { _ in .note(note(duration: quarter)) }
-        let sized = sizer.size(measure(events: events), unitNoteLength: unitNoteLength)
+        let sized = sizer.size(measure(events: events))
         #expect(sized.eventOffsets.count == 4)
     }
 
     @Test func quarterNoteOffsetsAreStrictlyIncreasing() {
         let quarter = Fraction(numerator: 2, denominator: 1)
         let events: [Event] = (0..<4).map { _ in .note(note(duration: quarter)) }
-        let sized = sizer.size(measure(events: events), unitNoteLength: unitNoteLength)
+        let sized = sizer.size(measure(events: events))
         for i in 1..<sized.eventOffsets.count {
             #expect(sized.eventOffsets[i] > sized.eventOffsets[i - 1])
         }
@@ -78,7 +79,7 @@ private func measure(events: [Event]) -> Measure {
                        ?? config.staffSize * 1.2
         let quarter = Fraction(numerator: 2, denominator: 1)
         let events: [Event] = [.note(note(duration: quarter))]
-        let sized = sizer.size(measure(events: events), unitNoteLength: unitNoteLength)
+        let sized = sizer.size(measure(events: events))
         #expect(abs(sized.eventOffsets[0] - noteW) < 0.001)
     }
 
@@ -89,8 +90,8 @@ private func measure(events: [Event]) -> Measure {
         let quarterMeasure = measure(events: [.note(note(duration: quarterDur))])
         let wholeMeasure   = measure(events: [.note(note(duration: wholeDur))])
 
-        let quarterSized = sizer.size(quarterMeasure, unitNoteLength: unitNoteLength)
-        let wholeSized   = sizer.size(wholeMeasure,   unitNoteLength: unitNoteLength)
+        let quarterSized = sizer.size(quarterMeasure)
+        let wholeSized   = sizer.size(wholeMeasure)
 
         // Quarter column width = naturalWidth − bar padding; whole column must be wider.
         let barPad = SVGRenderConfig().staffSize * 0.5
@@ -104,8 +105,8 @@ private func measure(events: [Event]) -> Measure {
         let plain  = measure(events: [.note(note(duration: quarter))])
         let sharp  = measure(events: [.note(note(duration: quarter, accidental: .sharp))])
 
-        let plainSized = sizer.size(plain, unitNoteLength: unitNoteLength)
-        let sharpSized = sizer.size(sharp, unitNoteLength: unitNoteLength)
+        let plainSized = sizer.size(plain)
+        let sharpSized = sizer.size(sharp)
 
         #expect(sharpSized.naturalWidth > plainSized.naturalWidth)
     }
@@ -117,7 +118,7 @@ private func measure(events: [Event]) -> Measure {
         let grace = GraceGroup(kind: .appoggiatura, notes: [gNote], source: dummyRange)
         let quarter = Fraction(numerator: 2, denominator: 1)
         let events: [Event] = [.grace(grace), .note(note(duration: quarter))]
-        let sized = sizer.size(measure(events: events), unitNoteLength: unitNoteLength)
+        let sized = sizer.size(measure(events: events))
 
         #expect(sized.eventOffsets.count == 2)
         #expect(sized.eventOffsets[1] > sized.eventOffsets[0])
@@ -141,7 +142,7 @@ private func measure(events: [Event]) -> Measure {
         let grace = GraceGroup(kind: .appoggiatura, notes: [gNote], source: dummyRange)
         let quarter = Fraction(numerator: 2, denominator: 1)
         let events: [Event] = [.grace(grace), .note(note(duration: quarter))]
-        let sized = sizer.size(measure(events: events), unitNoteLength: unitNoteLength)
+        let sized = sizer.size(measure(events: events))
 
         #expect(abs(sized.eventOffsets[1] - expectedNoteOffset) < 0.001)
     }
@@ -156,8 +157,8 @@ private func measure(events: [Event]) -> Measure {
         let pairedMeasure = measure(events: [.grace(grace), .note(note(duration: quarter))])
         let twoNoteMeasure = measure(events: [.note(note(duration: quarter)), .note(note(duration: quarter))])
 
-        let pairedSized   = sizer.size(pairedMeasure,   unitNoteLength: unitNoteLength)
-        let twoNoteSized  = sizer.size(twoNoteMeasure,  unitNoteLength: unitNoteLength)
+        let pairedSized   = sizer.size(pairedMeasure)
+        let twoNoteSized  = sizer.size(twoNoteMeasure)
 
         // Grace+note pair is narrower than two independent notes
         // (grace group is smaller than a full note column).
@@ -208,8 +209,8 @@ private func measure(events: [Event]) -> Measure {
         let wide  = MeasureSizer(config: SVGRenderConfig(graceNoteSpacing: 1.5), metadata: metadata)
         let tight = MeasureSizer(config: SVGRenderConfig(graceNoteSpacing: 1.05), metadata: metadata)
 
-        let wideSized  = wide.size(measure(events: events),  unitNoteLength: unitNoteLength)
-        let tightSized = tight.size(measure(events: events), unitNoteLength: unitNoteLength)
+        let wideSized  = wide.size(measure(events: events))
+        let tightSized = tight.size(measure(events: events))
 
         #expect(tightSized.naturalWidth < wideSized.naturalWidth)
         // The principal note follows the grace group, so it moves left by the same amount.
@@ -302,8 +303,8 @@ private func measure(events: [Event]) -> Measure {
         let natural = measure(events: [.note(note(duration: quarter, accidental: .natural))])
         let dblFlat = measure(events: [.note(note(duration: quarter, accidental: .doubleFlat))])
 
-        let naturalSized = sizer.size(natural, unitNoteLength: unitNoteLength)
-        let dblFlatSized = sizer.size(dblFlat, unitNoteLength: unitNoteLength)
+        let naturalSized = sizer.size(natural)
+        let dblFlatSized = sizer.size(dblFlat)
 
         #expect(dblFlatSized.naturalWidth > naturalSized.naturalWidth)
     }

--- a/Tests/CeolKitSVGRendererTests/MidVoiceUnitLengthTests.swift
+++ b/Tests/CeolKitSVGRendererTests/MidVoiceUnitLengthTests.swift
@@ -1,0 +1,111 @@
+import Testing
+import CeolKitModel
+import CeolKitParser
+import CeolKitSVGGeometry
+@testable import CeolKitSVGRenderer
+
+/// Issue #122: an `L:` that moves part way through a voice has to reach the renderer.
+///
+/// The parser records the effective unit note length on every `Measure` (#85 and #122), and
+/// the sizer and emitter read it from there. Before this, the renderer resolved one unit
+/// note length per voice and drew every bar of that voice against it, so a bar after a
+/// mid-voice `[L:]` came out at the length the voice *opened* in — flagged sixteenths where
+/// the parser had already resolved unbeamable whole notes.
+@Suite("Mid-voice [L:] reaches the renderer")
+struct MidVoiceUnitLengthTests {
+
+    private func render(_ abc: String) throws -> (svg: String, system: SystemGeometry) {
+        let score = CeolKitParser().parse(abc, options: .default).score
+        let svgs = try textProbeRenderer().render(score)
+        let svg = try #require(svgs.first)
+        let page = try #require(try SVGGeometry.pages(from: svgs).first)
+        let system = try #require(page.systems.first)
+        return (svg, system)
+    }
+
+    /// The x positions of every `<text>` run carrying `glyph`.
+    private func xs(of glyph: SMuFLGlyph, in svg: String) -> [Double] {
+        let character = String(glyph.character)
+        return svg.components(separatedBy: "<text ").dropFirst().compactMap { segment in
+            guard segment.contains(character),
+                  let start = segment.range(of: "x=\""),
+                  let end = segment[start.upperBound...].firstIndex(of: "\"")
+            else { return nil }
+            return Double(segment[start.upperBound..<end])
+        }
+    }
+
+    /// How many of `positions` fall in each bar of `system`, in bar order.  The bar lines
+    /// the geometry reads back are the cuts; anything left of the first is the staff head.
+    private func countPerBar(_ positions: [Double], in system: SystemGeometry) -> [Int] {
+        let cuts = system.barlineXs.sorted()
+        var counts = [Int](repeating: 0, count: cuts.count)
+        for x in positions {
+            guard let bar = cuts.firstIndex(where: { x < $0 }) else { continue }
+            counts[bar] += 1
+        }
+        return counts
+    }
+
+    /// The issue's own reproduction: sixteen sixteenths, then `[L:1/1]`, then two bars that
+    /// are sixteen whole notes.
+    private let midChange = """
+        X:1
+        T:Mid change
+        M:4/4
+        L:1/16
+        K:C
+        cccc cccc | [L:1/1] cccc cccc | cccc cccc |
+        """
+
+    @Test("The bar after a mid-voice [L:] is drawn at the new unit length")
+    func changeReachesTheNoteheads() throws {
+        let (svg, system) = try render(midChange)
+
+        // Bar 1 is written in sixteenths, bars 2 and 3 in whole notes.
+        #expect(countPerBar(xs(of: .noteheadBlack, in: svg), in: system) == [8, 0, 0])
+        #expect(countPerBar(xs(of: .noteheadWhole, in: svg), in: system) == [0, 8, 8])
+        // A whole note has neither stem nor flag, so every flag on the page is bar 1's —
+        // and bar 1's eight sixteenths beam in two groups of four, so it has none either.
+        #expect(xs(of: .flag16thDown, in: svg).isEmpty)
+        #expect(xs(of: .flag16thUp, in: svg).isEmpty)
+    }
+
+    @Test("The change carries forward to later bars until another L: moves it")
+    func changeCarriesForwardAndIsMovedAgain() throws {
+        let (svg, system) = try render("""
+            X:1
+            M:4/4
+            L:1/16
+            K:C
+            cccc cccc | [L:1/1] cccc cccc | [L:1/16] cccc cccc |
+            """)
+        #expect(countPerBar(xs(of: .noteheadBlack, in: svg), in: system) == [8, 0, 8])
+        #expect(countPerBar(xs(of: .noteheadWhole, in: svg), in: system) == [0, 8, 0])
+    }
+
+    @Test("Whole notes take more room than the sixteenths they replaced")
+    func theSystemIsWiderThanTheUnchangedTune() throws {
+        let (_, changed) = try render(midChange)
+        let (_, unchanged) = try render(midChange.replacing("[L:1/1] ", with: ""))
+        #expect(changed.width > unchanged.width)
+    }
+
+    @Test("A mid-voice [L:] belongs to the voice that carries it")
+    func changeDoesNotLeakToAnotherVoice() throws {
+        // Voice 1 changes to whole notes half way through; voice 2 says nothing and stays in
+        // sixteenths.  Both staves are read together, so the count is the sum of the two.
+        let (svg, system) = try render("""
+            X:1
+            M:4/4
+            L:1/16
+            K:C
+            V:1
+            V:2
+            [V:1] cccc cccc | [L:1/1] cccc cccc |
+            [V:2] cccc cccc | cccc cccc |
+            """)
+        #expect(countPerBar(xs(of: .noteheadBlack, in: svg), in: system) == [16, 8])
+        #expect(countPerBar(xs(of: .noteheadWhole, in: svg), in: system) == [0, 8])
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/SharedStaffMergeTests.swift
+++ b/Tests/CeolKitSVGRendererTests/SharedStaffMergeTests.swift
@@ -9,7 +9,6 @@ import CeolKitSVGGeometry
 private let config   = SVGRenderConfig()
 private let metadata = try! BravuraMetadata.load()
 private let sizer    = MeasureSizer(config: config, metadata: metadata)
-private let eighth   = Fraction(numerator: 1, denominator: 8)
 
 /// The first bar of every voice of `abc`, in `V:` declaration order.
 private func firstBars(_ abc: String) -> [Measure] {
@@ -17,11 +16,10 @@ private func firstBars(_ abc: String) -> [Measure] {
         .voices.map { $0.staves[0].measures[0] }
 }
 
-private func shared(_ measures: [Measure], padding: Set<Int> = [],
-                    unitNoteLength: Fraction = eighth) -> SizedMeasure {
+private func shared(_ measures: [Measure], padding: Set<Int> = []) -> SizedMeasure {
     sizer.size(sharedStaff: measures.enumerated().map { index, measure in
-        MeasureSizer.SharedVoice(measure: measure, unitNoteLength: unitNoteLength,
-                                 voiceIndex: index, isPadding: padding.contains(index))
+        MeasureSizer.SharedVoice(measure: measure, voiceIndex: index,
+                                 isPadding: padding.contains(index))
     })
 }
 
@@ -58,7 +56,7 @@ struct SharedStaffMergeTests {
             [V:2]CDEFGABc|
             """)
         let merged = shared(bars)
-        let alone  = sizer.size(bars[0], unitNoteLength: eighth)
+        let alone  = sizer.size(bars[0])
 
         #expect(isClose(merged.naturalWidth, alone.naturalWidth))
         #expect(columns(of: merged).count == 8)
@@ -81,7 +79,7 @@ struct SharedStaffMergeTests {
             [V:2]X|
             """)
         let merged = shared(bars, padding: [1])
-        let alone  = sizer.size(bars[0], unitNoteLength: eighth)
+        let alone  = sizer.size(bars[0])
 
         #expect(isClose(merged.naturalWidth, alone.naturalWidth))
         #expect(zip(merged.eventOffsets, alone.eventOffsets).allSatisfy(isClose))
@@ -180,7 +178,7 @@ struct SharedStaffMergeTests {
         let steps = zip(grid.dropFirst(), grid).map(-)
         #expect(steps.allSatisfy { isClose($0, steps[0]) })
         // And the lower voice alone would have used exactly the same grid.
-        let alone = sizer.size(bars[1], unitNoteLength: eighth)
+        let alone = sizer.size(bars[1])
         #expect(zip(grid, alone.eventOffsets).allSatisfy(isClose))
     }
 
@@ -197,12 +195,11 @@ struct SharedStaffMergeTests {
             [V:1]C2D2E2F2|
             [V:2][L:1/4]CDEF|
             """)
+        // Each bar carries the unit note length its own voice is written in (#122):
+        // 1/8 for V:1, 1/4 for V:2.
         let merged = sizer.size(sharedStaff: [
-            MeasureSizer.SharedVoice(measure: bars[0], unitNoteLength: eighth,
-                                     voiceIndex: 0, isPadding: false),
-            MeasureSizer.SharedVoice(measure: bars[1],
-                                     unitNoteLength: Fraction(numerator: 1, denominator: 4),
-                                     voiceIndex: 1, isPadding: false)
+            MeasureSizer.SharedVoice(measure: bars[0], voiceIndex: 0, isPadding: false),
+            MeasureSizer.SharedVoice(measure: bars[1], voiceIndex: 1, isPadding: false)
         ])
         #expect(merged.eventOffsets.count == 8)
         #expect(columns(of: merged).count == 4)
@@ -222,7 +219,7 @@ struct SharedStaffMergeTests {
             [V:2]C2D2|
             """)
         let merged = shared(bars)
-        let alone  = sizer.size(bars[0], unitNoteLength: eighth)
+        let alone  = sizer.size(bars[0])
 
         #expect(!merged.graceEventIndices.isEmpty)
         let graceIndex = try #require(alone.graceEventIndices.min())
@@ -307,7 +304,7 @@ struct SharedStaffMergeTests {
             """)
         for bar in bars {
             let viaShared = shared([bar])
-            let alone     = sizer.size(bar, unitNoteLength: eighth)
+            let alone     = sizer.size(bar)
             #expect(isClose(viaShared.naturalWidth, alone.naturalWidth))
             #expect(zip(viaShared.eventOffsets, alone.eventOffsets).allSatisfy(isClose))
             #expect(viaShared.graceEventIndices == alone.graceEventIndices)

--- a/Tests/CeolKitSVGRendererTests/StaffSpanThreadingTests.swift
+++ b/Tests/CeolKitSVGRendererTests/StaffSpanThreadingTests.swift
@@ -12,7 +12,8 @@ private let metadata   = try! BravuraMetadata.load()
 
 private func emptyMeasure(line: Int = 0) -> Measure {
     Measure(openingBar: nil, events: [], closingBar: dummyBar, endingNumber: nil,
-            source: SourceRange(file: nil, byteOffset: 0, length: 0, line: line, column: 0))
+            source: SourceRange(file: nil, byteOffset: 0, length: 0, line: line, column: 0),
+            unitNoteLength: Fraction(numerator: 1, denominator: 8))
 }
 
 private func sizedMeasure(width: Double = 100) -> SizedMeasure {

--- a/Tests/CeolKitSVGRendererTests/StyleTests.swift
+++ b/Tests/CeolKitSVGRendererTests/StyleTests.swift
@@ -189,7 +189,7 @@ struct StyleTests {
             let isLast = si == voice.staves.count - 1
             for (mi, m) in stave.measures.enumerated() {
                 pairs.append((
-                    measure: sizer.size(m, unitNoteLength: tune.unitNoteLength),
+                    measure: sizer.size(m),
                     breakAfter: (!isLast && mi == stave.measures.count - 1) ? .hard : nil
                 ))
             }
@@ -263,7 +263,7 @@ struct StyleTests {
             let isLast = si == voice.staves.count - 1
             for (mi, m) in stave.measures.enumerated() {
                 pairs.append((
-                    measure: sizer.size(m, unitNoteLength: tune.unitNoteLength),
+                    measure: sizer.size(m),
                     breakAfter: (!isLast && mi == stave.measures.count - 1) ? .hard : nil
                 ))
             }

--- a/Tests/CeolKitSVGRendererTests/TitleBlockIntegrationTests.swift
+++ b/Tests/CeolKitSVGRendererTests/TitleBlockIntegrationTests.swift
@@ -138,7 +138,8 @@ struct TitleBlockIntegrationTests {
                     source: SourceRange(file: nil, byteOffset: 0, length: 0, line: 1, column: 1)
                 ),
                 endingNumber: nil,
-                source: SourceRange(file: nil, byteOffset: 0, length: 0, line: 1, column: 1)
+                source: SourceRange(file: nil, byteOffset: 0, length: 0, line: 1, column: 1),
+                unitNoteLength: Fraction(numerator: 1, denominator: 8)
             ),
             naturalWidth: 50,
             eventOffsets: []

--- a/Tests/CeolKitSVGRendererTests/TunebookTests.swift
+++ b/Tests/CeolKitSVGRendererTests/TunebookTests.swift
@@ -53,9 +53,8 @@ struct TunebookTests {
         let voice = try #require(score.tunes.first?.voices.first)
         let stave = try #require(voice.staves.first)
         var totalWidth = 0.0
-        let unl = score.tunes.first!.unitNoteLength
         for m in stave.measures {
-            totalWidth += sizer.size(m, unitNoteLength: unl).naturalWidth
+            totalWidth += sizer.size(m).naturalWidth
         }
         let usable = effectiveConfig.pageSize.width - effectiveConfig.margins.left - effectiveConfig.margins.right
         let header = systemHeaderWidth(

--- a/Tests/CeolKitSVGRendererTests/VerticalLayoutTests.swift
+++ b/Tests/CeolKitSVGRendererTests/VerticalLayoutTests.swift
@@ -10,7 +10,8 @@ private let dummyFraction = Fraction(numerator: 1, denominator: 4)
 
 private func emptyMeasure(line: Int = 0) -> Measure {
     let source = SourceRange(file: nil, byteOffset: 0, length: 0, line: line, column: 0)
-    return Measure(openingBar: nil, events: [], closingBar: dummyBar, endingNumber: nil, source: source)
+    return Measure(openingBar: nil, events: [], closingBar: dummyBar, endingNumber: nil,
+                   source: source, unitNoteLength: Fraction(numerator: 1, denominator: 8))
 }
 
 /// Distinct source range per bar, so two `BarLine`s compare unequal unless they
@@ -21,11 +22,12 @@ private func barSource(byteOffset: Int) -> SourceRange {
 
 private func measure(opening: BarLine?, closing: BarLine) -> Measure {
     Measure(openingBar: opening, events: [], closingBar: closing,
-            endingNumber: nil, source: dummyRange)
+            endingNumber: nil, source: dummyRange, unitNoteLength: Fraction(numerator: 1, denominator: 8))
 }
 
 private func measureWith(events: [Event]) -> Measure {
-    Measure(openingBar: nil, events: events, closingBar: dummyBar, endingNumber: nil, source: dummyRange)
+    Measure(openingBar: nil, events: events, closingBar: dummyBar, endingNumber: nil,
+            source: dummyRange, unitNoteLength: Fraction(numerator: 1, denominator: 8))
 }
 
 private func justifiedSystem(measures: [Measure] = [], isLast: Bool = false) -> JustifiedSystem {

--- a/Tests/CeolKitSVGRendererTests/VoiceAlignerTests.swift
+++ b/Tests/CeolKitSVGRendererTests/VoiceAlignerTests.swift
@@ -9,7 +9,8 @@ private let dummyBar   = BarLine(kind: .single, source: dummyRange)
 
 private func measure(line: Int) -> Measure {
     Measure(openingBar: nil, events: [], closingBar: dummyBar, endingNumber: nil,
-            source: SourceRange(file: nil, byteOffset: 0, length: 0, line: line, column: 0))
+            source: SourceRange(file: nil, byteOffset: 0, length: 0, line: line, column: 0),
+            unitNoteLength: Fraction(numerator: 1, denominator: 8))
 }
 
 /// A voice whose staves are given as measure counts — one stave per source line.


### PR DESCRIPTION
Closes #122.

The renderer resolved one unit note length per voice and sized every measure of that voice against it, so a bar after a mid-voice `[L:]` was drawn at the length the voice *opened* in. #85 had already fixed the parser side, so the two halves of the pipeline disagreed about the same bar.

## The model change

`Measure.unitNoteLength` goes from `Fraction?` meaning *"non-nil where an `L:` moved it"* to a non-optional `Fraction` meaning *"the unit this measure's durations are counted in"*.

This deliberately diverges from `Measure.meter`, which keeps the "non-nil means change" convention, and the doc comment says why: **a renderer must draw a time signature exactly where the meter changes, whereas a unit note length is never drawn, only used as a scale.** "Always the effective value" is the useful shape for a divisor; "only where it changed" is the useful shape for something engraved at the point of change. "Did it change here?" stays recoverable as `m.unitNoteLength != previous`, with `Voice.unitNoteLength` as the comparison for a voice's first measure.

## Parser

`VoiceAccumulator` gains `effectiveUnitNoteLength`, which lags the running `unitNoteLength` by exactly the deferral `pendingUnitNoteLength` describes — an `L:` written against a bar line takes effect at the bar the next note falls in — and stamps every closed measure. Empty measures, the final open measure and overlay reconciliation all carry it. The beam pass rebuilds its resolver wherever a measure differs from the last rather than on a non-nil tag.

## Renderer

- `voiceUnitLengths` and its per-region recomputation are gone; the key is still resolved per voice, the unit note length is not.
- `MeasureSizer.size(_:voiceIndex:)` loses the parameter and reads `measure.unitNoteLength`.
- `MeasureSizer.SharedVoice` and `SharedStaffMerger.VoicePart` lose their own copy — it is `part.measure`'s. The shared-staff onset grid gets correct for free.
- `VoiceAligner.pad` writes its filler in the unit the voice is in there, carried across staves so a voice that skips a line entirely still pads in the unit it was last in.

## Result

The issue's reproduction, counted in `page0.svg`:

| glyph | before | after | expected |
|---|---|---|---|
| `noteheadBlack` | 24 | 8 | 8 |
| `noteheadWhole` | 0 | 16 | 16 |
| `flag16thDown` | 16 | 0 | 0 |

## Tests

New `MidVoiceUnitLengthTests` covers the reproduction, carry-forward through a second `[L:]`, the resulting width change, and that a mid-voice `[L:]` stays in the voice that carries it. `InlineLengthAndMeterBeamingTests` is updated for the new convention — the assertions that read `== nil` now name the effective value.

1080 tests pass. No snapshot golden moved, so a tune with no mid-voice `[L:]` renders byte-identically, `tunebook.abc` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015vXQgpS4yz6oUj2K2DY2BJ