### PR TITLE
Fix #98 — a key signature is laid out for the clef its staff carries

### DIFF
--- a/Sources/CeolKitSVGRenderer/Emission/KeySignatureLayout.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/KeySignatureLayout.swift
@@ -2,29 +2,40 @@ import CeolKitModel
 
 /// A single accidental glyph in a key signature and its vertical position on the staff.
 ///
-/// Staff position 0 = bottom line of treble staff (E4); 8 = top line (F5).
+/// Staff position 0 = bottom line of the staff, 8 = top line, counting one position
+/// per diatonic step. Which pitch a position names depends on the clef, so the
+/// positions are produced per clef by `keyAccidentals(for:clef:)`.
 struct KeyAccidental: Sendable {
     let glyph: SMuFLGlyph      // .accidentalSharp or .accidentalFlat
     let staffPosition: Int
 }
 
-/// Returns the ordered list of accidentals to draw for `key` on a treble-clef staff.
+/// Returns the ordered list of accidentals to draw for `key` on a staff carrying `clef`.
 ///
-/// Returns an empty array for `K:none`, highland-pipe keys, and keys with no accidentals.
-func keyAccidentals(for key: KeySignature) -> [KeyAccidental] {
+/// Returns an empty array for `K:none`, highland-pipe keys, keys with no accidentals,
+/// and clefs that carry no key signature (`percussion`, `none`).
+///
+/// The positions are per clef because a key signature names pitches, not offsets from
+/// the staff top: F♯ sits on the top line in treble and on the fourth line in bass.
+/// An octave shift on the clef (`treble+8`) does not move them — the shifted clef still
+/// names the same staff lines.
+func keyAccidentals(for key: KeySignature, clef: ClefSpec) -> [KeyAccidental] {
     guard key.mode != .none,
           key.mode != .highlandPipes,
           key.mode != .highlandPipesNoSignature,
-          let tonic = key.tonic else { return [] }
+          let tonic = key.tonic,
+          let table = signatureTable(for: clef.clef) else { return [] }
 
     let cof = circleOfFifthsPosition(tonic: tonic, mode: key.mode)
 
     if cof > 0 {
-        let positions = [8, 5, 2, 6, 3, 7, 4]   // F C G D A E B on treble staff
-        return (0..<min(cof, 7)).map { KeyAccidental(glyph: .accidentalSharp, staffPosition: positions[$0]) }
+        return (0..<min(cof, 7)).map {
+            KeyAccidental(glyph: .accidentalSharp, staffPosition: table.sharps[$0])
+        }
     } else if cof < 0 {
-        let positions = [4, 7, 3, 6, 2, 5, 8]   // B E A D G C F on treble staff
-        return (0..<min(-cof, 7)).map { KeyAccidental(glyph: .accidentalFlat, staffPosition: positions[$0]) }
+        return (0..<min(-cof, 7)).map {
+            KeyAccidental(glyph: .accidentalFlat, staffPosition: table.flats[$0])
+        }
     }
     return []
 }
@@ -34,9 +45,9 @@ func keyAccidentals(for key: KeySignature) -> [KeyAccidental] {
 /// - Parameter trailingGap: Space to reserve after the last accidental glyph.
 ///   Defaults to `staffSize * 0.5`. Pass `noteheadWidth` when no time signature
 ///   follows, so the gap to the first bar line equals one note head.
-func keySignatureWidth(for key: KeySignature, metadata: BravuraMetadata, staffSize: Double,
-                        trailingGap: Double? = nil) -> Double {
-    let accs = keyAccidentals(for: key)
+func keySignatureWidth(for key: KeySignature, clef: ClefSpec, metadata: BravuraMetadata,
+                        staffSize: Double, trailingGap: Double? = nil) -> Double {
+    let accs = keyAccidentals(for: key, clef: clef)
     guard !accs.isEmpty else { return 0 }
     let glyphW    = metadata.glyphBBoxes["accidentalSharp"].map { $0.width * staffSize } ?? staffSize * 0.75
     let interGap  = staffSize * 0.1
@@ -45,6 +56,49 @@ func keySignatureWidth(for key: KeySignature, metadata: BravuraMetadata, staffSi
 }
 
 // MARK: - Private
+
+/// The staff positions a key signature's accidentals occupy on one clef, in
+/// circle-of-fifths order (F C G D A E B for sharps, B E A D G C F for flats).
+private struct SignatureTable {
+    let sharps: [Int]
+    let flats: [Int]
+}
+
+/// The engraved accidental positions for `clef`, or `nil` for a clef that carries
+/// no key signature.
+///
+/// Each table is the conventional engraving rather than a shift of the treble one:
+/// the C clefs place individual accidentals an octave away from a plain transposition
+/// so the whole signature stays on the staff.
+private func signatureTable(for clef: Clef) -> SignatureTable? {
+    switch clef {
+    // Bottom line E4. F♯5 top line, G♯5 the space above the staff, F♭4 the first space.
+    case .treble:
+        return SignatureTable(sharps: [8, 5, 9, 6, 3, 7, 4], flats: [4, 7, 3, 6, 2, 5, 1])
+    // Bottom line G2 — every position two below treble. F♭2 sits below the bottom
+    // line; a key signature draws no ledger line for it.
+    case .bass:
+        return SignatureTable(sharps: [6, 3, 7, 4, 1, 5, 2], flats: [2, 5, 1, 4, 0, 3, -1])
+    // F clef on line 3: bottom line B2.
+    case .baritone:
+        return SignatureTable(sharps: [4, 8, 5, 2, 6, 3, 7], flats: [7, 3, 6, 2, 5, 1, 4])
+    // C clef on line 3: bottom line F3.
+    case .alto:
+        return SignatureTable(sharps: [7, 4, 8, 5, 2, 6, 3], flats: [3, 6, 2, 5, 1, 4, 0])
+    // C clef on line 4: bottom line D3. F♯ starts an octave below the treble pattern.
+    case .tenor:
+        return SignatureTable(sharps: [2, 6, 3, 7, 4, 8, 5], flats: [5, 8, 4, 7, 3, 6, 2])
+    // C clef on line 1: bottom line C4.
+    case .soprano:
+        return SignatureTable(sharps: [3, 7, 4, 8, 5, 2, 6], flats: [6, 2, 5, 1, 4, 0, 3])
+    // C clef on line 2: bottom line A3.
+    case .mezzoSoprano:
+        return SignatureTable(sharps: [5, 2, 6, 3, 7, 4, 8], flats: [8, 4, 7, 3, 6, 2, 5])
+    // Neither staff carries pitch, so neither carries a key signature.
+    case .percussion, .none:
+        return nil
+    }
+}
 
 /// Maps a tonic+mode pair to a circle-of-fifths position.
 ///

--- a/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
@@ -782,7 +782,7 @@ struct SVGEmitter: Sendable {
 
     private func emitKeySignature(_ keySig: KeySignature, system: ResolvedSystem,
                                   builder: inout SVGBuilder) {
-        let accs = keyAccidentals(for: keySig)
+        let accs = keyAccidentals(for: keySig, clef: system.clef)
         guard !accs.isEmpty else { return }
 
         let s            = config.staffSize
@@ -805,7 +805,7 @@ struct SVGEmitter: Sendable {
     private func emitTimeSignature(_ meter: Meter, system: ResolvedSystem, builder: inout SVGBuilder) {
         let s = config.staffSize
         let keySigW = system.keySignature.map {
-            keySignatureWidth(for: $0, metadata: metadata, staffSize: s)
+            keySignatureWidth(for: $0, clef: system.clef, metadata: metadata, staffSize: s)
         } ?? 0
         let startX = system.origin.x + clefWidth(for: system.clef) + keySigW
         emitTimeSignatureGlyph(meter, atX: startX, system: system, builder: &builder)

--- a/Sources/CeolKitSVGRenderer/Emission/SystemHeaderLayout.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SystemHeaderLayout.swift
@@ -65,7 +65,8 @@ func systemHeaderWidth(
         metadata.glyphBBoxes["noteheadBlack"].map { $0.width * staffSize } ?? staffSize * 1.2
     }()
     let keySigW = keySignature.map {
-        keySignatureWidth(for: $0, metadata: metadata, staffSize: staffSize, trailingGap: keySigTrailing)
+        keySignatureWidth(for: $0, clef: clef, metadata: metadata, staffSize: staffSize,
+                          trailingGap: keySigTrailing)
     } ?? 0
     return clefW + keySigW + timeSigW
 }

--- a/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
@@ -369,7 +369,7 @@ public struct VerticalLayoutEngine: Sendable {
                 ?? staffSize * 1.2
         }()
         let keySigW = jsystem.keySignature.map {
-            keySignatureWidth(for: $0, metadata: metadata, staffSize: staffSize,
+            keySignatureWidth(for: $0, clef: jsystem.clef, metadata: metadata, staffSize: staffSize,
                               trailingGap: keySigTrailing)
         } ?? 0
         let clefW = clefHeaderWidth(for: jsystem.clef, metadata: metadata, staffSize: staffSize)

--- a/Tests/CeolKitSVGRendererTests/KeySignaturePositionTests.swift
+++ b/Tests/CeolKitSVGRendererTests/KeySignaturePositionTests.swift
@@ -1,0 +1,227 @@
+import Testing
+import CeolKitModel
+import CeolKitParser
+import CeolKitSVGGeometry
+@testable import CeolKitSVGRenderer
+
+/// Issue #98: a key signature names pitches, so where its accidentals sit depends on the
+/// clef the staff carries. `keyAccidentals` used one treble-clef table for every clef, and
+/// two entries of that table were themselves an octave out.
+@Suite("Key signature positions per clef")
+struct KeySignaturePositionTests {
+
+    // MARK: - Reading positions back off the page
+
+    /// The staff positions of every `glyph` drawn on the staff of `system`, left to right.
+    ///
+    /// 0 = bottom line, 8 = top line — the same scale `KeyAccidental` uses. Only glyphs
+    /// within a staff's height of it are counted, which on a two-staff system is enough to
+    /// keep each staff's signature to itself.
+    private func positions(of glyph: SMuFLGlyph, on system: SystemGeometry,
+                           in svg: String) -> [Int] {
+        let character = String(glyph.character)
+        var found: [(x: Double, position: Int)] = []
+        for segment in svg.components(separatedBy: "<text ").dropFirst() {
+            guard segment.contains(character) else { continue }
+            func attribute(_ name: String) -> Double? {
+                guard let start = segment.range(of: "\(name)=\"") else { return nil }
+                let after = segment[start.upperBound...]
+                guard let end = after.firstIndex(of: "\"") else { return nil }
+                return Double(after[after.startIndex..<end])
+            }
+            guard let x = attribute("x"), let y = attribute("y") else { continue }
+            let position = (system.bottomY - y) / (system.staffLineGap / 2)
+            guard position > -6, position < 14 else { continue }
+            found.append((x, Int(position.rounded())))
+        }
+        return found.sorted { $0.x < $1.x }.map(\.position)
+    }
+
+    private func render(_ abc: String) throws -> (svg: String, page: PageGeometry) {
+        let score = CeolKitParser().parse(abc, options: .default).score
+        let svgs = try textProbeRenderer().render(score)
+        let svg = try #require(svgs.first)
+        let page = try #require(try SVGGeometry.pages(from: svgs).first)
+        return (svg, page)
+    }
+
+    /// A two-staff tune: voice 1 on the default treble clef, voice 2 on `clef`.
+    private func twoStaves(key: String, secondClef: String) throws -> (svg: String, page: PageGeometry) {
+        try render("""
+            X:1
+            T:Clefs
+            M:4/4
+            L:1/4
+            K:\(key)
+            V:1
+            V:2 clef=\(secondClef)
+            V:1
+            cdec |
+            V:2
+            CDEC |
+            """)
+    }
+
+    // MARK: - The bug as filed
+
+    @Test("A bass staff draws its key signature at bass-clef positions")
+    func bassClefKeySignature() throws {
+        let (svg, page) = try twoStaves(key: "E", secondClef: "bass")
+        #expect(page.systems.count == 2)
+        // Read as pitches both staves say F♯ C♯ G♯ D♯; before the fix the bass staff took
+        // the treble offsets and said A♯ E♯ B♯ F♯.
+        #expect(positions(of: .accidentalSharp, on: page.systems[0], in: svg) == [8, 5, 9, 6])
+        #expect(positions(of: .accidentalSharp, on: page.systems[1], in: svg) == [6, 3, 7, 4])
+    }
+
+    @Test("Three sharps put G♯ in the space above a treble staff")
+    func trebleThirdSharpIsAboveTheStaff() throws {
+        let (svg, page) = try render("""
+            X:1
+            T:A major
+            M:4/4
+            L:1/4
+            K:A
+            cdec |
+            """)
+        let staff = try #require(page.systems.first)
+        #expect(positions(of: .accidentalSharp, on: staff, in: svg) == [8, 5, 9])
+    }
+
+    @Test("K:Cb puts F♭ in the first space")
+    func cFlatMajorSeventhFlat() throws {
+        let (svg, page) = try render("""
+            X:1
+            T:C flat major
+            M:4/4
+            L:1/4
+            K:Cb
+            cdec |
+            """)
+        let staff = try #require(page.systems.first)
+        #expect(positions(of: .accidentalFlat, on: staff, in: svg) == [4, 7, 3, 6, 2, 5, 1])
+    }
+
+    @Test("One and two accidentals on a treble staff are where they always were")
+    func fewAccidentalsAreUnchanged() throws {
+        for (key, glyph, expected) in [("G", SMuFLGlyph.accidentalSharp, [8]),
+                                       ("D", .accidentalSharp, [8, 5]),
+                                       ("F", .accidentalFlat, [4]),
+                                       ("Bb", .accidentalFlat, [4, 7])] {
+            let (svg, page) = try render("""
+                X:1
+                T:\(key)
+                M:4/4
+                L:1/4
+                K:\(key)
+                cdec |
+                """)
+            let staff = try #require(page.systems.first)
+            #expect(positions(of: glyph, on: staff, in: svg) == expected, "K:\(key)")
+        }
+    }
+
+    @Test("A percussion staff draws no key signature")
+    func percussionDrawsNothing() throws {
+        let (svg, page) = try twoStaves(key: "E", secondClef: "perc")
+        #expect(page.systems.count == 2)
+        #expect(positions(of: .accidentalSharp, on: page.systems[1], in: svg).isEmpty)
+        // The treble voice above it still gets its four, so the tune really is in E.
+        #expect(positions(of: .accidentalSharp, on: page.systems[0], in: svg).count == 4)
+    }
+
+    @Test("K:none draws no key signature")
+    func keyNoneDrawsNothing() throws {
+        let (svg, page) = try render("""
+            X:1
+            T:No key
+            M:4/4
+            L:1/4
+            K:none
+            cdec |
+            """)
+        let staff = try #require(page.systems.first)
+        #expect(positions(of: .accidentalSharp, on: staff, in: svg).isEmpty)
+        #expect(positions(of: .accidentalFlat, on: staff, in: svg).isEmpty)
+    }
+
+    // MARK: - The whole table, clef by clef
+
+    /// The key signature of `key`, laid out on `clef`, as staff positions.
+    private func table(_ key: String, _ clef: Clef) throws -> [Int] {
+        let score = CeolKitParser().parse("""
+            X:1
+            T:T
+            M:4/4
+            L:1/4
+            K:\(key)
+            cdec |
+            """, options: .default).score
+        let signature = try #require(score.tunes.first?.key)
+        return keyAccidentals(for: signature, clef: ClefSpec(clef: clef, octaveShift: 0))
+            .map(\.staffPosition)
+    }
+
+    /// Every accidental of a seven-accidental signature is on the staff, or — for the bass
+    /// F♭ alone — the position immediately below it, where a key signature draws no ledger
+    /// line. The C clefs earn their own tables precisely because a plain shift would push
+    /// accidentals off the staff.
+    @Test("Seven sharps and seven flats stay on the staff on every pitched clef",
+          arguments: [Clef.treble, .bass, .baritone, .alto, .tenor, .soprano, .mezzoSoprano])
+    func sevenAccidentalsFitTheStaff(clef: Clef) throws {
+        let sharps = try table("C#", clef)
+        let flats  = try table("Cb", clef)
+        #expect(sharps.count == 7)
+        #expect(flats.count == 7)
+        // The treble G♯ sits one position above the top line by convention; nothing else
+        // leaves the staff except the bass F♭, one below the bottom line.
+        #expect(sharps.allSatisfy { $0 >= 0 && $0 <= 9 })
+        #expect(flats.allSatisfy { $0 >= -1 && $0 <= 8 })
+    }
+
+    /// The engraved positions, clef by clef, in circle-of-fifths order.
+    @Test("The accidental tables are the conventional engraving",
+          arguments: [(Clef.treble,       [8, 5, 9, 6, 3, 7, 4], [4, 7, 3, 6, 2, 5, 1]),
+                      (.bass,             [6, 3, 7, 4, 1, 5, 2], [2, 5, 1, 4, 0, 3, -1]),
+                      (.baritone,         [4, 8, 5, 2, 6, 3, 7], [7, 3, 6, 2, 5, 1, 4]),
+                      (.alto,             [7, 4, 8, 5, 2, 6, 3], [3, 6, 2, 5, 1, 4, 0]),
+                      (.tenor,            [2, 6, 3, 7, 4, 8, 5], [5, 8, 4, 7, 3, 6, 2]),
+                      (.soprano,          [3, 7, 4, 8, 5, 2, 6], [6, 2, 5, 1, 4, 0, 3]),
+                      (.mezzoSoprano,     [5, 2, 6, 3, 7, 4, 8], [8, 4, 7, 3, 6, 2, 5])])
+    func tablesMatchTheEngravedConvention(clef: Clef, sharps: [Int], flats: [Int]) throws {
+        #expect(try table("C#", clef) == sharps)
+        #expect(try table("Cb", clef) == flats)
+    }
+
+    /// Consecutive accidentals of a signature move by a fifth or a fourth, in whichever
+    /// octave keeps them on the staff — the property that makes each table a signature
+    /// rather than seven unrelated positions.
+    @Test("Consecutive accidentals are a fifth or a fourth apart",
+          arguments: [Clef.treble, .bass, .baritone, .alto, .tenor, .soprano, .mezzoSoprano])
+    func accidentalsStepByFifthsAndFourths(clef: Clef) throws {
+        for key in ["C#", "Cb"] {
+            let table = try table(key, clef)
+            for (a, b) in zip(table, table.dropFirst()) {
+                #expect(abs(b - a) == 3 || abs(b - a) == 4,
+                        "\(clef) \(key): \(a) → \(b) is neither a fourth nor a fifth")
+            }
+        }
+    }
+
+    @Test("An octave-shifted clef does not move the key signature",
+          arguments: [-8, 8])
+    func octaveShiftDoesNotMoveTheSignature(shift: Int) throws {
+        let score = CeolKitParser().parse("""
+            X:1
+            T:T
+            M:4/4
+            L:1/4
+            K:E
+            cdec |
+            """, options: .default).score
+        let signature = try #require(score.tunes.first?.key)
+        let plain   = keyAccidentals(for: signature, clef: ClefSpec(clef: .treble, octaveShift: 0))
+        let shifted = keyAccidentals(for: signature, clef: ClefSpec(clef: .treble, octaveShift: shift))
+        #expect(plain.map(\.staffPosition) == shifted.map(\.staffPosition))
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/__Snapshots__/CanzonettaConformanceTests/pageMatchesSnapshot.1.txt
+++ b/Tests/CeolKitSVGRendererTests/__Snapshots__/CanzonettaConformanceTests/pageMatchesSnapshot.1.txt
@@ -390,9 +390,9 @@
   <use href="#libertinusSerif-g80" xlink:href="#libertinusSerif-g80" transform="translate(66.084 232.548) scale(0.012 -0.012)"/>
   <use href="#libertinusSerif-g83" xlink:href="#libertinusSerif-g83" transform="translate(72.132 232.548) scale(0.012 -0.012)"/>
   <use href="#bravura-g92" xlink:href="#bravura-g92" transform="translate(97.752 222.6) scale(0.024 -0.024)"/>
-  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(115.788 228.6) scale(0.024 -0.024)"/>
-  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(122.364 219.6) scale(0.024 -0.024)"/>
-  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(128.94 231.6) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(115.788 234.6) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(122.364 225.6) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(128.94 237.6) scale(0.024 -0.024)"/>
   <use href="#bravura-g132" xlink:href="#bravura-g132" transform="translate(138.516 228.6) scale(0.024 -0.024)"/>
   <line x1="159.192" y1="216.6" x2="159.192" y2="240.6" stroke="black" stroke-width="0.96"/>
   <line x1="163.992" y1="216.6" x2="163.992" y2="240.6" stroke="black" stroke-width="3"/>
@@ -763,9 +763,9 @@
   <line x1="63.996" y1="453" x2="576" y2="453" stroke="black" stroke-width="0.78"/>
   <use href="#libertinusSerif-g35" xlink:href="#libertinusSerif-g35" transform="translate(37.284 444.948) scale(0.012 -0.012)"/>
   <use href="#bravura-g92" xlink:href="#bravura-g92" transform="translate(65.496 435) scale(0.024 -0.024)"/>
-  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(83.532 441) scale(0.024 -0.024)"/>
-  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(90.108 432) scale(0.024 -0.024)"/>
-  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(96.684 444) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(83.532 447) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(90.108 438) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(96.684 450) scale(0.024 -0.024)"/>
   <line x1="220.022" y1="429" x2="220.022" y2="453" stroke="black" stroke-width="0.96"/>
   <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(117.42 423) scale(0.024 -0.024)"/>
   <line x1="117.42" y1="423" x2="117.42" y2="444" stroke="black" stroke-width="0.72"/>
@@ -1098,9 +1098,9 @@
   <use href="#libertinusSerif-g19" xlink:href="#libertinusSerif-g19" transform="translate(459.206 646.242) scale(0.013 -0.013)"/>
   <use href="#libertinusSerif-g35" xlink:href="#libertinusSerif-g35" transform="translate(37.284 666.21) scale(0.012 -0.012)"/>
   <use href="#bravura-g92" xlink:href="#bravura-g92" transform="translate(65.496 656.262) scale(0.024 -0.024)"/>
-  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(83.532 662.262) scale(0.024 -0.024)"/>
-  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(90.108 653.262) scale(0.024 -0.024)"/>
-  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(96.684 665.262) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(83.532 668.262) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(90.108 659.262) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(96.684 671.262) scale(0.024 -0.024)"/>
   <line x1="194.178" y1="650.262" x2="194.178" y2="674.262" stroke="black" stroke-width="0.96"/>
   <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(117.42 656.262) scale(0.024 -0.024)"/>
   <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(111.276 656.262) scale(0.024 -0.024)"/>

--- a/Tests/CeolKitSVGRendererTests/__Snapshots__/ZochartiLochConformanceTests/zochartiPageMatchesSnapshot.1.txt
+++ b/Tests/CeolKitSVGRendererTests/__Snapshots__/ZochartiLochConformanceTests/zochartiPageMatchesSnapshot.1.txt
@@ -187,8 +187,8 @@
   <use href="#libertinusSerif-g80" xlink:href="#libertinusSerif-g80" transform="translate(64.86 150.948) scale(0.012 -0.012)"/>
   <use href="#libertinusSerif-g42" xlink:href="#libertinusSerif-g42" transform="translate(73.908 150.948) scale(0.012 -0.012)"/>
   <use href="#bravura-g92" xlink:href="#bravura-g92" transform="translate(84.972 141) scale(0.024 -0.024)"/>
-  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(103.008 147) scale(0.024 -0.024)"/>
-  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(109.584 138) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(103.008 153) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(109.584 144) scale(0.024 -0.024)"/>
   <use href="#bravura-g132" xlink:href="#bravura-g132" transform="translate(119.16 147) scale(0.024 -0.024)"/>
   <line x1="252.279" y1="135" x2="252.279" y2="159" stroke="black" stroke-width="0.96"/>
   <use href="#bravura-g994" xlink:href="#bravura-g994" transform="translate(146.916 141) scale(0.024 -0.024)"/>
@@ -286,8 +286,8 @@
   <use href="#libertinusSerif-g15" xlink:href="#libertinusSerif-g15" transform="translate(43.164 258.948) scale(0.012 -0.012)"/>
   <use href="#libertinusSerif-g42" xlink:href="#libertinusSerif-g42" transform="translate(45.804 258.948) scale(0.012 -0.012)"/>
   <use href="#bravura-g92" xlink:href="#bravura-g92" transform="translate(56.868 249) scale(0.024 -0.024)"/>
-  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(74.904 255) scale(0.024 -0.024)"/>
-  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(81.48 246) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(74.904 261) scale(0.024 -0.024)"/>
+  <use href="#bravura-g535" xlink:href="#bravura-g535" transform="translate(81.48 252) scale(0.024 -0.024)"/>
   <line x1="153.216" y1="243" x2="153.216" y2="267" stroke="black" stroke-width="0.96"/>
   <use href="#bravura-g158" xlink:href="#bravura-g158" transform="translate(102.216 249) scale(0.024 -0.024)"/>
   <line x1="109.296" y1="228" x2="109.296" y2="249" stroke="black" stroke-width="0.72"/>


### PR DESCRIPTION
Closes #98.

`keyAccidentals` took a key and nothing else, so every staff drew its signature at treble-clef offsets from its own staff top. Read as pitches, a bass staff in E major was drawing A♯ E♯ B♯ F♯.

## What changed

`Sources/CeolKitSVGRenderer/Emission/KeySignatureLayout.swift`

- `keyAccidentals(for:clef:)` takes the staff's `ClefSpec` and reads a private `signatureTable(for:)` per clef. An octave shift on the clef does not move the signature — `treble+8` still names the same staff lines.
- The tables are the engraved convention, not arithmetic on the treble one. The C clefs place individual accidentals an octave away from a plain transposition so all seven stay on the staff (tenor starts F♯ on line 2; mezzo-soprano and soprano pick their own octaves).
- `percussion` and `none` carry no pitch, so they return no accidentals.
- Two octave slips in the treble table are fixed alongside, since they live in the same arrays: **G♯ → position 9**, the space above the staff (shows from three sharps up), and **F♭ → position 1**, the first space (`K:Cb` only).
- `keySignatureWidth` takes the clef too. Unchanged for the pitched clefs, since it only counts accidentals — but it now correctly returns 0 for a percussion staff.

Call sites updated: `SVGEmitter.emitKeySignature`, `SVGEmitter.emitTimeSignature`, `SystemHeaderLayout.systemHeaderWidth`, `VerticalLayoutEngine.systemStartWidth`. All four already had the clef in hand.

## Verification

Measured off the emitted SVG with the issue's repro — staff position, 0 = bottom line of each staff:

| | before | after |
|---|---|---|
| treble | 8, 5, 2, 6 | 8, 5, **9**, 6 |
| bass | 8, 5, 2, 6 | **6, 3, 7, 4** |

`K:Cb` on treble now gives 4, 7, 3, 6, 2, 5, **1**.

## Tests

New `Tests/CeolKitSVGRendererTests/KeySignaturePositionTests.swift` — 10 tests reading positions back off the page, one per acceptance criterion, plus the full table for all seven pitched clefs and two invariants: every accidental stays on the staff (the bass F♭ one position below it excepted, where a signature draws no ledger line), and consecutive accidentals are a fourth or a fifth apart.

Two page snapshots re-recorded: Canzonetta and Zocharti Loch each have a bass voice, and its key signature moving down two positions is the only difference in either diff.

Full suite: 1100 tests pass.

## Found while here, not fixed

Both outside this issue, both pre-existing:

- A clef stated on the `K:` line (`K:E clef=bass`) never reaches `VoiceProperties.clef`, so it renders as treble. Only `V:` clefs take effect.
- `SVGEmitter.emitClef` draws `baritone` at the same y as `bass` — an F clef on line 4 rather than line 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gcoatYjXw3aQyM4oaoiou