### PR TITLE
Fix #107 — a field reached through a \ continuation applies at the line break

### DIFF
--- a/Sources/CeolKitParser/Lexer/LineClassifier.swift
+++ b/Sources/CeolKitParser/Lexer/LineClassifier.swift
@@ -19,8 +19,11 @@ struct LineClassifier {
 
             // §2.2: a backslash continues a music line *through* information fields,
             // comments and stylesheet directives — only the next line of music code joins
-            // it.  Anything else is set aside and emitted after the music line it
-            // interrupted, so a `w:` still lands on the line it belongs to.  Comments are
+            // it.  §6.1.1 has those interrupting lines take effect *at the physical line
+            // break*, which is the whole reason to write a backslash, so each is spliced
+            // into the joined text as its inline equivalent.  A line with no inline form —
+            // `w:` above all — is set aside and emitted after the music line it
+            // interrupted, so it still lands on the line it belongs to.  Comments are
             // dropped, as they are everywhere else.
             if var cont = pendingContinuation {
                 switch line {
@@ -44,7 +47,11 @@ struct LineClassifier {
                     result += cont.deferred
                     pendingContinuation = nil
                 default:
-                    cont.deferred.append(line)
+                    if let inline = Self.inlineEquivalent(of: line) {
+                        cont.text += inline
+                    } else {
+                        cont.deferred.append(line)
+                    }
                     pendingContinuation = cont
                     continue
                 }
@@ -81,6 +88,35 @@ struct LineClassifier {
         }
 
         return joiningContinuedLyrics(result)
+    }
+
+    /// The `[code:payload]` text a line interrupting a `\\` continuation is equivalent to
+    /// (§6.1.1), or `nil` when it has no inline form and must be deferred to the end of the
+    /// joined line instead.
+    private static func inlineEquivalent(of line: LogicalLine) -> String? {
+        switch line {
+        case .informationField(let code, let payload, _):
+            guard inlineLegalFieldCodes.contains(code) else { return nil }
+            return bracketed(code: code, payload: payload)
+        case .directive(let name, let payload, _):
+            // §4.4: the stylesheet directive `%%name payload` is the field `I:name payload`.
+            return bracketed(code: "I", payload: payload.isEmpty ? name : "\(name) \(payload)")
+        default:
+            return nil
+        }
+    }
+
+    /// §4.19: the field codes that may be written inline in a line of music code.  `w:` is
+    /// pointedly not among them.
+    private static let inlineLegalFieldCodes: Set<Character> = [
+        "I", "K", "L", "M", "m", "N", "P", "Q", "R", "r", "s", "U", "V", "W",
+    ]
+
+    private static func bracketed(code: Character, payload: String) -> String? {
+        // An inline field ends at the first `]`, so a payload carrying one has no inline
+        // form at all and the line keeps its deferral rather than being truncated.
+        guard !payload.contains("]") else { return nil }
+        return "[\(code):\(payload)]"
     }
 
     /// Joins a `w:` line that ends in `\\` to the one after it (§2.2).

--- a/Sources/CeolKitParser/Semantic/SemanticPass.swift
+++ b/Sources/CeolKitParser/Semantic/SemanticPass.swift
@@ -753,6 +753,19 @@ struct SemanticPass {
                 message: "I:abc-include has no effect as an inline field",
                 source: source
             ))
+        case .instruction(let t):
+            // §4.4: `I:name payload` is the stylesheet directive `%%name payload`.  A `%%`
+            // line interrupting a `\\` continuation is spliced in as one of these, and a
+            // source may write one directly.  The instructions that configure the *parser*
+            // are not stylesheet directives and are handled (or ignored) elsewhere.
+            let value = t.value.trimmingCharacters(in: .whitespaces)
+            let parts = value.split(separator: " ", maxSplits: 1)
+            let name = parts.first.map(String.init) ?? value
+            guard !Self.parserInstructions.contains(name.lowercased()) else { break }
+            applyBodyDirective(
+                name: name, payload: parts.count > 1 ? String(parts[1]) : "",
+                source: source, voice: voice.base, ctx: &ctx, diagnostics: &diagnostics
+            )
         case .unknown(let code, let payload, let src) where String(code) == "%":
             // Body-level directive stored by ABCFileBuilder as .unknown(code:"%", payload:"name payload")
             let parts = payload.split(separator: " ", maxSplits: 1)
@@ -766,6 +779,12 @@ struct SemanticPass {
             break
         }
     }
