### PR TITLE
Fix #134 — a system's head draws the key that system opens in

### DIFF
--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -114,6 +114,21 @@ conforming; §4.1 says the name is *"printed on the left of the first staff of t
 question"* and says nothing about what to do when two voices claim the same staff. CeolKit's
 gutter reserves one line per staff, which is the choice this follows from.
 
+### The head of every system draws the key that system opens in
+
+§7.3 says a `K:` in the tune body changes the key from that point on, and says nothing about
+what the *next* staff head draws. Every engraving convention repeats the key signature at the
+head of every system, so CeolKit does — and repeats the key in force where that system starts,
+not the one the voice was declared in. A tune that changes key half way through therefore
+carries the new signature at the head of every system after the change, as printed music does.
+
+Where a system opens *on* the bar the change lands in, the head is the change itself: the
+naturals cancelling the outgoing signature, then the incoming one's accidentals. It is drawn
+there and not again at the head of the bar, so the change is engraved once.
+
+A time signature is not treated this way, and deliberately: `M:` is drawn where the meter
+moves and never repeated at a line break, which is also standard practice.
+
 ### Everything about a floating voice
 
 The standard names the outcome — each note on the staff above or the staff below — and gives

--- a/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
+++ b/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
@@ -99,6 +99,11 @@ public struct SVGRenderer: CeolKitRenderer {
             // boundary is always a system break; a staff plan cannot change mid-system.
             var groups: [SystemGroup] = []
             var headerWidths: [Double] = []
+            // The key each voice is standing in, threaded across the regions: a `%%score` in
+            // the body cuts the tune but does not reset it, so the region after one opens in
+            // whatever key the music before it reached (#134).  Empty until a body `K:` moves
+            // a voice, which leaves the tune's own key standing for everything else.
+            var runningKeys: [VoiceId: KeySignature] = [:]
 
             for region in PlanRegions.segment(tune) {
                 let selection = VoiceSelector.select(from: region.voices, plan: region.plan,
@@ -107,11 +112,12 @@ public struct SVGRenderer: CeolKitRenderer {
                 guard !printedVoices.isEmpty else { continue }
 
                 // §7.3: a voice states its own `K:` where it needs one, and the tune's stands
-                // in where it does not.  Resolved once here — every staff head of the voice
-                // draws the same key.  The unit note length is *not* resolved here: an `L:`
-                // moves it part way through a voice, so it is the measure that carries it
-                // (issue #122).
-                let voiceKeys = printedVoices.map { tune.effectiveKey(for: $0) }
+                // in where it does not.  This is the key the voice *opens* this region in,
+                // not one it holds throughout: a body `K:` moves it, and the staff heads
+                // after that draw the new one (#134), which the column walk below resolves.
+                // The unit note length is not resolved here either — an `L:` moves it part
+                // way through a voice, so it is the measure that carries it (issue #122).
+                let voiceKeys = printedVoices.map { runningKeys[$0.id] ?? tune.effectiveKey(for: $0) }
 
                 // Bring the voices into agreement about how much music each source line
                 // holds, so the break points chosen below are legal for every one of them.
@@ -132,6 +138,10 @@ public struct SVGRenderer: CeolKitRenderer {
                 let voicesByStaff = selection.voicesByStaff
                 var breaks: [ScoreLineBreak?] = []
                 var columnsPerStaff = [[SizedMeasure]](repeating: [], count: voicesByStaff.count)
+                // The same columns as they are drawn when one opens a system: the change moves
+                // up into the staff head there, so the bar reserves no space for it (#134).
+                // Only a column carrying a `K:` differs, and only that one is sized twice.
+                var startColumnsPerStaff = [[SizedMeasure]](repeating: [], count: voicesByStaff.count)
                 // The key each staff is standing in, so a `K:` part way through the tune is
                 // drawn as the change it is — the naturals cancelling the signature being
                 // left behind, then the new one (#129).  It starts at what the staff's head
@@ -139,6 +149,11 @@ public struct SVGRenderer: CeolKitRenderer {
                 // `K:`: one staff carries one signature, and the lead is the voice whose
                 // clef and key the head already reads (§7.3).
                 var staffKeys: [KeySignature?] = voicesByStaff.map { voiceKeys[$0[0]] }
+                // That running value, kept rather than discarded: it is the signature the head
+                // of a system opening at this column has to draw, and it is knowable here —
+                // before anything is packed — because it depends only on the columns before it
+                // and not on how they were broken (#134).
+                var columnKeysPerStaff = [[KeySignature?]](repeating: [], count: voicesByStaff.count)
                 for (si, stave) in alignedStaves.enumerated() {
                     let isLastStave = si == alignedStaves.count - 1
                     for column in 0..<stave.measureCount {
@@ -151,17 +166,27 @@ public struct SVGRenderer: CeolKitRenderer {
                                                       clef: printedVoices[lead].properties.clef)
                                 staffKeys[staffIndex] = newKey
                             }
-                            columnsPerStaff[staffIndex].append(
-                                sizer.size(sharedStaff: members.enumerated().map { position, voice in
-                                    MeasureSizer.SharedVoice(
-                                        measure: stave.measures[voice][column],
-                                        voiceIndex: position,
-                                        isPadding: stave.isPadding(voice: voice, column: column))
-                                }, keyChange: keyChange))
+                            columnKeysPerStaff[staffIndex].append(staffKeys[staffIndex])
+                            let parts = members.enumerated().map { position, voice in
+                                MeasureSizer.SharedVoice(
+                                    measure: stave.measures[voice][column],
+                                    voiceIndex: position,
+                                    isPadding: stave.isPadding(voice: voice, column: column))
+                            }
+                            let sized = sizer.size(sharedStaff: parts, keyChange: keyChange)
+                            columnsPerStaff[staffIndex].append(sized)
+                            startColumnsPerStaff[staffIndex].append(
+                                keyChange == nil ? sized : sizer.size(sharedStaff: parts))
                         }
                     }
                 }
                 guard !breaks.isEmpty else { continue }
+                // Hand the keys this region ended in to the next one.  A staff carries one
+                // signature, so every voice drawn on it leaves in the key its lead does.
+                for (staffIndex, members) in voicesByStaff.enumerated() {
+                    guard let key = staffKeys[staffIndex] else { continue }
+                    for voice in members { runningKeys[printedVoices[voice].id] = key }
+                }
 
                 // Everything below draws one staff at a time, and a shared staff draws the
                 // clef, key and name of the voice written at the top of it — as an engraver
@@ -197,7 +222,9 @@ public struct SVGRenderer: CeolKitRenderer {
                                           laterSystemLabel: laterLabels[staffIndex],
                                           voiceStemDirections: voicesByStaff[staffIndex].map {
                                               printedVoices[$0].properties.stemDirection
-                                          })
+                                          },
+                                          systemStartMeasures: startColumnsPerStaff[staffIndex],
+                                          columnKeys: columnKeysPerStaff[staffIndex])
                 }
                 // Space for the region's braces and brackets, reserved before anything is
                 // packed into the line.  It is added to the header widths rather than taken
@@ -219,27 +246,42 @@ public struct SVGRenderer: CeolKitRenderer {
                 let laterGutter = VoiceLabelGutter(labels: laterLabels, font: labelFont,
                                                    staffSize: tuneConfig.staffSize).width
 
-                // Header widths differ between the first system (has time sig) and later
-                // ones, and are the max across the group: the staves of a system have to
-                // start at the same x even when one voice's clef or key signature is wider.
-                let openingHeaderW = indent + openingGutter + staffLead.reduce(0.0) { widest, voice in
-                    max(widest, systemHeaderWidth(clef: printedVoices[voice].properties.clef,
-                                                  keySignature: voiceKeys[voice],
-                                                  meter: regionMeter, metadata: metadata,
-                                                  staffSize: tuneConfig.staffSize))
+                // The header width of one system: the max across the group, because its staves
+                // have to start at the same x even when one voice's clef or key signature is
+                // wider.  It differs system by system twice over — the region's first carries
+                // the time signature and the full voice names, and a system opening on a `K:`
+                // draws that change rather than a plain signature (#134) — so it is a function
+                // rather than the two flat numbers it used to be.  Written once and asked
+                // twice: of the *columns*, while the breaker is deciding where the systems
+                // fall, and of the systems it decided on, so the justifier spends what the
+                // breaker charged.
+                let headerWidth = { (isOpening: Bool,
+                                     signature: (Int) -> (KeySignature?, KeyChange?)) -> Double in
+                    indent + (isOpening ? openingGutter : laterGutter)
+                        + staffLead.indices.reduce(0.0) { widest, staffIndex in
+                            let (key, change) = signature(staffIndex)
+                            return max(widest, systemHeaderWidth(
+                                clef: printedVoices[staffLead[staffIndex]].properties.clef,
+                                keySignature: key, meter: isOpening ? regionMeter : nil,
+                                metadata: metadata, staffSize: tuneConfig.staffSize,
+                                keyChange: change))
+                        }
                 }
-                let laterHeaderW = indent + laterGutter + staffLead.reduce(0.0) { widest, voice in
-                    max(widest, systemHeaderWidth(clef: printedVoices[voice].properties.clef,
-                                                  keySignature: voiceKeys[voice],
-                                                  meter: nil, metadata: metadata,
-                                                  staffSize: tuneConfig.staffSize))
+                let regionGroups = breaker.breakIntoGroups(
+                    voiceLines, breaks: breaks, usableWidth: usableWidth,
+                    grouping: selection.grouping,
+                    headerWidth: { systemIndex, startColumn in
+                        headerWidth(systemIndex == 0) { staffIndex in
+                            (columnKeysPerStaff[staffIndex][startColumn],
+                             columnsPerStaff[staffIndex][startColumn].keyChange)
+                        }
+                    })
+                headerWidths += regionGroups.enumerated().map { index, group in
+                    headerWidth(index == 0) { staffIndex in
+                        (group.staves[staffIndex].keySignature,
+                         group.staves[staffIndex].headerKeyChange)
+                    }
                 }
-                let regionGroups = breaker.breakIntoGroups(voiceLines, breaks: breaks,
-                                                           usableWidth: usableWidth,
-                                                           firstSystemHeaderWidth: openingHeaderW,
-                                                           laterSystemHeaderWidth: laterHeaderW,
-                                                           grouping: selection.grouping)
-                headerWidths += regionGroups.indices.map { $0 == 0 ? openingHeaderW : laterHeaderW }
                 groups += regionGroups
             }
 
@@ -406,7 +448,8 @@ private extension SystemGroup {
             System(measures: $0.measures, isLastSystem: isLast, sourceForced: $0.sourceForced,
                    staveWasSplit: $0.staveWasSplit, clef: $0.clef,
                    keySignature: $0.keySignature, meter: $0.meter,
-                   voiceLabel: $0.voiceLabel, voiceStemDirections: $0.voiceStemDirections)
+                   voiceLabel: $0.voiceLabel, voiceStemDirections: $0.voiceStemDirections,
+                   headerKeyChange: $0.headerKeyChange)
         }, grouping: grouping)
     }
 }

