### PR TITLE
Fix #86 — an abandoned tuplet keeps the notes it collected

### DIFF
--- a/Sources/CeolKitModel/Diagnostic.swift
+++ b/Sources/CeolKitModel/Diagnostic.swift
@@ -38,6 +38,11 @@ public enum DiagnosticCode: String, Codable, Sendable {
     case constructOutOfOrder
     case reservedCharacter
     case danglingTie
+    /// A tuplet ended before the `r` notes it asked for — at a bar line, at the end of a
+    /// line, or because a second tuplet started inside it.  The notes it did collect are kept,
+    /// as a tuplet of the length actually written, so the duration scaling the source asked
+    /// for still applies to them.
+    case incompleteTuplet
     /// Two voices of the same tune disagree about how much music a source line holds,
     /// so the staves of a system cannot be aligned from the source alone.  The renderer
     /// pads the short voice with invisible full-measure rests and carries on.

--- a/Sources/CeolKitParser/Semantic/BodyContext.swift
+++ b/Sources/CeolKitParser/Semantic/BodyContext.swift
@@ -177,6 +177,15 @@ struct TupletState {
     let r: Int
     let source: SourceRange
     var events: [Event] = []
+
+    /// How many of the collected events are music.  A space inside a tuplet breaks a beam;
+    /// it is not one of the `r` notes the tuplet is counting off.
+    var musicalEventCount: Int {
+        events.reduce(into: 0) { count, event in
+            if case .spacer = event { return }
+            count += 1
+        }
+    }
 }
 
 // MARK: - VoiceState
@@ -260,7 +269,7 @@ struct VoiceState {
         }
         if tuplet != nil {
             tuplet!.events.append(event)
-            if tuplet!.events.count >= tuplet!.r {
+            if tuplet!.musicalEventCount >= tuplet!.r {
                 flushTuplet()
             }
             return
@@ -324,12 +333,33 @@ struct VoiceState {
         tuplet = TupletState(p: p, q: q, r: r, source: source)
     }
 
-    mutating func flushTuplet() {
-        guard let open = tuplet else { return }
-        let adjustedEvents = open.events.map { applyTupletFactor(q: open.q, p: open.p, to: $0) }
-        let t = Tuplet(p: open.p, q: open.q, r: open.r, events: adjustedEvents, source: open.source)
+    /// Closes the open tuplet, if any, and writes it into the measure being written.
+    ///
+    /// Returns the state it closed when the tuplet was *abandoned* — short of the `r` events
+    /// it asked for, because a bar line, the end of a line or a second `(` reached it first —
+    /// and `nil` when there was nothing open or the tuplet was complete.  What comes back is
+    /// a warning waiting to be written: the caller has the diagnostics list, this does not.
+    ///
+    /// An abandoned tuplet keeps the notes it did collect, as a tuplet of the length actually
+    /// written (#86).  Dropping them loses music the author wrote; emitting them outside a
+    /// tuplet loses the duration scaling the source asked for.
+    @discardableResult
+    mutating func flushTuplet() -> TupletState? {
+        guard let open = tuplet else { return nil }
         tuplet = nil
+        // A tuplet abandoned at a bar line or a line end ends on the space before it, and that
+        // space separates the tuplet from what follows rather than sitting inside it.
+        var events = open.events
+        while let last = events.last, case .spacer = last { events.removeLast() }
+        let count = open.musicalEventCount
+        guard count > 0 else { return open }  // `(3` with nothing after it: nothing to keep
+        let adjustedEvents = events.map { applyTupletFactor(q: open.q, p: open.p, to: $0) }
+        // `p` and `q` say what the source asked for and stand as written; only `r`, which
+        // counts the notes the tuplet spans, moves to what is actually there.
+        let t = Tuplet(p: open.p, q: open.q, r: min(open.r, count), events: adjustedEvents,
+                       source: open.source)
         accumulator.currentEvents.append(.tuplet(t))
+        return count < open.r ? open : nil
     }
 
     // MARK: Lyrics
@@ -789,6 +819,24 @@ struct BodyContext {
     }
 
     func isInTuplet(_ voice: VoiceKey) -> Bool { voices[voice]?.tuplet != nil }
+
+    /// Closes `voice`'s open tuplet, returning it when it was abandoned short of its `r`
+    /// events — see ``VoiceState/flushTuplet()``.
+    @discardableResult
+    mutating func flushTuplet(in voice: VoiceKey) -> TupletState? {
+        voices[voice]?.flushTuplet() ?? nil
+    }
+
+    /// Closes every voice's open tuplet, and returns those that were abandoned short.
+    ///
+    /// A line can leave a tuplet open in a voice the cursor has since left — an inline `[V:]`
+    /// moves the cursor and the tuplet stays where it was written — so the end of a line has
+    /// to sweep every voice rather than just the one being written.
+    mutating func flushOpenTuplets() -> [TupletState] {
+        voices.keys
+            .sorted { ($0.base, $0.overlay) < ($1.base, $1.overlay) }
+            .compactMap { flushTuplet(in: $0) }
+    }
 
     mutating func applyLyrics(_ tokens: [LyricToken], in voice: VoiceKey) {
         // No state means no music line to align against — nothing to do.

--- a/Sources/CeolKitParser/Semantic/SemanticPass.swift
+++ b/Sources/CeolKitParser/Semantic/SemanticPass.swift
@@ -374,6 +374,26 @@ struct SemanticPass {
         if ctx.isInGrace(voice) {
             ctx.flushGrace(in: voice)
         }
+        // A tuplet does not run past the end of the line that opened it: whatever it collected
+        // is written here rather than left hanging, where the next line would drop it (#86).
+        for abandoned in ctx.flushOpenTuplets() {
+            diagnostics.append(incompleteTuplet(abandoned))
+        }
+    }
+
+    /// The warning for a tuplet that ended before the `r` notes it asked for.
+    private func incompleteTuplet(_ open: TupletState) -> Diagnostic {
+        let kept = open.musicalEventCount
+        return Diagnostic(
+            severity: .warning, code: .incompleteTuplet,
+            message: "this tuplet asks for \(open.r) notes but "
+                   + (kept == 0 ? "none follow it" : "only \(kept) follow it"),
+            source: open.source,
+            hint: kept == 0
+                ? "a tuplet's notes follow it directly; nothing was collected here, so nothing "
+                + "is drawn for it."
+                : "the \(kept) note\(kept == 1 ? "" : "s") written are kept, as a tuplet of "
+                + "\(kept).")
     }
 
     /// Moves the cursor into the temporary voice a run of `bars` `&`s opens (§7.4).
@@ -392,6 +412,9 @@ struct SemanticPass {
     ) {
         // Whatever the layer being left holds open is finished before the clock moves.
         if ctx.isInGrace(voice) { ctx.flushGrace(source: source, in: voice) }
+        if let abandoned = ctx.flushTuplet(in: voice) {
+            diagnostics.append(incompleteTuplet(abandoned))
+        }
 
         let primary = ctx.voice(voice.primary)?.accumulator
         let closed = primary?.closedMeasures.count ?? 0
@@ -435,6 +458,11 @@ struct SemanticPass {
             ctx.emit(.rest(rest), in: voice)
 
         case .barLine(let kind, let src):
+            // A tuplet does not span a bar line, so one still open here is short of what it
+            // asked for; it is written into the bar being closed rather than lost with it (#86).
+            if let abandoned = ctx.flushTuplet(in: voice) {
+                diagnostics.append(incompleteTuplet(abandoned))
+            }
             // Closes this bar for every `&` layer standing in it, not just the current one:
             // the bar line is the staff's, and §7.4 overlays share the bar it ends.
             ctx.closeBar(barLine: BarLine(kind: kind, source: src), in: voice)
@@ -469,6 +497,11 @@ struct SemanticPass {
             ctx.setPendingChordSymbol(parseChordSymbol(s, source: src), in: voice, source: src)
 
         case .tupletStart(let p, let q, let r, let src):
+            // Tuplets do not nest: a second one closes the first, which keeps what the first
+            // had collected instead of clobbering it (#86).
+            if let abandoned = ctx.flushTuplet(in: voice) {
+                diagnostics.append(incompleteTuplet(abandoned))
+            }
             let resolvedQ = q ?? defaultQ(p: p, meter: ctx.meter)
             let resolvedR = r ?? p
             ctx.startTuplet(p: p, q: resolvedQ, r: resolvedR, source: src, in: voice)

--- a/Tests/CeolKitParserTests/Recovery/IncompleteTupletTests.swift
+++ b/Tests/CeolKitParserTests/Recovery/IncompleteTupletTests.swift
@@ -1,0 +1,142 @@
+// Issue #86: a tuplet that ends before the notes it asked for keeps what it collected.
+//
+// Three ways a tuplet can be cut short — a bar line, the end of a line, and a second `(`
+// opening inside it — each of which used to discard every event the tuplet had gathered,
+// silently.  The contract now is the one the rest of the parser keeps: the music survives,
+// and a diagnostic says what happened.
+import Testing
+import CeolKitModel
+import CeolKitParser
+
+@Suite("Incomplete Tuplets")
+struct IncompleteTupletTests {
+
+    private func tune(_ body: String) -> String {
+        "X:1\nT:Test\nM:4/4\nL:1/8\nK:C\n\(body)"
+    }
+
+    private func incompleteWarnings(_ result: ParseResult) -> [Diagnostic] {
+        result.score.diagnostics.filter { $0.code == .incompleteTuplet }
+    }
+
+    // MARK: - A bar line ends the tuplet
+
+    @Test("A tuplet cut short by a bar line keeps its notes")
+    func barLineKeepsNotes() {
+        let measures = parse(tune("(3ab | cdef |\n")).score.firstTune?.singleVoiceMeasures ?? []
+        let tuplets = measures.first?.tupletEvents ?? []
+        guard let tuplet = tuplets.first else {
+            Issue.record("Expected the truncated tuplet to survive the bar line")
+            return
+        }
+        #expect(tuplet.events.count == 2)
+    }
+
+    @Test("A tuplet cut short by a bar line keeps p and q, and corrects r")
+    func barLineCorrectsR() {
+        let measures = parse(tune("(3ab | cdef |\n")).score.firstTune?.singleVoiceMeasures ?? []
+        let tuplets = measures.first?.tupletEvents ?? []
+        guard let tuplet = tuplets.first else {
+            Issue.record("Expected the truncated tuplet to survive the bar line")
+            return
+        }
+        #expect(tuplet.p == 3)
+        #expect(tuplet.q == 2)
+        #expect(tuplet.r == 2)
+    }
+
+    @Test("The notes of a truncated tuplet are still scaled by q/p")
+    func truncatedTupletStillScales() {
+        let measures = parse(tune("(3ab | cdef |\n")).score.firstTune?.singleVoiceMeasures ?? []
+        let tuplets = measures.first?.tupletEvents ?? []
+        guard let tuplet = tuplets.first, case .note(let first) = tuplet.events.first else {
+            Issue.record("Expected the truncated tuplet to survive the bar line")
+            return
+        }
+        #expect(first.duration == Fraction(numerator: 2, denominator: 3))
+    }
+
+    @Test("A tuplet cut short by a bar line warns")
+    func barLineWarns() {
+        let warnings = incompleteWarnings(parse(tune("(3ab | cdef |\n")))
+        #expect(warnings.count == 1)
+        #expect(warnings.first?.severity == .warning)
+    }
+
+    // MARK: - The end of a line ends the tuplet
+
+    @Test("A tuplet left open at the end of a line keeps its notes, and warns")
+    func endOfLineKeepsNotes() {
+        let result = parse(tune("(3ab\ncdef|\n"))
+        let measures = result.score.firstTune?.singleVoiceMeasures ?? []
+        let tuplets = measures.first?.tupletEvents ?? []
+        guard let tuplet = tuplets.first else {
+            Issue.record("Expected the truncated tuplet to survive the line break")
+            return
+        }
+        #expect(tuplet.events.count == 2)
+        #expect(incompleteWarnings(result).count == 1)
+    }
+
+    @Test("A tuplet does not swallow the notes of the following line")
+    func endOfLineDoesNotRunOn() {
+        let measures = parse(tune("(3ab\ncdef|\n")).score.firstTune?.singleVoiceMeasures ?? []
+        let notes = measures.last?.noteEvents ?? []
+        #expect(notes.count == 4)
+    }
+
+    // MARK: - A second tuplet ends the first
+
+    @Test("A tuplet restarted inside another keeps both sets of notes")
+    func restartKeepsBothTuplets() {
+        let result = parse(tune("(3ab(3cde |\n"))
+        let measures = result.score.firstTune?.singleVoiceMeasures ?? []
+        let tuplets = measures.first?.tupletEvents ?? []
+        #expect(tuplets.count == 2)
+        #expect(tuplets.first?.events.count == 2)
+        #expect(tuplets.first?.r == 2)
+        #expect(tuplets.last?.events.count == 3)
+        #expect(tuplets.last?.r == 3)
+        #expect(incompleteWarnings(result).count == 1)
+    }
+
+    // MARK: - A tuplet with nothing after it
+
+    @Test("A tuplet with no notes at all draws nothing and warns")
+    func emptyTupletWarns() {
+        let result = parse(tune("(3 | cdef |\n"))
+        let measures = result.score.firstTune?.singleVoiceMeasures ?? []
+        let tuplets = measures.first?.tupletEvents ?? []
+        #expect(tuplets.isEmpty)
+        #expect(incompleteWarnings(result).count == 1)
+    }
+
+    // MARK: - Well-formed tuplets are untouched
+
+    @Test("A complete tuplet is unchanged and silent")
+    func completeTupletIsSilent() {
+        let result = parse(tune("(3abc |\n"))
+        let measures = result.score.firstTune?.singleVoiceMeasures ?? []
+        let tuplets = measures.first?.tupletEvents ?? []
+        #expect(tuplets.first?.r == 3)
+        #expect(tuplets.first?.events.count == 3)
+        #expect(incompleteWarnings(result).isEmpty)
+    }
+
+    @Test("A space inside a tuplet breaks a beam, it does not count as one of the r notes")
+    func spaceInsideTupletIsNotANote() {
+        let result = parse(tune("(3a b c d2 |\n"))
+        let measures = result.score.firstTune?.singleVoiceMeasures ?? []
+        let tuplets = measures.first?.tupletEvents ?? []
+        guard let tuplet = tuplets.first else {
+            Issue.record("Expected a tuplet spanning the three spaced notes")
+            return
+        }
+        #expect(tuplet.r == 3)
+        let notes = tuplet.events.compactMap { event -> Note? in
+            if case .note(let n) = event { return n } else { return nil }
+        }
+        #expect(notes.count == 3)
+        #expect(incompleteWarnings(result).isEmpty)
+    }
+}


### PR DESCRIPTION
Closes #86.

A tuplet that never reached its `r` events discarded everything it had collected, without a diagnostic. Three ways to lose notes: `(3ab | c` at a bar line, the same at the end of a line, and `(3ab(3cde` where the second `(` clobbered the first.

## What changed

`VoiceState.flushTuplet()` is now the single exit and returns the state it closed when the tuplet was short — a warning waiting to be written, since the diagnostics list lives with the caller. An abandoned tuplet keeps its notes, with `p` and `q` as the source stated them and only `r` moved to the count actually there: dropping them loses music the author wrote, and emitting them outside a tuplet loses the duration scaling the source asked for. The trailing spacer a bar line or line end leaves behind is trimmed off the group, and a `(3` with nothing after it draws nothing.

The four places a tuplet can be abandoned flush it — a bar line, the end of a line, a second `(`, and the `&` that moves to another layer — each with a new `incompleteTuplet` warning naming what was asked for and what was kept. End of line sweeps every voice rather than the cursor's, because an inline `[V:]` moves the cursor and leaves the tuplet where it was written.

`emit` also counts *musical* events toward `r` rather than every event. A space inside a tuplet breaks a beam; it is not one of its notes, and counting it closed `(3a b c` two notes in and left `c` outside the group.

## Reproduction, after

```
[warning] line 6: this tuplet asks for 3 notes but only 2 follow it
```

with both notes drawn, triplet-scaled, in the first bar. `(3abc` is untouched and silent.

## Tests

`Tests/CeolKitParserTests/Recovery/IncompleteTupletTests.swift` — the three loss paths, the duration scaling that survives them, the empty `(3`, and the two well-formed cases that must stay silent. Full suite: 1090 tests, all passing.

Note for reviewers: an incremental build after adding the `DiagnosticCode` case produces bogus failures in the renderer test target (stale module); `swift package clean` clears them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TYmSzvtty6HBLpRZ4DxKX