+
+    /// §4.4 instructions that configure the parser rather than the stylesheet.  They are not
+    /// `%%` directives, so they must not be reported as unsupported ones.
+    private static let parserInstructions: Set<String> = [
+        "abc-version", "abc-charset", "abc-creator", "abc-include", "linebreak", "decoration",
+    ]
 
     private func applyBodyDirective(
         name: String,

--- a/Tests/CeolKitParserTests/Conformance/LineContinuationTests.swift
+++ b/Tests/CeolKitParserTests/Conformance/LineContinuationTests.swift
@@ -55,6 +55,48 @@ struct LineContinuationTests {
         #expect(staves.first?.measures.count == 2)
     }
 
+    /// §6.1.1: "any information fields and stylesheet directives are processed (and comments
+    /// are removed) at the point where the physical line-break occurs.  Hence the backslash
+    /// is commonly used to include meter or key changes halfway through a line of music."
+    ///
+    /// A field written between the two halves therefore governs the second half, not the
+    /// line after the joined one, and the standard gives the equivalence itself: it is the
+    /// inline `[M:9/8]` written at the break.
+    @Test("A meter change between the halves governs the second half")
+    func meterChangeAtTheBreakGovernsSecondHalf() {
+        // §6.1.1's own example.
+        let result = parse("X:1\nT:Test\nM:4/4\nL:1/8\nK:C\nabc cab|\\\n%%setbarnb 10\nM:9/8\n%comment\nabc cba abc|\n")
+        let measures = result.score.firstTune?.firstVoice?.staves.first?.measures ?? []
+        #expect(measures.count == 2)
+        #expect(measures.first?.meter == nil, "the first half stays in the header's 4/4")
+        if case .fraction(let num, let den) = measures.last?.meter {
+            #expect((num, den) == (9, 8))
+        } else {
+            Issue.record("second half is not in 9/8: \(String(describing: measures.last?.meter))")
+        }
+    }
+
+    @Test("A key change between the halves governs the second half")
+    func keyChangeAtTheBreakGovernsSecondHalf() {
+        // In C the f is natural; from the break on, G major sharpens it.
+        let result = parse(contTune("CDEF|\\\nK:G\nFGAB|"))
+        let notes = (result.score.firstTune?.firstVoice?.staves.first?.measures ?? [])
+            .map { $0.noteEvents.first?.pitch.alteration }
+        #expect(notes == [.natural, .sharp])
+    }
+
+    @Test("A field with no inline form is still applied after the joined line")
+    func fieldWithoutInlineFormStaysDeferred() {
+        // `w:` has no inline form (§4.19), so it keeps the deferral that puts it on the
+        // joined line as a whole rather than being spliced into the middle of it.
+        let result = parse(contTune("CDEF|\\\nw: la la la la\nGABC|"))
+        let notes = (result.score.firstTune?.firstVoice?.staves.first?.measures ?? [])
+            .flatMap(\.noteEvents)
+        #expect(notes.count == 8)
+        #expect(notes.prefix(4).allSatisfy { $0.lyric != nil })
+        #expect(notes.dropFirst(4).allSatisfy { $0.lyric == nil })
+    }
+
     @Test("A backslash before an empty line still yields its music")
     func danglingBackslashBeforeEmptyLine() {
         // Illegal per §6.1.1, so this is the recovery path: the half-line already written


### PR DESCRIPTION
Closes #107.

§6.1.1: information fields and stylesheet directives reached through a backslash are
processed "at the point where the physical line-break occurs. Hence the backslash is
commonly used to include meter or key changes halfway through a line of music." They were
being set aside and emitted *after* the joined line instead, so a `M:` or `K:` written
between the halves governed the next line rather than the second half of this one — the
documented reason to write a backslash at all.

## What changed

**`LineClassifier`** — at the join, each interrupting line is spliced into the merged music
text as the inline field the standard says it is equivalent to, in source order:

- a field whose code is inline-legal (§4.19 `I K L M m N P Q R r s U V W`) → `[code:payload]`
- `%%name payload` → `[I:name payload]` (§4.4)
- a comment is dropped, as before
- a line with **no** inline form keeps the present deferral — `w:` above all, which belongs
  to the joined line as a whole — as does one whose payload carries a `]`, since the inline
  form ends there and would otherwise be silently truncated

**`SemanticPass`** — a spliced `[I:name payload]` has to act as the directive it stands for,
so `applyInlineField` routes `.instruction` to `applyBodyDirective`. Without this the
directive would have been silently *dropped* rather than merely applied late. The §4.4
instructions that configure the parser rather than the stylesheet — `abc-version`,
`abc-charset`, `abc-creator`, `abc-include`, `linebreak`, `decoration` — are excluded, so
they are not reported as unsupported directives.

## Tests

Three added to `LineContinuationTests`:

- §6.1.1's own example — the second measure carries `Meter.fraction(9, 8)`, the first carries
  none, so the second half bars and beams in 9/8
- a mid-break `K:G` — the second half's `F` resolves sharp, the first half's natural
- a `w:` still landing on the joined line as a whole, and only its first four notes

Full suite: 1114 tests, all passing. §14.4 Canzonetta is unchanged — its only deferred lines
are `w:`.

## One acceptance bullet is deferred

The issue also asks that a mid-break `K:` **draw** its change mid-system. It does not, but
not for want of placement: the domain model has no carrier for a key change after a voice
has started, so a `K:` on its own line in the body renders no signature either. Filed as
**#129**, with the `Measure.meter` convention as the shape to mirror. The change does land
at the break here, which the resolved pitches show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gcoatYjXw3aQyM4oaoiou