--- a/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
@@ -379,9 +379,7 @@ struct SVGEmitter: Sendable {
         emitEndingBrackets(system, builder: &builder)
         emitVoiceLabel(system, builder: &builder)
         emitClef(system, builder: &builder)
-        if let keySig = system.keySignature {
-            emitKeySignature(keySig, system: system, builder: &builder)
-        }
+        emitKeySignature(system: system, builder: &builder)
         if let meter = system.meter {
             emitTimeSignature(meter, system: system, builder: &builder)
         }
@@ -783,9 +781,19 @@ struct SVGEmitter: Sendable {
 
     // MARK: - Key signature
 
-    private func emitKeySignature(_ keySig: KeySignature, system: ResolvedSystem,
-                                  builder: inout SVGBuilder) {
-        emitKeyAccidentals(keyAccidentals(for: keySig, clef: system.clef),
+    /// Draws the staff head's key signature: the *change* where a body `K:` lands on this
+    /// system's first measure — cancelling naturals and all, drawn here and not again in the
+    /// bar (#134) — and the plain signature on every other system.
+    private func emitKeySignature(system: ResolvedSystem, builder: inout SVGBuilder) {
+        let accidentals: [KeyAccidental]
+        if let change = system.headerKeyChange {
+            accidentals = keyChangeAccidentals(for: change)
+        } else if let keySig = system.keySignature {
+            accidentals = keyAccidentals(for: keySig, clef: system.clef)
+        } else {
+            return
+        }
+        emitKeyAccidentals(accidentals,
                            atX: system.origin.x + clefWidth(for: system.clef),
                            system: system, builder: &builder)
     }
@@ -814,9 +822,9 @@ struct SVGEmitter: Sendable {
 
     private func emitTimeSignature(_ meter: Meter, system: ResolvedSystem, builder: inout SVGBuilder) {
         let s = config.staffSize
-        let keySigW = system.keySignature.map {
-            keySignatureWidth(for: $0, clef: system.clef, metadata: metadata, staffSize: s)
-        } ?? 0
+        let keySigW = headerKeySignatureWidth(keySignature: system.keySignature,
+                                              keyChange: system.headerKeyChange,
+                                              clef: system.clef, metadata: metadata, staffSize: s)
         let startX = system.origin.x + clefWidth(for: system.clef) + keySigW
         emitTimeSignatureGlyph(meter, atX: startX, system: system, builder: &builder)
     }

--- a/Sources/CeolKitSVGRenderer/Emission/SystemHeaderLayout.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SystemHeaderLayout.swift
@@ -50,12 +50,18 @@ func clefHeaderWidth(for spec: ClefSpec, metadata: BravuraMetadata, staffSize: D
 ///
 /// Mirrors the `startWidth` calculation in `VerticalLayoutEngine` so that the
 /// `LineBreaker` and `Justifier` can account for it when packing and stretching measures.
+///
+/// - Parameter keyChange: Non-nil where a body `K:` lands on the system's first measure and
+///   the head therefore draws the *change* — cancelling naturals included — rather than the
+///   plain signature (#134).  It supersedes `keySignature`, which is the key the change
+///   arrives at and so would draw only half of it.
 func systemHeaderWidth(
     clef: ClefSpec,
     keySignature: KeySignature?,
     meter: Meter?,
     metadata: BravuraMetadata,
-    staffSize: Double
+    staffSize: Double,
+    keyChange: KeyChange? = nil
 ) -> Double {
     let clefW    = clefHeaderWidth(for: clef, metadata: metadata, staffSize: staffSize)
     let timeSigW = meter.map { timeSignatureWidth(for: $0, metadata: metadata, staffSize: staffSize) } ?? 0
@@ -64,9 +70,25 @@ func systemHeaderWidth(
     let keySigTrailing: Double? = timeSigW > 0 ? nil : {
         metadata.glyphBBoxes["noteheadBlack"].map { $0.width * staffSize } ?? staffSize * 1.2
     }()
-    let keySigW = keySignature.map {
-        keySignatureWidth(for: $0, clef: clef, metadata: metadata, staffSize: staffSize,
-                          trailingGap: keySigTrailing)
-    } ?? 0
+    let keySigW = headerKeySignatureWidth(keySignature: keySignature, keyChange: keyChange,
+                                          clef: clef, metadata: metadata, staffSize: staffSize,
+                                          trailingGap: keySigTrailing)
     return clefW + keySigW + timeSigW
+}
+
+/// The width of the key signature run a staff head draws — the change where one lands on the
+/// system's first measure, the plain signature otherwise, and zero where the staff carries
+/// neither.  One function so the breaker, the justifier, the layout engine and the emitter
+/// cannot disagree about how much space the head's accidentals take.
+func headerKeySignatureWidth(keySignature: KeySignature?, keyChange: KeyChange?,
+                             clef: ClefSpec, metadata: BravuraMetadata, staffSize: Double,
+                             trailingGap: Double? = nil) -> Double {
+    if let change = keyChange {
+        return keyChangeWidth(for: change, metadata: metadata, staffSize: staffSize,
+                              trailingGap: trailingGap)
+    }
+    return keySignature.map {
+        keySignatureWidth(for: $0, clef: clef, metadata: metadata, staffSize: staffSize,
+                          trailingGap: trailingGap)
+    } ?? 0
 }

--- a/Sources/CeolKitSVGRenderer/Layout/Justifier.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/Justifier.swift
@@ -117,7 +117,8 @@ public struct Justifier: Sendable {
                                    sourceForced: staff.sourceForced, clef: staff.clef,
                                    keySignature: staff.keySignature, meter: staff.meter,
                                    voiceLabel: staff.voiceLabel,
-                                   voiceStemDirections: staff.voiceStemDirections)
+                                   voiceStemDirections: staff.voiceStemDirections,
+                                   headerKeyChange: staff.headerKeyChange)
         }
         return JustifiedSystemGroup(staves: staves, grouping: group.grouping)
     }

--- a/Sources/CeolKitSVGRenderer/Layout/LineBreaker.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/LineBreaker.swift
@@ -60,8 +60,20 @@ public struct LineBreaker: Sendable {
     /// travels with them.
     public struct VoiceLine: Sendable {
         public let measures: [SizedMeasure]
+        /// The same columns, sized as they are drawn when one *opens* a system: a `K:` landing
+        /// on such a column is engraved in the staff head rather than at the head of the bar,
+        /// so the bar reserves no space for it (#134).  Only the columns carrying a change
+        /// differ from ``measures``; empty means none do.
+        public let systemStartMeasures: [SizedMeasure]
         public let clef: ClefSpec
+        /// The key the voice opens in, and the signature every staff head draws where
+        /// ``columnKeys`` says nothing more specific.
         public let keySignature: KeySignature?
+        /// The key in force *from* each column on — the tune's or voice's `K:` until a body
+        /// `K:` moves it, and the new key from the column that one lands on (#134).  Parallel
+        /// to ``measures``; empty means the voice never changes key and every system's head
+        /// draws ``keySignature``.
+        public let columnKeys: [KeySignature?]
         /// Stamped on the voice's first system only.
         public let meter: Meter?
         /// What the voice is called on the first system it appears on — its `V:` `name=`.
@@ -79,8 +91,16 @@ public struct LineBreaker: Sendable {
         public init(measures: [SizedMeasure], clef: ClefSpec = ClefSpec(clef: .treble, octaveShift: 0),
                     keySignature: KeySignature? = nil, meter: Meter? = nil,
                     firstSystemLabel: String? = nil, laterSystemLabel: String? = nil,
-                    voiceStemDirections: [StemDirection] = []) {
+                    voiceStemDirections: [StemDirection] = [],
+                    systemStartMeasures: [SizedMeasure] = [],
+                    columnKeys: [KeySignature?] = []) {
             self.measures = measures
+            // A caller with nothing to say about key changes gets the plain columns back for
+            // both roles, so everything below can index one array without testing the other.
+            self.systemStartMeasures = systemStartMeasures.count == measures.count
+                ? systemStartMeasures : measures
+            self.columnKeys = columnKeys.count == measures.count
+                ? columnKeys : Array(repeating: keySignature, count: measures.count)
             self.clef = clef
             self.keySignature = keySignature
             self.meter = meter
@@ -111,13 +131,18 @@ public struct LineBreaker: Sendable {
     ///   - grouping: The staff plan's spans and bar-line joins, stamped on every group.
     ///     One call covers one plan region (see `PlanRegions`), so a single grouping governs
     ///     everything the breaker is handed and it has nothing to decide here.
+    ///   - headerWidth: The header width of a system that is the `systemIndex`-th of this call
+    ///     and opens on measure column `startColumn`.  Supersedes the two flat widths above,
+    ///     which cannot express a staff head whose key signature depends on where the system
+    ///     starts (#134); `nil` falls back to them.
     public func breakIntoGroups(
         _ voices: [VoiceLine],
         breaks: [ScoreLineBreak?],
         usableWidth: Double,
         firstSystemHeaderWidth: Double = 0,
         laterSystemHeaderWidth: Double = 0,
-        grouping: StaffGrouping? = nil
+        grouping: StaffGrouping? = nil,
+        headerWidth: ((_ systemIndex: Int, _ startColumn: Int) -> Double)? = nil
     ) -> [SystemGroup] {
         guard let first = voices.first, !first.measures.isEmpty else { return [] }
 
@@ -125,35 +150,53 @@ public struct LineBreaker: Sendable {
         let columnWidths = (0..<first.measures.count).map { column in
             voices.reduce(0.0) { max($0, $1.measures[column].naturalWidth) }
         }
+        // What that same column costs when it *opens* a system and its key change moves up
+        // into the staff head.  Refunded to the line rather than subtracted from the column,
+        // which is the same arithmetic and leaves the packer's prefix sums alone.
+        let startRefunds = (0..<first.measures.count).map { column in
+            columnWidths[column] - voices.reduce(0.0) {
+                max($0, $1.systemStartMeasures[column].naturalWidth)
+            }
+        }
+        let headerW = headerWidth ?? { systemIndex, _ in
+            systemIndex == 0 ? firstSystemHeaderWidth : laterSystemHeaderWidth
+        }
 
         var groups: [SystemGroup] = []
         for stave in staves(columnCount: columnWidths.count, breaks: breaks) {
-            // Header width — and therefore the space left for music — differs between the
-            // very first system of the tune and every later one.
+            // Header width — and therefore the space left for music — is the header of the
+            // system that starts at this column, which differs between the tune's first
+            // system and every later one and again wherever a `K:` lands.
             let firstSystemIndex = groups.count
-            let available: (Int) -> Double = { indexWithinStave in
-                usableWidth - (firstSystemIndex + indexWithinStave == 0
-                               ? firstSystemHeaderWidth
-                               : laterSystemHeaderWidth)
+            let offset = stave.columns.lowerBound
+            let available: (Int, Int) -> Double = { indexWithinStave, startWithinStave in
+                let column = offset + startWithinStave
+                return usableWidth - headerW(firstSystemIndex + indexWithinStave, column)
+                    + startRefunds[column]
             }
 
             let ranges = pack(Array(columnWidths[stave.columns]), available: available)
-                .map { $0.offset(by: stave.columns.lowerBound) }
+                .map { $0.offset(by: offset) }
             for (i, range) in ranges.enumerated() {
                 let isLastOfStave = i == ranges.count - 1
                 let isFirstOfTune = groups.isEmpty
+                let start = range.lowerBound
                 groups.append(SystemGroup(staves: voices.map { voice in
                     System(
-                        measures: Array(voice.measures[range]),
+                        // The opening column is the one drawn without its in-bar key change:
+                        // a system that starts on a `K:` engraves it in the staff head.
+                        measures: [voice.systemStartMeasures[start]]
+                            + voice.measures[(start + 1)..<range.upperBound],
                         isLastSystem: false,
                         // Only the system that ends on the source break inherited it.
                         sourceForced: stave.endsAtSourceBreak && isLastOfStave,
                         staveWasSplit: ranges.count > 1,
                         clef: voice.clef,
-                        keySignature: voice.keySignature,
+                        keySignature: voice.columnKeys[start],
                         meter: isFirstOfTune ? voice.meter : nil,
                         voiceLabel: isFirstOfTune ? voice.firstSystemLabel : voice.laterSystemLabel,
-                        voiceStemDirections: voice.voiceStemDirections
+                        voiceStemDirections: voice.voiceStemDirections,
+                        headerKeyChange: voice.measures[start].keyChange
                     )
                 }, grouping: grouping))
             }
@@ -166,7 +209,8 @@ public struct LineBreaker: Sendable {
                        sourceForced: staff.sourceForced, staveWasSplit: staff.staveWasSplit,
                        clef: staff.clef, keySignature: staff.keySignature, meter: staff.meter,
                        voiceLabel: staff.voiceLabel,
-                       voiceStemDirections: staff.voiceStemDirections)
+                       voiceStemDirections: staff.voiceStemDirections,
+                       headerKeyChange: staff.headerKeyChange)
             }, grouping: last.grouping))
         }
 
@@ -201,8 +245,10 @@ public struct LineBreaker: Sendable {
 
     /// Splits one stave into system-sized runs of columns, as ranges into `widths`.
     ///
-    /// `available(i)` gives the width left for music on the `i`-th system of this stave.
-    private func pack(_ widths: [Double], available: (Int) -> Double) -> [Range<Int>] {
+    /// `available(i, c)` gives the width left for music on the `i`-th system of this stave
+    /// when it opens on column `c` of `widths` — the staff head it has to draw, and therefore
+    /// the room left over, depends on where it starts (#134).
+    private func pack(_ widths: [Double], available: (Int, Int) -> Double) -> [Range<Int>] {
         guard !widths.isEmpty else { return [] }
         let greedy = greedyPack(widths, available: available)
         // A stave that fits on one system has nothing to rebalance.
@@ -212,13 +258,13 @@ public struct LineBreaker: Sendable {
 
     /// First-fit packing.  Establishes the minimum number of systems the stave needs; the
     /// balancing pass keeps that number and only moves columns between the systems.
-    private func greedyPack(_ widths: [Double], available: (Int) -> Double) -> [Range<Int>] {
+    private func greedyPack(_ widths: [Double], available: (Int, Int) -> Double) -> [Range<Int>] {
         var groups: [Range<Int>] = []
         var start = 0
         var bucketWidth: Double = 0
 
         for (i, width) in widths.enumerated() {
-            let limit = capacity(available(groups.count))
+            let limit = capacity(available(groups.count, start))
             if i > start && bucketWidth + width > limit {
                 groups.append(start..<i)
                 start = i
@@ -243,7 +289,7 @@ public struct LineBreaker: Sendable {
     /// heuristic would misfire.  Returns `nil` if no assignment respects the width limits,
     /// which cannot happen for a `systemCount` that greedy first-fit already achieved.
     private func balance(_ widths: [Double], systemCount: Int,
-                         available: (Int) -> Double) -> [Range<Int>]? {
+                         available: (Int, Int) -> Double) -> [Range<Int>]? {
         let n = widths.count
         guard systemCount > 1, systemCount <= n else { return nil }
 
@@ -259,13 +305,14 @@ public struct LineBreaker: Sendable {
         cost[0][n] = 0
 
         for s in 1...systemCount {
-            // The system being filled is the (systemCount - s)-th of this stave.
-            let width = available(systemCount - s)
-            let limit = capacity(width)
             // Leave room for the s-1 systems that follow: each needs at least one measure.
             let lastStart = n - s
             guard lastStart >= 0 else { continue }
             for i in stride(from: lastStart, through: 0, by: -1) {
+                // The system being filled is the (systemCount - s)-th of this stave and it
+                // opens on column `i`, which is what decides the head it draws.
+                let width = available(systemCount - s, i)
+                let limit = capacity(width)
                 var best = Double.infinity
                 var bestEnd = 0
                 for j in (i + 1)...(n - s + 1) {

--- a/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
@@ -82,6 +82,11 @@ public struct System: Sendable {
     /// case — means that voice asked for nothing, and its position on the staff, then the
     /// document, then the note's own pitch decides (issue #77).
     public let voiceStemDirections: [StemDirection]
+    /// Non-nil when a body `K:` lands on this system's *first* measure, so the head signature
+    /// is the change itself: the naturals cancelling the key being left behind, then the new
+    /// one.  It is drawn there and not again at the head of the bar — the opening measure is
+    /// sized without it for exactly that reason (#134).
+    public let headerKeyChange: KeyChange?
 
     /// What the staff's *first* voice asked for.  That is the whole answer for a staff
     /// carrying one voice, which is every staff until a `%%score` group shares one.
@@ -96,7 +101,8 @@ public struct System: Sendable {
         keySignature: KeySignature? = nil,
         meter: Meter? = nil,
         voiceLabel: String? = nil,
-        voiceStemDirections: [StemDirection] = []
+        voiceStemDirections: [StemDirection] = [],
+        headerKeyChange: KeyChange? = nil
     ) {
         self.measures = measures
         self.isLastSystem = isLastSystem
@@ -107,6 +113,7 @@ public struct System: Sendable {
         self.meter = meter
         self.voiceLabel = voiceLabel
         self.voiceStemDirections = voiceStemDirections
+        self.headerKeyChange = headerKeyChange
     }
 }
 
@@ -259,6 +266,11 @@ public struct JustifiedSystem: Sendable {
     /// Carried through from ``System/voiceStemDirections`` — justification moves x
     /// positions, never which way a voice's stems point.
     public let voiceStemDirections: [StemDirection]
+    /// Non-nil when a body `K:` lands on this system's *first* measure, so the head signature
+    /// is the change itself: the naturals cancelling the key being left behind, then the new
+    /// one.  It is drawn there and not again at the head of the bar — the opening measure is
+    /// sized without it for exactly that reason (#134).
+    public let headerKeyChange: KeyChange?
 
     /// What the staff's first voice asked for; see ``System/stemDirection``.
     public var stemDirection: StemDirection { voiceStemDirections.first ?? .auto }
@@ -271,7 +283,8 @@ public struct JustifiedSystem: Sendable {
         keySignature: KeySignature? = nil,
         meter: Meter? = nil,
         voiceLabel: String? = nil,
-        voiceStemDirections: [StemDirection] = []
+        voiceStemDirections: [StemDirection] = [],
+        headerKeyChange: KeyChange? = nil
     ) {
         self.measures = measures
         self.isLastSystem = isLastSystem
@@ -281,6 +294,7 @@ public struct JustifiedSystem: Sendable {
         self.meter = meter
         self.voiceLabel = voiceLabel
         self.voiceStemDirections = voiceStemDirections
+        self.headerKeyChange = headerKeyChange
     }
 }
 
@@ -548,6 +562,11 @@ public struct ResolvedSystem: Sendable {
     /// The variant-ending brackets drawn above this staff, left to right.  Empty on every
     /// staff of every tune that writes none, which reserves no space for them either.
     public let endingBrackets: [EndingBracket]
+    /// Non-nil when a body `K:` lands on this system's *first* measure, so the head signature
+    /// is the change itself: the naturals cancelling the key being left behind, then the new
+    /// one.  It is drawn there and not again at the head of the bar — the opening measure is
+    /// sized without it for exactly that reason (#134).
+    public let headerKeyChange: KeyChange?
 
     /// What the staff's first voice asked for; see ``System/stemDirection``.
     public var stemDirection: StemDirection { voiceStemDirections.first ?? .auto }
@@ -569,7 +588,8 @@ public struct ResolvedSystem: Sendable {
         staffGroup: StaffGroup? = nil,
         voiceLabel: VoiceLabel? = nil,
         voiceStemDirections: [StemDirection] = [],
-        endingBrackets: [EndingBracket] = []
+        endingBrackets: [EndingBracket] = [],
+        headerKeyChange: KeyChange? = nil
     ) {
         self.origin = origin
         self.measures = measures
@@ -588,6 +608,7 @@ public struct ResolvedSystem: Sendable {
         self.voiceLabel = voiceLabel
         self.voiceStemDirections = voiceStemDirections
         self.endingBrackets = endingBrackets
+        self.headerKeyChange = headerKeyChange
     }
 }
 

--- a/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
@@ -89,7 +89,8 @@ public struct VerticalLayoutEngine: Sendable {
                 abcLine: abcLine,
                 endingBrackets: EndingBracketBand.place(
                     runs, over: measures, bandTopY: systemOrigin.y,
-                    staffSize: config.staffSize, metadata: metadata)
+                    staffSize: config.staffSize, metadata: metadata),
+                headerKeyChange: jsystem.headerKeyChange
             ))
 
             y += totalHeight + config.systemGap
@@ -334,7 +335,8 @@ public struct VerticalLayoutEngine: Sendable {
                 voiceStemDirections: staff.voiceStemDirections,
                 endingBrackets: EndingBracketBand.place(
                     endingRuns[i], over: measures, bandTopY: systemOrigin.y,
-                    staffSize: staffSize, metadata: metadata)
+                    staffSize: staffSize, metadata: metadata),
+                headerKeyChange: staff.headerKeyChange
             )
         }
     }
@@ -368,10 +370,10 @@ public struct VerticalLayoutEngine: Sendable {
             metadata.glyphBBoxes["noteheadBlack"].map { $0.width * staffSize }
                 ?? staffSize * 1.2
         }()
-        let keySigW = jsystem.keySignature.map {
-            keySignatureWidth(for: $0, clef: jsystem.clef, metadata: metadata, staffSize: staffSize,
-                              trailingGap: keySigTrailing)
-        } ?? 0
+        let keySigW = headerKeySignatureWidth(keySignature: jsystem.keySignature,
+                                              keyChange: jsystem.headerKeyChange,
+                                              clef: jsystem.clef, metadata: metadata,
+                                              staffSize: staffSize, trailingGap: keySigTrailing)
         let clefW = clefHeaderWidth(for: jsystem.clef, metadata: metadata, staffSize: staffSize)
         return clefW + keySigW + timeSigW
     }

--- a/Tests/CeolKitSVGRendererTests/SystemHeadKeySignatureTests.swift
+++ b/Tests/CeolKitSVGRendererTests/SystemHeadKeySignatureTests.swift
@@ -1,0 +1,232 @@
+import Testing
+import CeolKitModel
+import CeolKitParser
+@testable import CeolKitSVGRenderer
+
+/// Issue #134: the key signature repeated at the head of every system is the key that system
+/// *opens in*, not the one the voice opened the tune in.
+///
+/// #129 made a body `K:` draw the change where it happens; the signature that then stands for
+/// the rest of the tune was still resolved once per voice, so every system after a mid-tune
+/// change drew the old key — or, where the old key had no accidentals, nothing at all.
+///
+/// Where a system opens *on* the measure the change lands on, the two meet: the head draws the
+/// change — cancelling naturals included — and the bar draws nothing, so it is engraved once.
+@Suite("A system's head draws the key it opens in")
+struct SystemHeadKeySignatureTests {
+
+    /// Every SMuFL glyph the page draws, as `(character, x, y)`.  `<text>` carries each run's
+    /// position in attributes rather than a transform, which is what makes it the probe.
+    private func glyphs(_ svg: String) -> [(char: Character, x: Double, y: Double)] {
+        var found: [(Character, Double, Double)] = []
+        for segment in svg.components(separatedBy: "<text ").dropFirst() {
+            guard let close = segment.range(of: ">"),
+                  let end = segment.range(of: "</text>") else { continue }
+            let attrs = segment[segment.startIndex..<close.lowerBound]
+            let body  = segment[close.upperBound..<end.lowerBound]
+            guard let char = body.first, char.unicodeScalars.first!.value > 0xE000 else { continue }
+            guard let x = attribute("x", in: attrs), let y = attribute("y", in: attrs) else { continue }
+            found.append((char, x, y))
+        }
+        return found
+    }
+
+    private func attribute(_ name: String, in attrs: Substring) -> Double? {
+        guard let start = attrs.range(of: "\(name)=\"") else { return nil }
+        let rest = attrs[start.upperBound...]
+        guard let end = rest.firstIndex(of: "\"") else { return nil }
+        return Double(rest[rest.startIndex..<end])
+    }
+
+    private func page(_ abc: String) throws -> String {
+        let score = CeolKitParser().parse(abc, options: .default).score
+        let pages = try textProbeRenderer().render(score)
+        return try #require(pages.first)
+    }
+
+    /// The glyphs of one staff system, keyed by the clef's y — one system per staff head, and
+    /// every glyph of a system shares its band.  Returned top to bottom.
+    private func systems(_ svg: String) -> [[(char: Character, x: Double, y: Double)]] {
+        let drawn = glyphs(svg)
+        let clefYs = drawn.filter { $0.char == SMuFLGlyph.gClef.character }
+            .map(\.y).sorted()
+        return clefYs.enumerated().map { i, clefY in
+            let upper = i + 1 < clefYs.count ? (clefY + clefYs[i + 1]) / 2 : Double.infinity
+            let lower = i == 0 ? -Double.infinity : (clefYs[i - 1] + clefY) / 2
+            return drawn.filter { $0.y > lower && $0.y < upper }.sorted { $0.x < $1.x }
+        }
+    }
+
+    /// The accidentals drawn at `system`'s head — between the clef and its first notehead.
+    private func headAccidentals(_ system: [(char: Character, x: Double, y: Double)]) -> [Character] {
+        guard let clefX = system.first(where: { $0.char == SMuFLGlyph.gClef.character })?.x,
+              let firstNoteX = system.first(where: {
+                  $0.char == SMuFLGlyph.noteheadBlack.character
+              })?.x else { return [] }
+        return system.filter { $0.x > clefX && $0.x < firstNoteX }
+            .map(\.char)
+            .filter { $0 == SMuFLGlyph.accidentalSharp.character
+                   || $0 == SMuFLGlyph.accidentalFlat.character
+                   || $0 == SMuFLGlyph.accidentalNatural.character }
+    }
+
+    /// The issue's own source: three systems, the `K:D` landing at the head of the second.
+    private let threeSystems = """
+        X:1
+        T:Key change, three systems
+        M:4/4
+        L:1/4
+        K:C
+        CDEF|CDEF|
+        K:D
+        DEFG|DEFG|
+        DEFG|DEFG|
+        """
+
+    // MARK: The bug
+
+    @Test("Every system after the change draws the new signature")
+    func laterSystemsDrawTheNewKey() throws {
+        let rows = systems(try page(threeSystems))
+        try #require(rows.count == 3)
+
+        let sharp = SMuFLGlyph.accidentalSharp.character
+        #expect(headAccidentals(rows[0]).isEmpty, "C major draws none")
+        #expect(headAccidentals(rows[1]) == [sharp, sharp], "the system the K:D lands on")
+        #expect(headAccidentals(rows[2]) == [sharp, sharp],
+                "and every system after it, which is the bug #134 reported")
+    }
+
+    @Test("The change is drawn once, in the head, not again in the bar")
+    func theOpeningSystemDrawsItOnlyOnce() throws {
+        let rows = systems(try page(threeSystems))
+        try #require(rows.count == 3)
+
+        let sharps = rows[1].filter { $0.char == SMuFLGlyph.accidentalSharp.character }
+        #expect(sharps.count == 2, "two sharps on the system the change opens, not four")
+        let firstNoteX = try #require(rows[1].first {
+            $0.char == SMuFLGlyph.noteheadBlack.character
+        }?.x)
+        #expect(sharps.allSatisfy { $0.x < firstNoteX }, "both stand in the head")
+    }
+
+    @Test("A head that opens on the change cancels the signature it leaves behind")
+    func theOpeningHeadCancelsTheOutgoingKey() throws {
+        // E♭ major (B♭ E♭ A♭) to C major across a source line break: the new key writes
+        // nothing, so the head of the second system is three naturals and no more.
+        let rows = systems(try page("""
+            X:1
+            M:4/4
+            L:1/4
+            K:Eb
+            EFGA|EFGA|
+            K:C
+            CDEF|CDEF|
+            """))
+        try #require(rows.count == 2)
+
+        let flat = SMuFLGlyph.accidentalFlat.character
+        let natural = SMuFLGlyph.accidentalNatural.character
+        #expect(headAccidentals(rows[0]) == [flat, flat, flat])
+        #expect(headAccidentals(rows[1]) == [natural, natural, natural])
+        #expect(rows[1].filter { $0.char == natural }.count == 3,
+                "the naturals are drawn in the head and nowhere else on the system")
+    }
+
+    // MARK: What #129 established, and must keep
+
+    @Test("A change part way through a system is still drawn in the bar")
+    func aMidSystemChangeStaysInTheBar() throws {
+        let rows = systems(try page("""
+            X:1
+            M:4/4
+            L:1/4
+            K:C
+            CDEF|[K:D]DEFG|
+            """))
+        try #require(rows.count == 1)
+
+        #expect(headAccidentals(rows[0]).isEmpty, "the system opens in C major")
+        let sharps = rows[0].filter { $0.char == SMuFLGlyph.accidentalSharp.character }
+        let noteXs = rows[0].filter { $0.char == SMuFLGlyph.noteheadBlack.character }.map(\.x)
+        try #require(sharps.count == 2 && noteXs.count == 8)
+        #expect(sharps.allSatisfy { noteXs[3] < $0.x && $0.x < noteXs[4] })
+    }
+
+    @Test("A staff plan in the body does not reset the key the music reached")
+    func aPlanRegionInheritsTheRunningKey() throws {
+        // §11.1 cuts the tune into plan regions and lays each out on its own, which is a
+        // system break like any other: the region after the change opens in D major, not in
+        // the C major the voice was declared in.
+        let svg = try page("""
+            X:1
+            M:4/4
+            L:1/4
+            V:1 clef=treble
+            V:2 clef=bass
+            K:C
+            %%score 1 2
+            V:1
+            CDEF|[K:D]DEFG|
+            V:2
+            C,D,E,F,|D,E,F,G,|
+            %%score 1
+            V:1
+            DEFG|DEFG|
+            """)
+        let drawn = glyphs(svg)
+
+        // The last treble staff head on the page is the one the second region opens.
+        let lastTrebleY = try #require(
+            drawn.filter { $0.char == SMuFLGlyph.gClef.character }.map(\.y).max())
+        let lastSystem = drawn.filter { $0.y == lastTrebleY || abs($0.y - lastTrebleY) < 24 }
+            .sorted { $0.x < $1.x }
+        #expect(headAccidentals(lastSystem) == [SMuFLGlyph.accidentalSharp.character,
+                                                SMuFLGlyph.accidentalSharp.character])
+    }
+
+    // MARK: The space the head is given
+
+    @Test("A system opening in the new key reserves the room its signature needs")
+    func theHeadIsGivenRoom() throws {
+        // The third system is in D major but was laid out as if it were in C: its music has
+        // to start clear of the two sharps, not on top of them.
+        let rows = systems(try page(threeSystems))
+        try #require(rows.count == 3)
+
+        let lastSharpX = try #require(
+            rows[2].filter { $0.char == SMuFLGlyph.accidentalSharp.character }.map(\.x).max())
+        let firstNoteX = try #require(rows[2].first {
+            $0.char == SMuFLGlyph.noteheadBlack.character
+        }?.x)
+        #expect(firstNoteX > lastSharpX + 5, "a notehead's clearance past the last accidental")
+    }
+
+    @Test("The line breaker charges the head the system actually draws")
+    func theBreakerChargesThePerSystemHead() throws {
+        // Every system of this tune is packed by the breaker rather than the source, and each
+        // one after the first is in C♯ major — seven sharps, the widest head there is.  A
+        // breaker still charging the opening key (no accidentals) would let a system take a
+        // measure it has no room for, and the justifier would then compress it past the right
+        // margin.  Nothing may cross it.
+        let svg = try page("""
+            X:1
+            M:4/4
+            L:1/8
+            K:C
+            CDEFGABc|
+            K:C#
+            CDEFGABc|CDEFGABc|CDEFGABc|CDEFGABc|CDEFGABc|CDEFGABc|\
+            CDEFGABc|CDEFGABc|CDEFGABc|CDEFGABc|CDEFGABc|CDEFGABc|
+            """)
+        let rows = systems(svg)
+        try #require(rows.count > 2, "the tune needs more systems than the source lines gave it")
+        for row in rows.dropFirst() {
+            #expect(headAccidentals(row).count == 7, "seven sharps at every later head")
+        }
+        let rightMargin = SVGRenderConfig().pageSize.width - SVGRenderConfig().margins.right
+        for glyph in glyphs(svg) {
+            #expect(glyph.x <= rightMargin, "no glyph may be drawn past the right margin")
+        }
+    }
+}


### PR DESCRIPTION
Closes #134.

A key signature is repeated at the head of every system, and after a mid-tune `K:` that head has to draw the *new* key. It drew the key the voice opened in, for the rest of the tune.

```abc
X:1
T:Key change, three systems
M:4/4
L:1/4
K:C
CDEF|CDEF|
K:D
DEFG|DEFG|
DEFG|DEFG|
```

Before, reading the glyphs back: system 1 looked right by accident — #129 draws the change at the head of the measure it lands on, and that measure happened to be the system's first — and system 2 drew no signature at all, as did every system after it.

## Breaking the circularity

The head signature was one value per voice for the whole tune, and the width it costs was two flat numbers computed *before* the systems existed and handed to the line breaker, which spent them deciding where the systems break. A per-system key is a per-system header width, and that looked like an input the breaker could not have until it had broken the lines. That is where #129 stopped.

It is not actually circular. The key a system opens in depends only on the measures before it, never on how they were packed, so it is knowable per *column* before any breaking happens:

- **Resolve the key at every column while sizing.** The driver's column walk already tracks a running key per staff to build each `KeyChange` (added by #129); it now keeps that value as `columnKeysPerStaff` instead of discarding it.
- **`LineBreaker.VoiceLine` carries the per-column key**, and `breakIntoGroups` takes a `headerWidth(systemIndex:startColumn:)` closure in place of `firstSystemHeaderWidth` / `laterSystemHeaderWidth`. `pack` / `greedyPack` / `balance` take `available(systemIndex, startColumn)` — in `balance` the width and limit move inside the `i` loop, since the system being filled now depends on where it starts.
- **One function, asked twice.** The same closure is re-run over the groups the breaker produced to build `headerWidths`, so the justifier spends exactly what the breaker charged. `VerticalLayoutEngine` reads the resolved value off the system rather than recomputing a third time.
- **`System.headerKeyChange`**, carried through `JustifiedSystem` and `ResolvedSystem`: where a system opens on the bar the change lands in, the head draws `keyChangeAccidentals` — cancelling naturals and all — and the bar draws nothing, so the change is engraved once. Such a column is sized twice, once with the in-bar change for a system that runs through it and once without for one that opens on it, and the breaker refunds the difference to the line. The widths stay exact rather than conservative.

## Also fixed

A `%%score` in the body cuts the tune into plan regions, and each region restarted from the voice's declared key — so a region after a change reverted to the tune's opening signature. The running key is now threaded across regions by voice id. Same defect, and a region boundary is always a system break.

## Not changed

`Measure.meter`. A time signature is drawn where the meter moves and never repeated at a line break, which is why `System.meter` is non-nil only on a tune's first system.

## Tests

Seven new tests in `Tests/CeolKitSVGRendererTests/SystemHeadKeySignatureTests.swift`, five of which fail against the pre-fix `Sources/`:

- every system after the change draws the new signature (the reported bug)
- the change is drawn once, in the head, not again in the bar
- a head that opens on the change cancels the signature it leaves behind (E♭ → C, three naturals)
- a change part way through a system is still drawn in the bar (#129 regression guard)
- a `%%score` in the body does not reset the key the music reached
- a system opening in the new key reserves the room its signature needs
- the breaker charges the head the system actually draws — seven sharps at every later head, and no glyph past the right margin

Full suite: 1156 tests pass.

`CONFORMANCE.md` gains a section on the choice, since §7.3 leaves the staff head to the engraver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YAEh7HZmy9xZEFBa7AcTFf