### PR TITLE
Fix #102 — a line-set marks a stave in every voice

### DIFF
--- a/Sources/CeolKitParser/Semantic/BodyContext.swift
+++ b/Sources/CeolKitParser/Semantic/BodyContext.swift
@@ -3,9 +3,20 @@ import CeolKitModel
 
 // MARK: - VoiceAccumulator
 
+/// Where one of a voice's staves ends, as a position in its `closedMeasures`.
+struct StaveBreak {
+    /// The measure the stave this break closes stops before.
+    var measureIndex: Int
+    /// True when the stave this break closes is one the voice wrote nothing in — a line-set
+    /// the source left it out of.  Kept so the voice's later staves stay in step with the
+    /// tune's stave numbering (#102); an ordinary break that happens to close no measures is
+    /// not one of these, and still collapses away when the staves are sliced.
+    var isEmptyStave = false
+}
+
 struct VoiceAccumulator {
     var closedMeasures: [Measure] = []
-    var staveBreakIndices: [Int] = []
+    var staveBreaks: [StaveBreak] = []
     var currentEvents: [Event] = []
     var lastBarLine: BarLine? = nil
     var measureSource: SourceRange
@@ -42,9 +53,19 @@ struct VoiceAccumulator {
     }
 
     /// How many staves of this voice are finished — the index of the stave now being
-    /// written.  Boundaries that close no measures are dropped when the staves are sliced
-    /// (a lone `V:` line before any music makes one), so they are not counted here either.
+    /// written.  A boundary that closes no measures is dropped when the staves are sliced, so
+    /// it is not counted here either; the one exception is the empty stave of a line-set the
+    /// voice was left out of, which is a stave and is counted once it is written out.
     var completedStaveCount = 0
+
+    /// Line-set boundaries this voice met with nothing to write — the systems the source
+    /// simply left it out of (#102).
+    ///
+    /// Remembered rather than recorded, because whether they are staves at all depends on
+    /// what comes after: a voice that plays again writes them out as empty staves, so its
+    /// later music keeps its own line, while one that has finished ends where it stops
+    /// rather than growing empty staves to the end of the tune.
+    var pendingEmptyStaves = 0
 
     /// True once any musical content has landed in this voice — a closed measure, or a
     /// non-spacer event in the measure now being written.
@@ -61,7 +82,7 @@ struct VoiceAccumulator {
     /// True when measures or events have accumulated since the last boundary, so the stave
     /// now being written already holds music.
     var hasStaveInProgress: Bool {
-        if closedMeasures.count > staveBreakIndices.last ?? 0 { return true }
+        if closedMeasures.count > staveBreaks.last?.measureIndex ?? 0 { return true }
         return currentEvents.contains {
             if case .spacer = $0 { return false }
             return true
@@ -109,9 +130,33 @@ struct VoiceAccumulator {
 
     mutating func markStaveBoundary() {
         let idx = closedMeasures.count
-        guard idx != staveBreakIndices.last else { return }  // no new measures since last split
-        if idx > staveBreakIndices.last ?? 0 { completedStaveCount += 1 }
-        staveBreakIndices.append(idx)
+        guard idx != staveBreaks.last?.measureIndex else { return }  // no new measures since last split
+        // Any line-set this voice sat out is a stave after all: it played again, so the
+        // music that follows belongs to a later line than the music before it (#102).  They
+        // close where the voice left off, which is where it still is — nothing was written
+        // in between, so that is the last break's own index.
+        let resume = staveBreaks.last?.measureIndex ?? 0
+        for _ in 0..<pendingEmptyStaves {
+            staveBreaks.append(StaveBreak(measureIndex: resume, isEmptyStave: true))
+            completedStaveCount += 1
+        }
+        pendingEmptyStaves = 0
+        if idx > resume { completedStaveCount += 1 }
+        staveBreaks.append(StaveBreak(measureIndex: idx))
+    }
+
+    /// Records the end of a line-set — one system of the source — for this voice.
+    ///
+    /// A voice with music standing in it finishes that stave.  A voice the line-set passed
+    /// over remembers an empty one; a voice that has not started yet gets nothing, because a
+    /// source that writes each voice as a block rather than line for line is not skipping
+    /// anything — its second voice simply begins at its own first stave.
+    mutating func markLineSetBoundary() {
+        if hasStaveInProgress {
+            markStaveBoundary()
+        } else if hasMusic {
+            pendingEmptyStaves += 1
+        }
     }
 
     mutating func closeWith(barLine: BarLine, endingNumber: [Int]?) {
@@ -783,6 +828,22 @@ struct BodyContext {
 
     mutating func splitStave(in voice: VoiceKey) {
         voices[voice]?.accumulator.markStaveBoundary()
+    }
+
+    /// Ends the line-set every voice is writing.
+    ///
+    /// Stave index is the unit the two layout passes align on — stave *k* of one voice is
+    /// stave *k* of every other — so the boundary has to reach every voice, not just the one
+    /// the source happened to leave the cursor in.  A voice the line-set holds no line for
+    /// is exactly what makes this necessary: without a stave marked here its later music
+    /// shifts up a line and nothing downstream can tell (#102).
+    ///
+    /// `&` layers are left alone: a layer is sliced with the staves of the voice it overlays,
+    /// so a break of its own would cut it somewhere that voice does not break.
+    mutating func closeLineSet() {
+        for key in voices.keys where !key.isOverlay {
+            voices[key]?.accumulator.markLineSetBoundary()
+        }
     }
 
     /// The index of the stave now being written, for the tune as a whole.

--- a/Sources/CeolKitParser/Semantic/SemanticPass.swift
+++ b/Sources/CeolKitParser/Semantic/SemanticPass.swift
@@ -294,40 +294,98 @@ struct SemanticPass {
         // The one cursor in the pass, threaded from here down.  It is a parameter rather than
         // a field on BodyContext so nothing can read "the current voice" implicitly.
         var voice = ctx.initialVoice
-        // Whether the line just walked asked for the system to break after it.  Held rather
-        // than acted on, because the *next* line gets to cancel it: §7.4 writes an overlay
-        // under the music it overlays, and a line beginning `&` is a continuation of the one
-        // above, not a stave of its own.
-        var breakPending = false
-        for line in body {
+        // Where each line-set ends, worked out ahead of the walk because it takes the *next*
+        // line to know: a system ends where the source starts writing a voice it has already
+        // written here.  Under `I:linebreak <none>` or `$` alone the end of a line is not a
+        // break at all, and only an explicit `$`/`!` splits a stave.
+        let lineSetEnds = ctx.linebreakOnEOL
+            ? lineSetBoundaries(body, initialVoice: ctx.initialVoice)
+            : []
+        for (index, line) in body.enumerated() {
             // Check if this is a single-field lyric line
-            if line.count == 1, case .inlineField(let f, _) = line[0], case .lyric(let tokens, _) = f {
+            if isLyricLine(line), case .inlineField(let f, _) = line[0], case .lyric(let tokens, _) = f {
                 // §7.4: "disregarding any overlay in the accompanying music code" — the
                 // syllables belong to the voice, not to whichever `&` layer the line above
                 // left the cursor standing in.
                 ctx.applyLyrics(tokens, in: voice.primary)
                 continue
             }
-            if continuesOverlay(line) {
-                // A line beginning `&` overlays the line above it, so it takes neither a
-                // stave of its own nor a lyric anchor of its own: §7.4 matches `w:` to the
-                // notes "disregarding any overlay in the accompanying music code", and the
-                // notes it means are the ones above.  The cursor stays where that line left
-                // it too, so this line's leading `&` opens the *next* layer over the same
-                // music: three parts written as three lines and three parts written on one
-                // line with two `&`s are the same tune.
-                breakPending = false
-            } else {
-                if breakPending { ctx.splitStave(in: voice.primary) }
+            // A line beginning `&` overlays the line above it, so it takes neither a stave of
+            // its own nor a lyric anchor of its own: §7.4 matches `w:` to the notes
+            // "disregarding any overlay in the accompanying music code", and the notes it
+            // means are the ones above.  The cursor stays where that line left it too, so
+            // this line's leading `&` opens the *next* layer over the same music: three parts
+            // written as three lines and three parts written on one line with two `&`s are
+            // the same tune.
+            if !continuesOverlay(line) {
                 ctx.recordLyricAnchors()
                 // An ordinary line opens in the voice itself: an `&` layer lives to the end
                 // of the line that opened it, and the next line's first `&` reopens layer one.
                 voice = voice.primary
             }
             walkLine(line, voice: &voice, ctx: &ctx, diagnostics: &diagnostics)
-            breakPending = ctx.linebreakOnEOL
+            if lineSetEnds.contains(index) { ctx.closeLineSet() }
         }
-        if breakPending { ctx.splitStave(in: voice.primary) }
+    }
+
+    /// The body lines each line-set ends at.
+    ///
+    /// A line-set is what the source lays out as one system, and the parser is handed a flat
+    /// stream of lines with no marker between them.  What identifies one is the voices: a run
+    /// of lines in which each voice appears once, ending as soon as a line writes to a voice
+    /// the run already holds.  A source that writes each voice as a whole block instead falls
+    /// out of the same rule — every one of its lines is a line-set of its own, which is what
+    /// keeps each voice counting its own staves from zero.
+    ///
+    /// The boundary is reported against the last line that *wrote* something, not the line
+    /// that begins the next set, so the `V:` and `%%score` lines introducing a system are
+    /// walked on its far side — a plan written there governs from the stave it stands above.
+    private func lineSetBoundaries(_ body: [[MusicElement]], initialVoice: VoiceKey) -> Set<Int> {
+        var boundaries: Set<Int> = []
+        var current = initialVoice.base
+        var written: Set<String> = []
+        var lastContentLine: Int? = nil
+
+        for (index, line) in body.enumerated() {
+            if isLyricLine(line) { continue }
+            // An `&` continuation belongs to the line above it, so it neither opens a set nor
+            // may be cut away from the music it overlays.
+            if continuesOverlay(line) {
+                lastContentLine = index
+                continue
+            }
+            var voicesWritten: Set<String> = []
+            for element in line {
+                switch element {
+                case .inlineField(let field, _):
+                    if case .voice(let id, _, _) = field { current = id }
+                case .space, .voiceOverlay, .unknown:
+                    continue
+                default:
+                    voicesWritten.insert(current)
+                }
+            }
+            guard !voicesWritten.isEmpty else { continue }
+            if !voicesWritten.isDisjoint(with: written), let end = lastContentLine {
+                boundaries.insert(end)
+                written = []
+            }
+            written.formUnion(voicesWritten)
+            lastContentLine = index
+        }
+        // The body ends the line-set it is in, at the last line that wrote anything: a
+        // `%%score` trailing the music governs from the stave after it, not from the last one
+        // written.
+        if let end = lastContentLine { boundaries.insert(end) }
+        return boundaries
+    }
+
+    /// Whether `line` is a lyric line — a `w:` on its own, which belongs to the music above
+    /// it and is neither music nor a line-set of its own.
+    private func isLyricLine(_ line: [MusicElement]) -> Bool {
+        guard line.count == 1, case .inlineField(let field, _) = line[0],
+              case .lyric = field else { return false }
+        return true
     }
 
     /// Whether `line` is the continuation of the one before it — an `&` overlay written on
@@ -1166,13 +1224,14 @@ struct SemanticPass {
                 // They are that line's — the source wrote them there — so the boundary
                 // recorded at what used to be the end is no longer a boundary at all.
                 let breaks = measures.count > barsWritten
-                    ? accumulator.staveBreakIndices.filter { $0 < barsWritten }
-                    : accumulator.staveBreakIndices
+                    ? accumulator.staveBreaks.filter { $0.measureIndex < barsWritten }
+                    : accumulator.staveBreaks
 
                 var start = 0
-                func appendStaff(through end: Int) {
+                func appendStaff(through end: Int, evenIfEmpty: Bool = false) {
                     let slice = Array(measures[start..<end])
-                    guard !slice.isEmpty || (staves.isEmpty && end == measures.count) else { return }
+                    guard evenIfEmpty || !slice.isEmpty || (staves.isEmpty && end == measures.count)
+                    else { return }
                     staves.append(Staff(
                         measures: slice,
                         overlays: layers.map {
@@ -1180,9 +1239,12 @@ struct SemanticPass {
                                          source: $0.source)
                         }))
                 }
-                for breakIdx in breaks where breakIdx <= measures.count {
-                    appendStaff(through: breakIdx)
-                    start = breakIdx
+                // An empty stave is kept, where an ordinary break that closed no measures is
+                // not: it is a line-set the source wrote no line for in this voice, and
+                // dropping it would shift every stave after it up one (#102).
+                for brk in breaks where brk.measureIndex <= measures.count {
+                    appendStaff(through: brk.measureIndex, evenIfEmpty: brk.isEmptyStave)
+                    start = brk.measureIndex
                 }
                 appendStaff(through: measures.count)
             } else {

--- a/Sources/CeolKitSVGRenderer/Layout/PlanRegion.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/PlanRegion.swift
@@ -15,11 +15,10 @@ import CeolKitModel
 ///
 /// **Regions are cut by stave index**, which is the same numbering ``VoiceAligner`` aligns on:
 /// stave *k* of one voice is stave *k* of every other.  A source that gives a voice no line at
-/// all in some line-set breaks that assumption before a plan is involved — the voice's later
-/// staves all shift up one — and a region cut then lands in the wrong place for it, exactly as
-/// the aligner's padding already does.  That is issue #102, and it is the parser that has to
-/// fix it: nothing here can recover a stave the model never recorded.  Until then, write every
-/// voice a line per system and the numbering holds.
+/// all in some line-set holds to that too, since #102: the parser marks a stave in every voice
+/// at each line-set boundary, so the voice has an empty `Staff` where it was left out and its
+/// later music keeps its own line.  A cut here therefore lands in the same place for every
+/// voice, and needs no caveat about how the source was written.
 struct PlanRegion {
     /// The plan governing this region, or `nil` for the opening region of a tune whose plans
     /// all start later — that stretch is laid out exactly as a tune with no plan at all.

--- a/Sources/CeolKitSVGRenderer/Layout/VoiceAligner.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VoiceAligner.swift
@@ -48,6 +48,10 @@ enum VoiceAligner {
     /// tune's widest therefore gains whole padded lines at the end rather than having its
     /// music silently slide up into someone else's line.
     ///
+    /// Only the *tail* is ever short: a voice the source left out of a line-set part way
+    /// through carries an empty `Staff` at that index (#102), so what arrives here is already
+    /// in the tune's stave numbering and the padding has nothing to guess at.
+    ///
     /// - Returns: One entry per stave, in source order.  Empty when `voices` is empty.
     static func align(_ voices: [Voice], into diagnostics: inout [Diagnostic]) -> [AlignedStave] {
         guard !voices.isEmpty else { return [] }

--- a/Tests/CeolKitParserTests/Conformance/LineSetStaveTests.swift
+++ b/Tests/CeolKitParserTests/Conformance/LineSetStaveTests.swift
@@ -1,0 +1,256 @@
+// Line-sets and stave numbering — issue #102.
+//
+// Stave index is the unit the layout passes align on: stave *k* of one voice is stave *k* of
+// every other.  A source that gives a voice no line at all in some line-set used to break
+// that silently — the voice simply got no stave there, and all its later music shifted up a
+// line — because the parser saw a flat stream of lines and never learned that three `V:`
+// lines were one system.
+//
+// What this file pins down is the line-set: where one ends, what every voice records at that
+// boundary, and the two shapes that must *not* change — a source written one block per voice,
+// and a voice that stops before the tune does.
+import Testing
+import CeolKitModel
+import CeolKitParser
+
+@Suite("Line-sets and stave numbering")
+struct LineSetStaveTests {
+
+    /// Each voice's stave count, in print order.
+    private func staveCounts(_ result: ParseResult) -> [Int] {
+        (result.score.firstTune?.voices ?? []).map(\.staves.count)
+    }
+
+    /// The source lines each stave of `voice` drew its measures from — `[]` for a stave the
+    /// voice wrote nothing in.
+    private func staveLines(_ result: ParseResult, _ id: String) -> [[Int]] {
+        let voice = result.score.firstTune?.voices.first { $0.id == .named(id) }
+        return (voice?.staves ?? []).map { $0.measures.map(\.source.line) }
+    }
+
+    // MARK: A voice omitted from a middle line-set
+
+    @Test("A voice with no line in a middle line-set gets an empty stave there")
+    func omittedMiddleLineSetLeavesAnEmptyStave() {
+        // V:2 is written for the first and third line-sets and left out of the second — the
+        // natural way to write it under a plan that does not print it there.  Its last line
+        // is its *third* stave, not its second.
+        let result = parse("""
+            X:1
+            L:1/4
+            V:1
+            V:2
+            K:C
+            V:1
+            CDEF|
+            V:2
+            GABc|
+            V:1
+            CDEF|
+            V:1
+            cdef|
+            V:2
+            GABc|
+            """)
+        #expect(staveCounts(result) == [3, 3])
+        #expect(staveLines(result, "1") == [[7], [11], [13]])
+        #expect(staveLines(result, "2") == [[9], [], [15]])
+    }
+
+    @Test("The empty stave holds no measures, and no overlays either")
+    func theEmptyStaveIsEmpty() {
+        let result = parse("""
+            X:1
+            L:1/4
+            V:1
+            V:2
+            K:C
+            V:1
+            CDEF|
+            V:2
+            GABc|
+            V:1
+            CDEF|
+            V:1
+            cdef|
+            V:2
+            GABc|
+            """)
+        let staff = result.score.firstTune?.voices.last?.staves[1]
+        #expect(staff?.measures.isEmpty == true)
+        #expect(staff?.overlays.isEmpty == true)
+    }
+
+    @Test("Two line-sets skipped in a row are two empty staves, not one")
+    func consecutiveOmissionsEachGetAStave() {
+        let result = parse("""
+            X:1
+            L:1/4
+            V:1
+            V:2
+            K:C
+            V:1
+            CDEF|
+            V:2
+            GABc|
+            V:1
+            CDEF|
+            V:1
+            CDEF|
+            V:1
+            cdef|
+            V:2
+            GABc|
+            """)
+        #expect(staveCounts(result) == [4, 4])
+        #expect(staveLines(result, "2") == [[9], [], [], [17]])
+    }
+
+    // MARK: What must not change
+
+    @Test("A voice that stops before the tune does ends where it stops")
+    func trailingOmissionDoesNotGrowEmptyStaves() {
+        // The aligner pads a short tail; the parser must not invent staves for music the
+        // source never wrote, or every voice would run to the end of the longest one.
+        let result = parse("""
+            X:1
+            L:1/4
+            V:1
+            V:2
+            K:C
+            V:1
+            CDEF|
+            V:2
+            GABc|
+            V:1
+            CDEF|
+            """)
+        #expect(staveCounts(result) == [2, 1])
+    }
+
+    @Test("A source written one block per voice keeps each voice counting from its own first stave")
+    func blockPerVoiceIsUnchanged() {
+        // Nothing here is skipped: V:2 simply begins where V:1 finished.  Its first line is
+        // stave 0, which is what makes the two blocks line up.
+        let result = parse("""
+            X:1
+            L:1/4
+            V:1
+            V:2
+            K:C
+            V:1
+            CDEF|
+            GABc|
+            V:2
+            cdef|
+            gabc'|
+            """)
+        #expect(staveCounts(result) == [2, 2])
+        #expect(staveLines(result, "1") == [[7], [8]])
+        #expect(staveLines(result, "2") == [[10], [11]])
+    }
+
+    @Test("A single-voice tune is one stave per source line, as it always was")
+    func singleVoiceIsUnchanged() {
+        let result = parse("""
+            X:1
+            L:1/4
+            K:C
+            CDEF|
+            GABc|
+            cdef|
+            """)
+        #expect(staveCounts(result) == [3])
+        #expect(staveLines(result, "1") == [[4], [5], [6]])
+    }
+
+    @Test("Voices written inline, one line-set to a line, still get one stave each per line")
+    func inlineVoiceSwitchesAreOneLineSetPerLine() {
+        let result = parse("""
+            X:1
+            L:1/4
+            V:1
+            V:2
+            K:C
+            [V:1]CDEF|
+            [V:2]GABc|
+            [V:1]cdef|
+            [V:2]gabc'|
+            """)
+        #expect(staveCounts(result) == [2, 2])
+        #expect(staveLines(result, "1") == [[6], [8]])
+        #expect(staveLines(result, "2") == [[7], [9]])
+    }
+
+    @Test("An & overlay line stays with the music it overlays rather than opening a line-set")
+    func overlayContinuationDoesNotBreakTheLineSet() {
+        let result = parse("""
+            X:1
+            L:1/4
+            V:1
+            V:2
+            K:C
+            V:1
+            CDEF|
+            &GABc|
+            V:2
+            cdef|
+            V:1
+            CDEF|
+            V:2
+            cdef|
+            """)
+        #expect(staveCounts(result) == [2, 2])
+        #expect(result.score.firstTune?.voices.first?.staves[0].overlays.count == 1)
+    }
+
+    // MARK: Where a line-set ends
+
+    @Test("A %%score after a line-set governs from the stave below it")
+    func bodyPlanTakesTheNextStave() {
+        // The boundary belongs after the last line the previous set wrote, so the plan
+        // introducing the next one is read on its own side of the break.
+        let result = parse("""
+            X:1
+            L:1/4
+            V:1
+            V:2
+            K:C
+            V:1
+            CDEF|
+            V:2
+            GABc|
+            %%score [1]
+            V:1
+            CDEF|
+            """)
+        #expect(result.score.firstTune?.staffPlans.map(\.effectiveFromStave) == [1])
+    }
+
+    @Test("A voice omitted from a middle line-set draws no diagnostic")
+    func theOmissionIsNotAnError() {
+        // Legal ABC, and idiomatic under a plan that does not print the voice there.
+        let result = parse("""
+            X:1
+            L:1/4
+            %%score [1 2]
+            V:1
+            V:2
+            K:C
+            V:1
+            CDEF|
+            V:2
+            GABc|
+            %%score [1]
+            V:1
+            CDEF|
+            %%score [1 2]
+            V:1
+            cdef|
+            V:2
+            GABc|
+            """)
+        #expect(result.diagnostics.isEmpty)
+        #expect(staveCounts(result) == [3, 3])
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/StaffPlanRegionTests.swift
+++ b/Tests/CeolKitSVGRendererTests/StaffPlanRegionTests.swift
@@ -174,6 +174,28 @@ struct StaffPlanRegionTests {
         #expect(dropped.first?.message.contains("'2'") == true)
     }
 
+    @Test("A voice the source leaves out of a region resumes on its own line after it")
+    func aVoiceOmittedFromARegionKeepsItsLine() {
+        // Issue #102: the same tune as `aDroppedVoiceComesBack`, written the way an author
+        // actually writes it — voice 2 has no line in the middle line-set, because the plan
+        // there does not print it.  Its last line must be drawn in the last region, not
+        // attributed to the middle one and dropped.
+        let abc = ([
+            "X:1", "L:1/4", "%%score [1 2]",
+            "V:1", "V:2", "K:C",
+            "V:1", "CDEF|", "V:2", "GABc|",
+            "%%score [1]",
+            "V:1", "CDEF|",
+            "%%score [1 2]",
+            "V:1", "cdef|", "V:2", "GABc|"
+        ] as [String]).joined(separator: "\n")
+
+        #expect(stavesPerSystem(abc) == [2, 1, 2])
+        // Nothing to say about it: an empty stave under a plan that prints no staff for the
+        // voice is exactly what the source asked for.
+        #expect(render(abc).diagnostics.isEmpty)
+    }
+
     @Test("Only the tune's very last system is the last one, however many regions there are")
     func onlyTheFinalRegionEndsTheTune() {
         // `justifyLastSystem` is off by default, so only a system marked last is left short;


### PR DESCRIPTION
Closes #102.

Stave index is the unit `VoiceAligner` and `PlanRegions` align on — stave *k* of one voice is stave *k* of every other. A source that gave a voice no line at all in some line-set broke that and nothing noticed: the voice got no stave there, so all its later music shifted up a line. The missing piece was that the parser had no notion of where a line-set ends.

## What changed

**`SemanticPass.lineSetBoundaries`** finds them ahead of the walk: a line-set is a run of lines in which each voice appears once, ending as soon as a line writes to a voice the run already holds. A source written one block per voice falls out of the same rule — every one of its lines is a line-set of its own, which is what keeps its second voice counting from its own first stave.

The boundary is recorded against the last line that *wrote* something, not the line that begins the next set, so the `V:` and `%%score` lines introducing a system are walked on its far side and a plan written there still governs from the stave it stands above.

**`BodyContext.closeLineSet`** marks a stave in every voice at that boundary, not just the one the source left the cursor in. `&` layers are left alone — a layer is sliced with the staves of the voice it overlays.

**`VoiceAccumulator.markLineSetBoundary`** decides what each voice records:

| voice at the boundary | what it gets |
| --- | --- |
| has music standing in it | finishes that stave |
| passed over, but has played | remembers an empty stave |
| has not started yet | nothing — a block-style source is not skipping anything |

A remembered empty stave is written out only when the voice plays again, so a voice that stops before the tune does ends where it stops and `VoiceAligner` keeps padding that tail. `staveBreakIndices: [Int]` became `staveBreaks: [StaveBreak]` carrying `isEmptyStave`, so a deliberate empty stave survives slicing while an ordinary break that closed no measures still collapses away.

## On the issue's source

`ckprobe` now reports both voices with 3 staves, voice 2's middle one empty and its last line at stave 2; plans govern from staves 0, 1, 2; the page renders two staves, then one, then two, with voice 2's last line drawn — and **no diagnostics at all**, where it previously emitted a `voiceNotInStaffPlan` that pointed at the plan rather than at the line whose music went missing.

## Two judgement calls

1. **No new diagnostic for an empty middle stave**, per the issue's own reading. With no `%%score` at all it does still surface as the existing `voiceLengthMismatch` warning — the same warning a voice already gets for a short *tail* — so `VoiceAligner.mismatch` was left alone rather than special-casing "wrote nothing here" in one place and not the other.
2. **A leading gap is not treated as a gap.** `V:2` first appearing after two of `V:1`'s line-sets is indistinguishable from a source written one block per voice, so it still starts at its own stave 0. Padding it would break the block style, which the aligner's design rests on.

## Tests

New `LineSetStaveTests` (10 cases): the omitted middle line-set, consecutive omissions, the trailing omission that must not grow, block-per-voice, single voice, inline `[V:n]` line-sets, an `&` continuation line, `%%score` placement, and the silence. One new case in `StaffPlanRegionTests` renders the issue's source and asserts 2/1/2 staves with no diagnostics — the sibling of `aDroppedVoiceComesBack`, written the way an author actually writes it.

Docs updated: the caveat `PlanRegion` carried from #69 is now a statement that the numbering holds, and `VoiceAligner.align` says only the tail is ever short.

1111 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gcoatYjXw3aQyM4oaoiou
