### PR TITLE
Fix #129 — a mid-tune K: is engraved where the key changes

### DIFF
--- a/Sources/CeolKitModel/Measure.swift
+++ b/Sources/CeolKitModel/Measure.swift
@@ -23,6 +23,20 @@ public struct Measure: Sendable {
     /// Non-nil when an inline `[M:…]` field changed the meter before this measure.
     /// A renderer should draw the corresponding time-signature glyph before the first note.
     public let meter: Meter?
+    /// Non-nil when a `K:` field changed the key before this measure — the same convention
+    /// `meter` uses, and for the same reason: a key signature is engraved exactly where the
+    /// key moves, so "changed here" is the useful shape.
+    ///
+    /// It is the *new* key, not the accidentals to draw: what a renderer engraves at the
+    /// point of change also depends on the key being left behind, whose accidentals are
+    /// cancelled with naturals, and on the clef the staff carries. The key in force before
+    /// this measure is the last preceding `key`, with `Voice.key` (failing that `Tune.key`)
+    /// standing for a voice that has not changed one yet.
+    ///
+    /// A `K:` written part way through a bar lands on the bar it falls in, exactly as a
+    /// mid-bar `L:` does (#122): a measure carries one signature, so there is nowhere finer
+    /// for it to go.
+    public let key: KeySignature?
     /// The unit note length this measure's durations are counted in — always the effective
     /// value, on every measure, not only where an `L:` moved it.
     ///
@@ -46,6 +60,7 @@ public struct Measure: Sendable {
         endingNumber: [Int]?,
         source: SourceRange,
         meter: Meter? = nil,
+        key: KeySignature? = nil,
         unitNoteLength: Fraction
     ) {
         self.openingBar = openingBar
@@ -54,6 +69,7 @@ public struct Measure: Sendable {
         self.endingNumber = endingNumber
         self.source = source
         self.meter = meter
+        self.key = key
         self.unitNoteLength = unitNoteLength
     }
 }

--- a/Sources/CeolKitParser/Semantic/BodyContext.swift
+++ b/Sources/CeolKitParser/Semantic/BodyContext.swift
@@ -45,6 +45,16 @@ struct VoiceAccumulator {
     /// bar line, which is where ABC habitually puts a mid-tune field (#85).
     var pendingUnitNoteLength: (length: Fraction, after: Int)? = nil
 
+    /// A `K:` that moved the key part way through the voice, paired with the number of
+    /// musical events the measure then being written already held.
+    ///
+    /// Consumed exactly as `pendingUnitNoteLength` is, and for the same reason: the change
+    /// belongs to the bar the first note after it falls in, which is this one where music
+    /// follows in the bar and the next where the field was written against the bar line
+    /// (#129).  Unlike the unit note length, this one is engraved — the measure it lands on
+    /// is where the new signature gets drawn.
+    var pendingKey: (key: KeySignature, after: Int)? = nil
+
     init(source: SourceRange, unitNoteLength: Fraction) {
         self.measureSource = source
         self.openingUnitNoteLength = unitNoteLength
@@ -114,6 +124,11 @@ struct VoiceAccumulator {
         pendingUnitNoteLength = (length, musicalEventCount)
     }
 
+    /// Records a `K:` met here, to be carried by whichever measure the next note lands in.
+    mutating func markKeyChange(_ key: KeySignature) {
+        pendingKey = (key, musicalEventCount)
+    }
+
     /// Appends a bar with no music in it, to keep an `&` overlay's measures aligned with the
     /// stave's own.  It draws nothing: the voice underneath owns the staff's furniture.
     mutating func appendEmptyMeasure(source: SourceRange) {
@@ -171,6 +186,7 @@ struct VoiceAccumulator {
             // Nothing was written, so nothing can have followed the change: it still belongs
             // to the measure the next note falls in, counted from that measure's start.
             pendingUnitNoteLength?.after = 0
+            pendingKey?.after = 0
             return
         }
         let src = measureSourceSpan(
@@ -189,6 +205,15 @@ struct VoiceAccumulator {
                 pendingUnitNoteLength = (change.length, 0)
             }
         }
+        var keyTag: KeySignature? = nil
+        if let change = pendingKey {
+            if musicalEventCount > change.after {
+                keyTag = change.key
+                pendingKey = nil
+            } else {
+                pendingKey = (change.key, 0)
+            }
+        }
         let measure = Measure(
             openingBar: lastBarLine,
             events: currentEvents,
@@ -196,6 +221,7 @@ struct VoiceAccumulator {
             endingNumber: endingNumber,
             source: src,
             meter: meterTag,
+            key: keyTag,
             unitNoteLength: effectiveUnitNoteLength
         )
         closedMeasures.append(measure)
@@ -256,9 +282,9 @@ struct VoiceState {
     /// voice it applies to, and so reads a `K:` as belonging to the voice that carries it.
     ///
     /// Only what the voice *opens* in, which is what gets drawn at the head of its staff.  A
-    /// later `K:` moves `accidentals` and leaves this alone: a key change part way through a
-    /// staff is not drawn at all yet, and reporting it here would put the wrong signature at
-    /// the head of the whole voice rather than no signature at the point of change.
+    /// later `K:` leaves this alone and lands on the measure it falls in, as
+    /// `Measure.key` (#129): reporting it here would put the new signature at the head of the
+    /// whole voice rather than at the point of change.
     var openingKey: KeySignature?
 
     /// The `L:` this voice stated before any of its music, or `nil` while the tune's stands.
@@ -334,6 +360,26 @@ struct VoiceState {
     /// and a measure carries one divisor, so there is nowhere finer for it to land — which is
     /// the case ABC itself gives no meaning to, since the durations either side of it would
     /// then be written in different units with nothing marking the seam.
+    /// Moves this voice's key.
+    ///
+    /// Before any music it is what the voice opens in — the signature drawn at the head of
+    /// every one of its staves.  After, it is a change, engraved where it happens: it is
+    /// carried by the measure the first note after it falls in, which is the measure being
+    /// written when the `K:` was met if music follows it in that bar, and the next one where
+    /// the field was written against a bar line.
+    ///
+    /// Either way the accidental scope is re-seeded here and now, because §4.2 scopes a bar's
+    /// written accidentals to the bar and the new key governs every note after this point —
+    /// including the rest of a bar whose signature is not drawn until its start.
+    mutating func setKey(_ key: KeySignature, alterations: [DiatonicStep: Alteration]) {
+        if accumulator.hasMusic {
+            accumulator.markKeyChange(key)
+        } else {
+            openingKey = key
+        }
+        accidentals = AccidentalScope(keyAlterations: alterations)
+    }
+
     mutating func setUnitNoteLength(_ length: Fraction) {
         accumulator.unitNoteLength = length
         if accumulator.hasMusic {
@@ -435,6 +481,7 @@ struct VoiceState {
                 endingNumber: m.endingNumber,
                 source: m.source,
                 meter: m.meter,
+                key: m.key,
                 unitNoteLength: m.unitNoteLength
             )
             offset += count
@@ -761,10 +808,7 @@ struct BodyContext {
     /// affect, which is only meaningful if one voice's does not reach the rest.
     mutating func setKey(_ newKey: KeySignature, in voice: VoiceKey, source: SourceRange) {
         let alterations = keyAlterations(for: newKey)
-        withVoice(voice, source: source) {
-            if !$0.accumulator.hasMusic { $0.openingKey = newKey }
-            $0.accidentals = AccidentalScope(keyAlterations: alterations)
-        }
+        withVoice(voice, source: source) { $0.setKey(newKey, alterations: alterations) }
     }
 
     /// Moves the unit note length for one voice, likewise — at its head as the length the

--- a/Sources/CeolKitParser/Semantic/SemanticPass.swift
+++ b/Sources/CeolKitParser/Semantic/SemanticPass.swift
@@ -1396,6 +1396,12 @@ struct SemanticPass {
             if let change = acc.pendingUnitNoteLength, acc.musicalEventCount > change.after {
                 finalUnit = change.length
             }
+            // A `K:` still pending lands here on the same terms, so a key stated in the last
+            // bar of a voice is still engraved where it happens.
+            var finalKey: KeySignature? = nil
+            if let change = acc.pendingKey, acc.musicalEventCount > change.after {
+                finalKey = change.key
+            }
             let finalMeasure = Measure(
                 openingBar: acc.lastBarLine,
                 events: acc.currentEvents,
@@ -1403,6 +1409,7 @@ struct SemanticPass {
                 endingNumber: nil,
                 source: src,
                 meter: acc.pendingMeter,
+                key: finalKey,
                 unitNoteLength: finalUnit
             )
             measures.append(finalMeasure)
@@ -1448,6 +1455,7 @@ struct SemanticPass {
                 endingNumber: m.endingNumber,
                 source: m.source,
                 meter: m.meter,
+                key: m.key,
                 unitNoteLength: m.unitNoteLength
             ))
         }
@@ -1474,6 +1482,7 @@ struct SemanticPass {
                 endingNumber: m.endingNumber,
                 source: m.source,
                 meter: m.meter,
+                key: m.key,
                 unitNoteLength: m.unitNoteLength
             ))
         }

--- a/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
+++ b/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
@@ -132,18 +132,32 @@ public struct SVGRenderer: CeolKitRenderer {
                 let voicesByStaff = selection.voicesByStaff
                 var breaks: [ScoreLineBreak?] = []
                 var columnsPerStaff = [[SizedMeasure]](repeating: [], count: voicesByStaff.count)
+                // The key each staff is standing in, so a `K:` part way through the tune is
+                // drawn as the change it is — the naturals cancelling the signature being
+                // left behind, then the new one (#129).  It starts at what the staff's head
+                // draws, which is its lead voice's key, and moves with that voice's own
+                // `K:`: one staff carries one signature, and the lead is the voice whose
+                // clef and key the head already reads (§7.3).
+                var staffKeys: [KeySignature?] = voicesByStaff.map { voiceKeys[$0[0]] }
                 for (si, stave) in alignedStaves.enumerated() {
                     let isLastStave = si == alignedStaves.count - 1
                     for column in 0..<stave.measureCount {
                         breaks.append(!isLastStave && column == stave.measureCount - 1 ? .hard : nil)
                         for (staffIndex, members) in voicesByStaff.enumerated() {
+                            let lead = members[0]
+                            var keyChange: KeyChange? = nil
+                            if let newKey = stave.measures[lead][column].key {
+                                keyChange = KeyChange(from: staffKeys[staffIndex], to: newKey,
+                                                      clef: printedVoices[lead].properties.clef)
+                                staffKeys[staffIndex] = newKey
+                            }
                             columnsPerStaff[staffIndex].append(
                                 sizer.size(sharedStaff: members.enumerated().map { position, voice in
                                     MeasureSizer.SharedVoice(
                                         measure: stave.measures[voice][column],
                                         voiceIndex: position,
                                         isPadding: stave.isPadding(voice: voice, column: column))
-                                }))
+                                }, keyChange: keyChange))
                         }
                     }
                 }

--- a/Sources/CeolKitSVGRenderer/Emission/KeySignatureLayout.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/KeySignatureLayout.swift
@@ -40,6 +40,64 @@ func keyAccidentals(for key: KeySignature, clef: ClefSpec) -> [KeyAccidental] {
     return []
 }
 
+/// A key change engraved part way through a staff — a `K:` in the tune body (§3.1.14,
+/// §7.3, issue #129).
+///
+/// It carries the key being left behind as well as the one arriving, because the two
+/// together decide what is drawn: an accidental the outgoing signature had and the incoming
+/// one does not is cancelled with a natural. The clef comes with them for the same reason
+/// the header signature reads one (#98) — it is what places every glyph on the staff.
+public struct KeyChange: Sendable {
+    /// The key in force before this point, or `nil` where nothing was in force.
+    public let from: KeySignature?
+    /// The key from this point on.
+    public let to: KeySignature
+    /// The clef the staff carries where the change happens.
+    public let clef: ClefSpec
+
+    public init(from: KeySignature?, to: KeySignature, clef: ClefSpec) {
+        self.from = from
+        self.to = to
+        self.clef = clef
+    }
+}
+
+/// The glyphs a mid-staff key change draws, left to right: the naturals that cancel the
+/// outgoing signature, then the incoming signature's own accidentals.
+///
+/// An accidental is cancelled when the incoming signature writes nothing on its staff
+/// position — a position names a letter, so a letter the new key alters differently (B♯ to
+/// B♭) is simply respelled and takes no natural. `K:none` cancels everything and writes
+/// nothing, which is what says the key signature has gone away.
+///
+/// Empty for a clef that carries no signature at all (`percussion`, `none`): `keyAccidentals`
+/// returns nothing for either key there, so there is nothing to cancel and nothing to draw.
+func keyChangeAccidentals(for change: KeyChange) -> [KeyAccidental] {
+    let incoming = keyAccidentals(for: change.to, clef: change.clef)
+    let outgoing = change.from.map { keyAccidentals(for: $0, clef: change.clef) } ?? []
+    let replaced = Set(incoming.map(\.staffPosition))
+    let cancellations = outgoing
+        .filter { !replaced.contains($0.staffPosition) }
+        .map { KeyAccidental(glyph: .accidentalNatural, staffPosition: $0.staffPosition) }
+    return cancellations + incoming
+}
+
+/// Total horizontal space (in points) reserved for a mid-staff key change, or 0 where it
+/// draws nothing.
+func keyChangeWidth(for change: KeyChange, metadata: BravuraMetadata,
+                    staffSize: Double, trailingGap: Double? = nil) -> Double {
+    accidentalRunWidth(count: keyChangeAccidentals(for: change).count, metadata: metadata,
+                       staffSize: staffSize, trailingGap: trailingGap)
+}
+
+/// The step from one signature accidental to the next: glyph width plus the gap between
+/// them. The emitter places its glyphs by this same measurement.
+func keyAccidentalAdvance(metadata: BravuraMetadata, staffSize: Double) -> Double {
+    let glyphW = metadata.glyphBBoxes["accidentalSharp"].map { $0.width * staffSize }
+        ?? staffSize * 0.75
+    return glyphW + staffSize * 0.1
+}
+
 /// Total horizontal space (in points) reserved for a key signature header segment.
 ///
 /// - Parameter trailingGap: Space to reserve after the last accidental glyph.
@@ -47,12 +105,17 @@ func keyAccidentals(for key: KeySignature, clef: ClefSpec) -> [KeyAccidental] {
 ///   follows, so the gap to the first bar line equals one note head.
 func keySignatureWidth(for key: KeySignature, clef: ClefSpec, metadata: BravuraMetadata,
                         staffSize: Double, trailingGap: Double? = nil) -> Double {
-    let accs = keyAccidentals(for: key, clef: clef)
-    guard !accs.isEmpty else { return 0 }
-    let glyphW    = metadata.glyphBBoxes["accidentalSharp"].map { $0.width * staffSize } ?? staffSize * 0.75
-    let interGap  = staffSize * 0.1
-    let trailing  = trailingGap ?? staffSize * 0.5
-    return Double(accs.count) * (glyphW + interGap) + trailing
+    accidentalRunWidth(count: keyAccidentals(for: key, clef: clef).count, metadata: metadata,
+                       staffSize: staffSize, trailingGap: trailingGap)
+}
+
+/// The space a run of `count` signature accidentals occupies, plus the gap after the last
+/// one. Zero for an empty run, which reserves no space and no trailing gap either.
+private func accidentalRunWidth(count: Int, metadata: BravuraMetadata,
+                                staffSize: Double, trailingGap: Double?) -> Double {
+    guard count > 0 else { return 0 }
+    let advance = keyAccidentalAdvance(metadata: metadata, staffSize: staffSize)
+    return Double(count) * advance + (trailingGap ?? staffSize * 0.5)
 }
 
 // MARK: - Private

--- a/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
@@ -785,18 +785,25 @@ struct SVGEmitter: Sendable {
 
     private func emitKeySignature(_ keySig: KeySignature, system: ResolvedSystem,
                                   builder: inout SVGBuilder) {
-        let accs = keyAccidentals(for: keySig, clef: system.clef)
+        emitKeyAccidentals(keyAccidentals(for: keySig, clef: system.clef),
+                           atX: system.origin.x + clefWidth(for: system.clef),
+                           system: system, builder: &builder)
+    }
+
+    /// Draws a run of signature accidentals left to right from `startX`, stepping by the same
+    /// advance `keySignatureWidth` and `keyChangeWidth` reserve space with.  Shared by the
+    /// signature at a staff head and the one a mid-staff `K:` draws (#129).
+    private func emitKeyAccidentals(_ accs: [KeyAccidental], atX startX: Double,
+                                    system: ResolvedSystem, builder: inout SVGBuilder) {
         guard !accs.isEmpty else { return }
 
         let s            = config.staffSize
         let fontSize     = 4.0 * s
         let bottomStaffY = system.origin.y + system.staffOrigin + system.staffHeight
-        let glyphW       = metadata.glyphBBoxes["accidentalSharp"].map { $0.width * s } ?? s * 0.75
-        let gap          = s * 0.1
-        let startX       = system.origin.x + clefWidth(for: system.clef)
+        let advance      = keyAccidentalAdvance(metadata: metadata, staffSize: s)
 
         for (i, acc) in accs.enumerated() {
-            let x = startX + Double(i) * (glyphW + gap)
+            let x = startX + Double(i) * advance
             let y = noteY(staffPos: acc.staffPosition, bottomStaffY: bottomStaffY)
             builder.text(String(acc.glyph.character), x: x, y: y,
                          fontFamily: "Bravura", fontSize: fontSize)
@@ -895,10 +902,21 @@ struct SVGEmitter: Sendable {
         emitBarLine(measure.closingBar, topY: topY, bottomY: bottomY,
                     lineBottomY: lineBottomY, builder: &builder)
 
-        if let meter = measure.meter {
+        // A key or time signature changing here is drawn at the head of the bar, in the
+        // space `ColumnMetrics.leftMargin` kept ahead of the first note — key first, which is
+        // the order they are engraved in and the order that margin was measured in.
+        if measure.keyChange != nil || measure.meter != nil {
             let thin = metadata.engravingDefaults.thinBarlineThickness * config.staffSize
-            emitTimeSignatureGlyph(meter, atX: measure.origin.x + 2.0 * thin,
+            var signatureX = measure.origin.x + 2.0 * thin
+            if let change = measure.keyChange {
+                emitKeyAccidentals(keyChangeAccidentals(for: change), atX: signatureX,
                                    system: system, builder: &builder)
+                signatureX += keyChangeWidth(for: change, metadata: metadata,
+                                             staffSize: config.staffSize)
+            }
+            if let meter = measure.meter {
+                emitTimeSignatureGlyph(meter, atX: signatureX, system: system, builder: &builder)
+            }
         }
 
         // Two parts are only visibly two where both of them draw: see `inkedVoices(of:)`.

--- a/Sources/CeolKitSVGRenderer/Layout/ColumnMetrics.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/ColumnMetrics.swift
@@ -191,13 +191,19 @@ struct ColumnMetrics: Sendable {
     /// For measures that begin with a start-repeat bar line the dots occupy
     /// the space immediately after the bar complex, so the first note is
     /// pushed past them before the standard one-notehead gap is added.
-    /// A mid-line time-signature change adds its glyph width before the note gap.
-    func leftMargin(for measure: Measure) -> Double {
+    /// A mid-line key or time-signature change adds its glyph width before the note gap,
+    /// key first — the order they are engraved in, and the order the emitter draws them.
+    func leftMargin(for measure: Measure, keyChange: KeyChange? = nil) -> Double {
         let nhw = noteheadWidth()
         let thin = metadata.engravingDefaults.thinBarlineThickness * config.staffSize
-        let meterGap = measure.meter != nil ? 2.0 * thin : 0
+        let keySigW = keyChange.map {
+            keyChangeWidth(for: $0, metadata: metadata, staffSize: config.staffSize)
+        } ?? 0
         let timeSigW = measure.meter.map { timeSignatureWidth(for: $0, metadata: metadata, staffSize: config.staffSize) } ?? 0
-        guard let opening = measure.openingBar else { return meterGap + timeSigW + nhw }
+        // One gap clear of the bar line, for whichever of the two is drawn first.
+        let signatureGap = keySigW > 0 || measure.meter != nil ? 2.0 * thin : 0
+        let signatures = signatureGap + keySigW + timeSigW
+        guard let opening = measure.openingBar else { return signatures + nhw }
         switch opening.kind {
         case .repeatStart, .sectionRepeatStart, .repeatBoth:
             let wideSep = metadata.engravingDefaults.barlineSeparation * config.staffSize * 2.0
@@ -205,9 +211,9 @@ struct ColumnMetrics: Sendable {
             let dotSep  = metadata.engravingDefaults.repeatBarlineDotSeparation * config.staffSize
             let dotW    = metadata.glyphBBoxes["repeatDot"].map { $0.width * config.staffSize }
                           ?? config.staffSize * 0.25
-            return wideSep + dotSep + dotW + meterGap + timeSigW + nhw
+            return wideSep + dotSep + dotW + signatures + nhw
         default:
-            return meterGap + timeSigW + nhw
+            return signatures + nhw
         }
     }
 

--- a/Sources/CeolKitSVGRenderer/Layout/FloatingVoiceSplitter.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/FloatingVoiceSplitter.swift
@@ -203,7 +203,7 @@ enum FloatingVoiceSplitter {
         // moves nothing.
         return Measure(openingBar: measure.openingBar, events: events,
                        closingBar: measure.closingBar, endingNumber: measure.endingNumber,
-                       source: measure.source, meter: measure.meter,
+                       source: measure.source, meter: measure.meter, key: measure.key,
                        unitNoteLength: measure.unitNoteLength)
     }
 

--- a/Sources/CeolKitSVGRenderer/Layout/MeasureSizer.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/MeasureSizer.swift
@@ -25,7 +25,12 @@ public struct MeasureSizer: Sendable {
     ///     tagged with it, so the passes below can tell the voices of a shared staff apart
     ///     without the layout types growing a second dimension.  A staff with one voice —
     ///     which is every staff but a `( … )` group — passes `0`.
-    public func size(_ measure: Measure, voiceIndex: Int = 0) -> SizedMeasure {
+    ///   - keyChange: The key change engraved before this measure's first note, where
+    ///     ``Measure/key`` says the key moved here (issue #129).  Resolved by the caller,
+    ///     which is the only place that knows the key the staff was in and the clef it
+    ///     carries; the signature's glyphs are reserved for at the head of the bar.
+    public func size(_ measure: Measure, voiceIndex: Int = 0,
+                     keyChange: KeyChange? = nil) -> SizedMeasure {
         let unitNoteLength = measure.unitNoteLength
         // Quarter-note duration expressed in unit-note-length units.
         // e.g. unitNoteLength = 1/8 → quarterInUnits = 2.0
@@ -34,7 +39,7 @@ public struct MeasureSizer: Sendable {
 
         var offsets: [Double] = []
         var graceEventIndices: Set<Int> = []
-        var x: Double = metrics.leftMargin(for: measure)
+        var x: Double = metrics.leftMargin(for: measure, keyChange: keyChange)
         var i = 0
 
         while i < measure.events.count {
@@ -70,7 +75,8 @@ public struct MeasureSizer: Sendable {
 
         return SizedMeasure(measure: measure, naturalWidth: naturalWidth, eventOffsets: offsets,
                             unitNoteLength: unitNoteLength, graceEventIndices: graceEventIndices,
-                            eventVoiceIndices: Array(repeating: voiceIndex, count: offsets.count))
+                            eventVoiceIndices: Array(repeating: voiceIndex, count: offsets.count),
+                            keyChange: keyChange)
     }
 
     /// The next event of the bar that a column runs to.  A column is spaced for the syllable
@@ -85,15 +91,19 @@ public struct MeasureSizer: Sendable {
     /// A staff whose voices all fell silent here but one is not a shared staff for this bar,
     /// and is sized as the single voice it is — which is what makes an aligner-padded voice
     /// contribute nothing at all.  See ``SharedStaffMerger``.
-    public func size(sharedStaff parts: [SharedVoice]) -> SizedMeasure {
+    ///
+    /// `keyChange` is the staff's, not a voice's: §7.3 makes a `K:` belong to the voice that
+    /// wrote it, but one staff carries one signature, and the lead voice is the one whose
+    /// clef and key the staff head already draws.
+    public func size(sharedStaff parts: [SharedVoice], keyChange: KeyChange? = nil) -> SizedMeasure {
         let sounding = parts.filter { !$0.isPadding }
         if let only = sounding.count == 1 ? sounding[0] : nil {
-            return size(only.measure, voiceIndex: only.voiceIndex)
+            return size(only.measure, voiceIndex: only.voiceIndex, keyChange: keyChange)
         }
         return merger.merge(parts.map {
             SharedStaffMerger.VoicePart(measure: $0.measure, voiceIndex: $0.voiceIndex,
                                         isPadding: $0.isPadding)
-        })
+        }, keyChange: keyChange)
     }
 
     /// One voice's contribution to one bar of a shared staff.

--- a/Sources/CeolKitSVGRenderer/Layout/OverlayExpander.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/OverlayExpander.swift
@@ -57,7 +57,7 @@ enum OverlayExpander {
     private static func silent(like measure: Measure) -> Measure {
         Measure(openingBar: measure.openingBar, events: [], closingBar: measure.closingBar,
                 endingNumber: nil, source: measure.source, meter: measure.meter,
-                unitNoteLength: measure.unitNoteLength)
+                key: measure.key, unitNoteLength: measure.unitNoteLength)
     }
 
     private static func rebuilt(_ voice: Voice, staves: [Staff]) -> Voice {

--- a/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
@@ -26,6 +26,12 @@ public struct SizedMeasure: Sendable {
     /// than a property of the measure, and what the opposed stems and per-voice beaming above
     /// this pass read to tell its tenants apart.
     public let eventVoiceIndices: [Int]
+    /// Non-nil where a `K:` moved the key before this measure, resolved against the key the
+    /// staff was in and the clef it carries — everything needed to engrave the change
+    /// (#129). `Measure.key` alone cannot say what to draw: the naturals that cancel the
+    /// outgoing signature depend on the key being left behind, which is not the measure's to
+    /// know.
+    public let keyChange: KeyChange?
 
     public init(
         measure: Measure,
@@ -33,13 +39,15 @@ public struct SizedMeasure: Sendable {
         eventOffsets: [Double],
         unitNoteLength: Fraction = Fraction(numerator: 1, denominator: 8),
         graceEventIndices: Set<Int> = [],
-        eventVoiceIndices: [Int]? = nil
+        eventVoiceIndices: [Int]? = nil,
+        keyChange: KeyChange? = nil
     ) {
         self.measure = measure
         self.naturalWidth = naturalWidth
         self.eventOffsets = eventOffsets
         self.unitNoteLength = unitNoteLength
         self.graceEventIndices = graceEventIndices
+        self.keyChange = keyChange
         // Kept parallel by construction: a caller that says nothing about voices gets the
         // single-voice answer rather than an array the rest of the pipeline has to test.
         self.eventVoiceIndices = eventVoiceIndices
@@ -296,6 +304,10 @@ public struct JustifiedMeasure: Sendable {
     /// ``eventOffsets``.  Justification moves events along the line; it never adds, drops or
     /// reorders one, so the sizer's table is as valid after it as before.
     public var eventVoiceIndices: [Int] { source.eventVoiceIndices }
+
+    /// The key change the sizer resolved for this bar, carried through unchanged:
+    /// justification moves x positions, never what a bar is written in.
+    public var keyChange: KeyChange? { source.keyChange }
 }
 
 // MARK: - Pass 4 output
@@ -591,6 +603,10 @@ public struct ResolvedMeasure: Sendable {
     /// Non-nil when an inline `[M:…]` changed the time signature before this measure.
     /// The emitter draws the corresponding glyph at `origin.x` before the first note.
     public let meter: Meter?
+    /// Non-nil when a `K:` changed the key before this measure. The emitter draws the
+    /// cancelling naturals and the new signature at `origin.x`, ahead of any time signature
+    /// changing in the same bar, in the space ``ColumnMetrics`` reserved for them.
+    public let keyChange: KeyChange?
 
     public init(
         origin: Point,
@@ -599,7 +615,8 @@ public struct ResolvedMeasure: Sendable {
         openingBar: ResolvedBarLine?,
         closingBar: ResolvedBarLine,
         unitNoteLength: Fraction = Fraction(numerator: 1, denominator: 8),
-        meter: Meter? = nil
+        meter: Meter? = nil,
+        keyChange: KeyChange? = nil
     ) {
         self.origin = origin
         self.width = width
@@ -608,6 +625,7 @@ public struct ResolvedMeasure: Sendable {
         self.closingBar = closingBar
         self.unitNoteLength = unitNoteLength
         self.meter = meter
+        self.keyChange = keyChange
     }
 }
 

--- a/Sources/CeolKitSVGRenderer/Layout/SharedStaffMerger.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/SharedStaffMerger.swift
@@ -71,12 +71,13 @@ struct SharedStaffMerger: Sendable {
     ///
     /// Callers with fewer than two sounding voices should size with ``MeasureSizer`` instead;
     /// this handles the case anyway, and identically, but the sizer says what it means.
-    func merge(_ parts: [VoicePart]) -> SizedMeasure {
+    func merge(_ parts: [VoicePart], keyChange: KeyChange? = nil) -> SizedMeasure {
         let sounding = parts.filter { !$0.isPadding }
         // Every voice padded: the bar is furniture only.  Its bar lines still draw, so it
         // keeps its width, and it contributes not one column of music.
         guard let primary = sounding.first ?? parts.first else {
-            return SizedMeasure(measure: emptyMeasure(), naturalWidth: 0, eventOffsets: [])
+            return SizedMeasure(measure: emptyMeasure(), naturalWidth: 0, eventOffsets: [],
+                                keyChange: keyChange)
         }
         let unitNoteLength = primary.measure.unitNoteLength
         let voices = sounding.map { Prepared(part: $0, metrics: metrics) }
@@ -91,8 +92,8 @@ struct SharedStaffMerger: Sendable {
         var voiceTags: [Int] = []
         var graceEventIndices: Set<Int> = []
 
-        var x = voices.map { metrics.leftMargin(for: $0.part.measure) }.max()
-            ?? metrics.leftMargin(for: primary.measure)
+        var x = voices.map { metrics.leftMargin(for: $0.part.measure, keyChange: keyChange) }.max()
+            ?? metrics.leftMargin(for: primary.measure, keyChange: keyChange)
 
         for (index, onset) in onsets.enumerated() {
             let next = index + 1 < onsets.count ? onsets[index + 1] : end
@@ -153,12 +154,14 @@ struct SharedStaffMerger: Sendable {
                              closingBar: primary.measure.closingBar,
                              endingNumber: primary.measure.endingNumber,
                              source: primary.measure.source, meter: primary.measure.meter,
+                             key: primary.measure.key,
                              unitNoteLength: unitNoteLength),
             naturalWidth: naturalWidth,
             eventOffsets: offsets,
             unitNoteLength: unitNoteLength,
             graceEventIndices: graceEventIndices,
-            eventVoiceIndices: voiceTags)
+            eventVoiceIndices: voiceTags,
+            keyChange: keyChange)
     }
 
     /// The measure a fully padded bar keeps: its own furniture, and no music at all.

--- a/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
@@ -555,7 +555,8 @@ public struct VerticalLayoutEngine: Sendable {
                 openingBar: openingBar,
                 closingBar: closingBar,
                 unitNoteLength: jm.source.unitNoteLength,
-                meter: jm.source.measure.meter
+                meter: jm.source.measure.meter,
+                keyChange: jm.keyChange
             ))
 
             x = measureOrigin.x + jm.finalWidth

--- a/Tests/CeolKitParserTests/MidTuneKeyChangeTests.swift
+++ b/Tests/CeolKitParserTests/MidTuneKeyChangeTests.swift
@@ -1,0 +1,163 @@
+import Testing
+import CeolKitModel
+@testable import CeolKitParser
+
+/// Issue #129: a `K:` written in the tune body changes the key from that point on
+/// (§3.1.14, §7.3), and the measure where it happens has to say so — the renderer draws
+/// the new signature there, and before this the change left no mark in the model at all.
+///
+/// `Measure.key` follows the convention `Measure.meter` already uses: non-nil only where
+/// the key moved.
+@Suite("A mid-tune K: lands on the measure it changes")
+struct MidTuneKeyChangeTests {
+
+    private func measures(_ abc: String, voice: Int = 0) -> [Measure] {
+        let score = CeolKitParser().parse(abc, options: .default).score
+        return score.tunes[0].voices[voice].staves.flatMap(\.measures)
+    }
+
+    /// The tonic letter and mode of a measure's key change, or `nil` where it carries none.
+    private func key(_ measure: Measure) -> (DiatonicStep, Mode)? {
+        guard let key = measure.key, let tonic = key.tonic else { return nil }
+        return (tonic.step, key.mode)
+    }
+
+    // MARK: The two forms of the field
+
+    @Test("A K: on its own line changes the key of the measure that follows it")
+    func keyFieldOnItsOwnLine() throws {
+        let bars = measures("""
+        X:1
+        T:Key change on its own line
+        M:4/4
+        L:1/4
+        K:C
+        CDEF|
+        K:G
+        GABC|
+        """)
+        try #require(bars.count == 2)
+
+        #expect(bars[0].key == nil)
+        #expect(key(bars[1])?.0 == .g)
+        #expect(key(bars[1])?.1 == .major)
+    }
+
+    @Test("An inline [K:] against a bar line changes the key of the measure after it")
+    func inlineKeyFieldAtABarLine() throws {
+        let bars = measures("""
+        X:1
+        T:Key change inline
+        M:4/4
+        L:1/4
+        K:C
+        CDEF|[K:G]GABC|
+        """)
+        try #require(bars.count == 2)
+
+        #expect(bars[0].key == nil)
+        #expect(key(bars[1])?.0 == .g)
+    }
+
+    @Test("An inline [K:] part way through a bar lands on the bar it falls in")
+    func inlineKeyFieldMidBar() throws {
+        // A measure carries one signature, so there is nowhere finer for the change to go —
+        // the same compromise a mid-bar `[L:]` makes (#122).
+        let bars = measures("""
+        X:1
+        M:4/4
+        L:1/4
+        K:C
+        CD[K:G]EF|GABC|
+        """)
+        try #require(bars.count == 2)
+
+        #expect(key(bars[0])?.0 == .g)
+        #expect(bars[1].key == nil, "the key moved once; the next bar simply stays in it")
+    }
+
+    @Test("A K: in the last bar of a voice is still recorded")
+    func keyChangeInTheFinalBar() throws {
+        // The final measure is closed by `finaliseAccumulator`, not by a bar line, so it
+        // takes its own copy of the pending change.
+        let bars = measures("""
+        X:1
+        M:4/4
+        L:1/4
+        K:C
+        CDEF|[K:F]FGAB
+        """)
+        try #require(bars.count == 2)
+
+        #expect(key(bars[1])?.0 == .f)
+    }
+
+    // MARK: What it does not do
+
+    @Test("A K: before any music is the voice's opening key, not a change")
+    func headerKeyIsNotAChange() throws {
+        let abc = """
+        X:1
+        M:4/4
+        L:1/4
+        K:C
+        V:1
+        K:G
+        GABc|defg|
+        """
+        let score = CeolKitParser().parse(abc, options: .default).score
+        let voice = score.tunes[0].voices[0]
+
+        #expect(voice.key?.tonic?.step == .g, "stated before any music, so it opens the voice")
+        #expect(voice.staves.flatMap(\.measures).allSatisfy { $0.key == nil },
+                "nothing changed part way through, so no measure carries a change")
+    }
+
+    @Test("A K: in one voice does not change another voice's measures")
+    func keyChangeIsPerVoice() throws {
+        // §7.3 asks for a field that sets a music property to be repeated in every voice it
+        // should affect, so one voice's `K:` must not reach the rest.
+        let abc = """
+        X:1
+        M:4/4
+        L:1/4
+        K:C
+        V:1
+        CDEF|[K:G]GABC|
+        V:2
+        CDEF|GABC|
+        """
+        let score = CeolKitParser().parse(abc, options: .default).score
+        let first  = score.tunes[0].voices[0].staves.flatMap(\.measures)
+        let second = score.tunes[0].voices[1].staves.flatMap(\.measures)
+        try #require(first.count == 2 && second.count == 2)
+
+        #expect(first[1].key?.tonic?.step == .g)
+        #expect(second.allSatisfy { $0.key == nil })
+    }
+
+    // MARK: The change the model already showed
+
+    @Test("The pitches after the change still resolve against the new key")
+    func resolvedPitchesFollowTheChange() throws {
+        // This part always worked — the accidental scope is re-seeded where the field is
+        // met — and it has to keep working now that the change is also recorded.
+        let bars = measures("""
+        X:1
+        M:4/4
+        L:1/4
+        K:C
+        FFFF|[K:G]FFFF|
+        """)
+        try #require(bars.count == 2)
+
+        func alterations(_ measure: Measure) -> [Alteration] {
+            measure.events.compactMap {
+                if case .note(let n) = $0 { return n.pitch.alteration }
+                return nil
+            }
+        }
+        #expect(alterations(bars[0]).allSatisfy { $0 == .natural })
+        #expect(alterations(bars[1]).allSatisfy { $0 == .sharp })
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/MidTuneKeyChangeRenderTests.swift
+++ b/Tests/CeolKitSVGRendererTests/MidTuneKeyChangeRenderTests.swift
@@ -1,0 +1,317 @@
+import Testing
+import CeolKitModel
+import CeolKitParser
+@testable import CeolKitSVGRenderer
+
+/// Issue #129: a `K:` in the tune body must be engraved where it happens — the naturals
+/// that cancel the outgoing signature, then the incoming one's own accidentals, drawn at
+/// the head of the measure the change lands on.
+///
+/// The renderer used to draw only the signature at a staff head, so a tune that changed key
+/// part way through showed no accidental anywhere but there.
+@Suite("Mid-tune key change rendering")
+struct MidTuneKeyChangeRenderTests {
+
+    /// Every SMuFL glyph the page draws, in document order, as `(character, x, y)`.
+    ///
+    /// `<text>` is the probe for the same reason the mid-line meter suite uses it: it
+    /// carries the position of each run as attributes rather than in a transform.
+    private func glyphs(_ svg: String) -> [(char: Character, x: Double, y: Double)] {
+        var found: [(Character, Double, Double)] = []
+        for segment in svg.components(separatedBy: "<text ").dropFirst() {
+            guard let close = segment.range(of: ">"),
+                  let end = segment.range(of: "</text>") else { continue }
+            let attrs = segment[segment.startIndex..<close.lowerBound]
+            let body  = segment[close.upperBound..<end.lowerBound]
+            guard let char = body.first, char.unicodeScalars.first!.value > 0xE000 else { continue }
+            guard let x = attribute("x", in: attrs), let y = attribute("y", in: attrs) else { continue }
+            found.append((char, x, y))
+        }
+        return found
+    }
+
+    private func attribute(_ name: String, in attrs: Substring) -> Double? {
+        guard let start = attrs.range(of: "\(name)=\"") else { return nil }
+        let rest = attrs[start.upperBound...]
+        guard let end = rest.firstIndex(of: "\"") else { return nil }
+        return Double(rest[rest.startIndex..<end])
+    }
+
+    private func page(_ abc: String) throws -> String {
+        let score = CeolKitParser().parse(abc, options: .default).score
+        let pages = try textProbeRenderer().render(score)
+        return try #require(pages.first)
+    }
+
+    private func count(_ glyph: SMuFLGlyph, in svg: String) -> Int {
+        glyphs(svg).filter { $0.char == glyph.character }.count
+    }
+
+    // MARK: The two forms the issue reported
+
+    @Test("A K: on its own line draws the new signature")
+    func keyFieldOnItsOwnLineIsDrawn() throws {
+        let svg = try page("""
+            X:1
+            T:Key change on its own line
+            M:4/4
+            L:1/4
+            K:C
+            CDEF|
+            K:G
+            GABC|
+            """)
+
+        #expect(count(.accidentalSharp, in: svg) == 1,
+                "the one sharp of K:G must be drawn where the key changes")
+    }
+
+    @Test("An inline [K:] draws the new signature")
+    func inlineKeyFieldIsDrawn() throws {
+        let svg = try page("""
+            X:1
+            T:Key change inline
+            M:4/4
+            L:1/4
+            K:C
+            CDEF|[K:G]GABC|
+            """)
+
+        #expect(count(.accidentalSharp, in: svg) == 1)
+    }
+
+    @Test("A K: reached through a line continuation draws its change mid-system")
+    func continuationKeyChangeIsDrawn() throws {
+        // The third acceptance bullet of #107, which was blocked on there being anything in
+        // the model for the renderer to draw: the `\` keeps both bars on one system, and the
+        // key changes inside it.
+        let svg = try page("""
+            X:1
+            M:4/4
+            L:1/4
+            K:C
+            CDEF|\\
+            K:G
+            GABC|
+            """)
+        let drawn = glyphs(svg)
+
+        #expect(drawn.filter { $0.char == SMuFLGlyph.gClef.character }.count == 1,
+                "the continuation keeps the music on one system")
+        let sharpX = try #require(drawn.first { $0.char == SMuFLGlyph.accidentalSharp.character }?.x)
+        let noteXs = drawn.filter { $0.char == SMuFLGlyph.noteheadBlack.character }.map(\.x)
+        try #require(noteXs.count == 8)
+        #expect(noteXs[3] < sharpX && sharpX < noteXs[4])
+    }
+
+    // MARK: Where it lands
+
+    @Test("The new signature sits in the body of the music, after the notes before it")
+    func signatureSitsAtThePointOfChange() throws {
+        let svg = try page("""
+            X:1
+            M:4/4
+            L:1/4
+            K:C
+            CDEF|[K:G]GABC|
+            """)
+        let drawn = glyphs(svg)
+
+        let sharpX = try #require(drawn.first { $0.char == SMuFLGlyph.accidentalSharp.character }?.x)
+        let noteXs = drawn.filter { $0.char == SMuFLGlyph.noteheadBlack.character }.map(\.x)
+        try #require(noteXs.count == 8)
+
+        #expect(noteXs[3] < sharpX, "the sharp follows the last note of the C major bar")
+        #expect(sharpX < noteXs[4], "and precedes the first note of the G major bar")
+    }
+
+    @Test("Nothing is drawn in the body when the key never moves")
+    func noChangeDrawsNothingExtra() throws {
+        // The control for the two tests above: the same music in one key throughout draws
+        // its signature once, at the staff head.
+        let svg = try page("""
+            X:1
+            M:4/4
+            L:1/4
+            K:G
+            CDEF|GABC|
+            """)
+        let drawn = glyphs(svg)
+        let sharps = drawn.filter { $0.char == SMuFLGlyph.accidentalSharp.character }
+        let clefX = try #require(drawn.first { $0.char == SMuFLGlyph.gClef.character }?.x)
+        let firstNoteX = try #require(drawn.first { $0.char == SMuFLGlyph.noteheadBlack.character }?.x)
+
+        try #require(sharps.count == 1)
+        #expect(sharps[0].x > clefX && sharps[0].x < firstNoteX, "drawn at the staff head")
+    }
+
+    // MARK: Cancelling the outgoing signature
+
+    @Test("Accidentals the new key drops are cancelled with naturals")
+    func outgoingAccidentalsAreCancelled() throws {
+        // D major (F♯ C♯) to E♭ major (B♭ E♭ A♭): both sharps go, so both are cancelled,
+        // and the three flats follow them.
+        let svg = try page("""
+            X:1
+            M:4/4
+            L:1/4
+            K:D
+            DEFG|[K:Eb]EFGA|
+            """)
+
+        #expect(count(.accidentalNatural, in: svg) == 2)
+        #expect(count(.accidentalFlat, in: svg) == 3)
+        #expect(count(.accidentalSharp, in: svg) == 2, "only the two at the staff head")
+    }
+
+    @Test("A key with no accidentals is drawn as naturals alone")
+    func returnToCMajorIsAllNaturals() throws {
+        let svg = try page("""
+            X:1
+            M:4/4
+            L:1/4
+            K:Eb
+            EFGA|[K:C]CDEF|
+            """)
+
+        #expect(count(.accidentalNatural, in: svg) == 3,
+                "all three flats of E♭ major are cancelled")
+        #expect(count(.accidentalFlat, in: svg) == 3, "only the three at the staff head")
+    }
+
+    @Test("An accidental the new key keeps is not cancelled")
+    func retainedAccidentalsTakeNoNatural() throws {
+        // D major (F♯ C♯) to G major (F♯): only C♯ goes, and F♯ is simply restated.
+        let svg = try page("""
+            X:1
+            M:4/4
+            L:1/4
+            K:D
+            DEFG|[K:G]GABc|
+            """)
+
+        #expect(count(.accidentalNatural, in: svg) == 1, "C♯ alone is cancelled")
+        #expect(count(.accidentalSharp, in: svg) == 3, "two at the head, one at the change")
+    }
+
+    @Test("The naturals come before the new signature")
+    func naturalsPrecedeTheNewSignature() throws {
+        let svg = try page("""
+            X:1
+            M:4/4
+            L:1/4
+            K:D
+            DEFG|[K:Eb]EFGA|
+            """)
+        let drawn = glyphs(svg)
+
+        let lastNaturalX = try #require(
+            drawn.filter { $0.char == SMuFLGlyph.accidentalNatural.character }.map(\.x).max())
+        let firstFlatX = try #require(
+            drawn.filter { $0.char == SMuFLGlyph.accidentalFlat.character }.map(\.x).min())
+
+        #expect(lastNaturalX < firstFlatX)
+    }
+
+    // MARK: The space it is given
+
+    @Test("The bar the key changes in is wider than the same bar without the change")
+    func theChangeIsGivenRoom() throws {
+        // Natural width, not justified: the sizer has to reserve the signature's glyphs
+        // before the first note, or they would be drawn over it.
+        func naturalWidths(_ abc: String) -> [Double] {
+            let score = CeolKitParser().parse(abc, options: .default).score
+            let config = SVGRenderConfig()
+            let metadata = try! BravuraMetadata.load()
+            let sizer = MeasureSizer(config: config, metadata: metadata)
+            let measures = score.tunes[0].voices[0].staves.flatMap(\.measures)
+            let clef = score.tunes[0].voices[0].properties.clef
+            var key: KeySignature? = score.tunes[0].key
+            return measures.map { measure in
+                var change: KeyChange? = nil
+                if let newKey = measure.key {
+                    change = KeyChange(from: key, to: newKey, clef: clef)
+                    key = newKey
+                }
+                return sizer.size(measure, keyChange: change).naturalWidth
+            }
+        }
+
+        let changed = naturalWidths("""
+            X:1
+            M:4/4
+            L:1/4
+            K:C
+            CDEF|[K:Eb]EFGA|
+            """)
+        let unchanged = naturalWidths("""
+            X:1
+            M:4/4
+            L:1/4
+            K:C
+            CDEF|EFGA|
+            """)
+        try #require(changed.count == 2 && unchanged.count == 2)
+
+        #expect(changed[0] == unchanged[0], "the bar before the change is untouched")
+        #expect(changed[1] > unchanged[1], "the bar it lands on makes room for three flats")
+    }
+
+    // MARK: Clefs
+
+    @Test("The signature follows the clef the staff carries")
+    func signatureFollowsTheClef() throws {
+        // #98 established this for the opening signature; a change is placed the same way,
+        // because it reads the same table.  F♯ sits on the top line in treble (staff
+        // position 8) and on the fourth line in bass (position 6).
+        let c = KeySignature(tonic: PitchClass(step: .c, alteration: .natural), mode: .major,
+                             modifications: [], explicit: false,
+                             clef: ClefSpec(clef: .treble, octaveShift: 0),
+                             transposition: .none, staffProperties: StaffProperties(staffLines: 5),
+                             source: .emptySourceRange)
+        let g = KeySignature(tonic: PitchClass(step: .g, alteration: .natural), mode: .major,
+                             modifications: [], explicit: false,
+                             clef: ClefSpec(clef: .treble, octaveShift: 0),
+                             transposition: .none, staffProperties: StaffProperties(staffLines: 5),
+                             source: .emptySourceRange)
+
+        func positions(_ clef: Clef) -> [Int] {
+            keyChangeAccidentals(for: KeyChange(from: c, to: g,
+                                                clef: ClefSpec(clef: clef, octaveShift: 0)))
+                .map(\.staffPosition)
+        }
+
+        #expect(positions(.treble) == [8])
+        #expect(positions(.bass) == [6])
+        #expect(keyChangeAccidentals(for: KeyChange(from: c, to: g,
+                                                    clef: ClefSpec(clef: .percussion,
+                                                                   octaveShift: 0))).isEmpty)
+    }
+
+    @Test("A bass staff draws its mid-tune change too")
+    func bassStaffDrawsTheChange() throws {
+        let svg = try page("""
+            X:1
+            M:4/4
+            L:1/4
+            K:C clef=bass
+            CDEF|[K:G]GABC|
+            """)
+
+        #expect(count(.accidentalSharp, in: svg) == 1)
+    }
+
+    @Test("A percussion staff draws no signature at all")
+    func percussionStaffDrawsNothing() throws {
+        let svg = try page("""
+            X:1
+            M:4/4
+            L:1/4
+            K:C clef=perc
+            CDEF|[K:G]GABC|
+            """)
+
+        #expect(count(.accidentalSharp, in: svg) == 0)
+        #expect(count(.accidentalNatural, in: svg) == 0)
+    }
+}


### PR DESCRIPTION
Closes #129.

A `K:` in the tune body moved the accidental scope and nothing else, so the change was real in the resolved pitches and invisible on the page: `Measure` had a carrier for a mid-tune meter and none for a mid-tune key, and the renderer drew a signature only at a staff head.

## Model

`Measure.key` follows the convention `Measure.meter` set — non-nil only where the key moved. It is filled the way a mid-voice `L:` is (#122): the change is pending on the voice until a measure closes, and lands on the bar the first note after it falls in — the next bar for the `K:` written against a bar line, this one for a `[K:]` written inside it.

## Renderer

What to draw needs more than the new key, so the renderer resolves a `KeyChange` — the key being left behind, the key arriving, and the staff's clef — once per staff as it sizes each column. `keyChangeAccidentals` turns that into the glyphs: naturals for every accidental the incoming signature does not replace, then the incoming signature itself. `ColumnMetrics.leftMargin` reserves their width ahead of the first note, before any time signature changing in the same bar, and the emitter draws them there through the same glyph-placing helper the staff head uses.

The signature follows the clef the staff carries, as #98 established for the opening one; a percussion or `none` clef draws nothing.

## Also

Unblocks the third acceptance bullet of #107: a `K:` reached through a `\` continuation now draws its change mid-system.

## Not covered

A system whose head follows a key change still draws the key the voice opened in. The head signature is resolved once per plan region, before the line breaker runs and from the width the breaker was given, so making it per-system is its own change.

## Tests

20 new tests across two suites — `MidTuneKeyChangeTests` (the model carrier: both forms of the field, mid-bar, final bar, per-voice scoping, and that the resolved pitches still follow the change) and `MidTuneKeyChangeRenderTests` (that it is drawn, where, the cancelling naturals, the reserved width, and the clef). Full suite: 1149 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAEh7HZmy9xZEFBa7AcTFf