### PR TITLE
Fix #137, #138 — footer substitution marks, and a page number that arrives

### DIFF
--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -235,7 +235,23 @@ T:Continued
 ...
 ```
 
+### Where it is read
+
+The last statement of the directive wins, and only the **file preamble and the first
+tune's header** are read. The number is set *before any output has been produced*, so
+that is the only place it can mean anything; a copy in a later tune's header would be
+asking to renumber pages already engraved, and is ignored.
+
+The number reaches both the `$P` and `${pagenumber}` substitutions in the footer and
+the `page` field of the `ceolkit-meta` scroll-sync comment, so a consumer pairing a
+rendered page with what the reader sees on paper agrees with the printed footer.
+
 ### Interaction with `%%newpage`
+
+> **Not yet implemented.** `%%newpage` is not supported — it reports
+> `info: Unsupported stylesheet directive '%%newpage'` and no page break occurs. It is
+> requested as [#140](https://github.com/sbeitzel/CeolKit/issues/140); this section
+> describes what the two directives will mean together once it lands.
 
 `%%newpage N` also sets the page number as a side-effect of forcing a page
 break. `%%ceolkit:pagenumber N` sets the page number *without* starting a new page,

--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -196,6 +196,14 @@ Page number substitution in headers and footers uses the `$P` placeholder
 (current page) and `$Q` placeholder (non-resetting page counter). Only `$P`
 is affected by `%%ceolkit:pagenumber`; `$Q` always starts at 1 and is never reset.
 
+This directive fixes the number **at authoring time**, which is what a multi-file
+*score* needs — the file that continues a piece knows where the previous file
+stopped. It cannot help a multi-file *compilation*: a tune assembled into a binder
+alongside others sits at a different offset in every binder it appears in, and the
+offsets shift whenever any of the tunes before it gains or loses a page. For that,
+mark the span and let the tool building the binder fill it in — see
+[Consumer-substitutable footer spans](#consumer-substitutable-footer-spans).
+
 ### Examples
 
 #### Start numbering from page 3
@@ -233,6 +241,127 @@ T:Continued
 break. `%%ceolkit:pagenumber N` sets the page number *without* starting a new page,
 so it is only meaningful before any output has been produced (i.e., in the
 file preamble or at the very start of a tune header).
+
+---
+
+## Consumer-substitutable footer spans
+
+**Syntax:** `${<name>}` inside a `%%footer` template
+
+**Scope:** the footer template it is written in
+
+### Description
+
+`${name}` marks a span of the footer as *substitutable*: CeolKit still lays out and
+draws its own value there, but the renderer emits that span as one findable,
+self-describing SVG element instead of as loose text or loose glyphs, so a downstream
+tool can replace it.
+
+This exists because outlining is a one-way door. Under the default
+`TextRendering.outlines` a footer reading `Page 1` leaves the renderer as six `<use>`
+elements and no text anywhere in the document — there is nothing left for a
+post-processor to rewrite, and only CeolKit still has the font, the metrics and the
+layout needed to draw a different string in that spot. The mark is how an author says
+in the ABC source that a particular span is somebody else's to fill in.
+
+The motivating case is a binder: a server renders each tune's `.abc` on its own and
+concatenates the pages, so page 1 of the third tune has to print `17`. No value of
+[`%%ceolkit:pagenumber`](#ceolkitpagenumber) is right for that, because the offset is
+not knowable when the ABC is written.
+
+`${…}` is a CeolKit extension. It is not part of the ABC v2.2 header/footer
+substitution set, and it is understood only in `%%footer`.
+
+### What is emitted
+
+Each marked span becomes a group wrapping CeolKit's own rendering of the default value:
+
+```xml
+<g id="ceolkit-tag-pagenumber" class="ceolkit-tag" data-ceolkit-tag="pagenumber"
+   data-x="306" data-y="753.048" data-font-size="12"
+   data-font-family="Libertinus Serif" data-text-anchor="middle">
+  <!-- CeolKit's own rendering of the default value: outlined or <text>, per mode -->
+</g>
+```
+
+The `data-*` attributes are the contract; the group's contents are CeolKit's. A
+consumer substitutes by emptying the group and drawing its own text at the advertised
+anchor — position, size and anchor are what a stamping API needs, not the face.
+
+Three properties follow, and all three are deliberate:
+
+- **It carries its own default.** A standalone render is unchanged and correct, and a
+  consumer that ignores the group gets exactly the output it always got.
+- **It is mode-independent.** `.outlines`, `.fontFace` and `.both` all wrap the same
+  way, so a consumer never has to care which mode produced the file — and `.outlines`
+  stays the default, with no hole in the guarantee it exists to give.
+- **`id` is unique, `data-ceolkit-tag` is not.** Nothing stops a template from marking
+  one name twice; the first gets `ceolkit-tag-<name>` and later ones are suffixed
+  `-2`, `-3`, … . `data-ceolkit-tag` carries the name unchanged on every one, so a
+  consumer keying off that finds them all.
+
+### Names
+
+A name is a letter followed by letters, digits, `_`, `.` or `-`. Anything else —
+`${1st}`, an unclosed `${`, a bare `${}` — is not a mark and is engraved literally,
+which is what an author who did not mean a mark expects to see.
+
+Four names carry a value CeolKit knows:
+
+| Name | Default value |
+|------|---------------|
+| `${pagenumber}` | the current page number — the same value as `$P` |
+| `${pagecount}` | the number of pages in this render |
+| `${title}` | the first tune's title — the same value as `$T` |
+| `${date}` | the render date, formatted by `%%dateformat` — the same value as `$D` |
+
+Any other name is a mark CeolKit has no value for. It draws nothing and emits an
+empty group at the right spot, which is exactly what a consumer that means to stamp
+its own text there wants: a binder name or a section title is not CeolKit's to invent.
+
+### Layout and overflow
+
+A substituted string is usually a different width from the default (`9` becomes
+`117`). CeolKit reserves the width of its own default and advertises the anchor;
+the consumer owns the overflow. Two rules make that workable:
+
+- A column that is **nothing but the mark** keeps that column's own anchor, so a wider
+  replacement grows the way the column does — leftwards from the right margin,
+  outwards from the centre — and stays on the page.
+- A mark **mixed with other text** is placed after the text it follows, at
+  `text-anchor="start"`. A longer replacement then overflows to the right of the mark,
+  over whatever follows it in that column.
+
+So for a page number that a consumer will rewrite, give it a column of its own.
+
+### Examples
+
+#### A page number a binder compiler fills in
+
+```abc
+%%footer "$T\t\t${pagenumber}"
+X:1
+T:My Tune
+M:4/4
+L:1/8
+K:G
+GABG|DEFD|GABG|D4|
+```
+
+The rendered page reads `My Tune` at the left margin and `1` at the right. The `1`
+sits inside `<g id="ceolkit-tag-pagenumber" … data-text-anchor="end">`, so a binder
+compiler replaces it with `17` — right-aligned at the same margin — without knowing
+anything about the font.
+
+#### A name CeolKit has no value for
+
+```abc
+%%footer "${bindername}\t$T\t${pagenumber}"
+```
+
+The centre column engraves the tune title as usual. The left column is an empty group
+at the left margin waiting for the compiler's binder name, and the right column is the
+page number as above.
 
 ---
 

--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -192,9 +192,9 @@ The value must be a positive integer (≥ 1). If the argument is missing, zero,
 negative, or non-numeric, an error message is emitted and the directive is
 ignored.
 
-Page number substitution in headers and footers uses the `$P` placeholder
-(current page) and `$Q` placeholder (non-resetting page counter). Only `$P`
-is affected by `%%ceolkit:pagenumber`; `$Q` always starts at 1 and is never reset.
+Page number substitution in the footer uses the `$P` placeholder, which is the token
+this directive sets. It is one of four — see
+[`%%footer` placeholders](#footer-placeholders).
 
 This directive fixes the number **at authoring time**, which is what a multi-file
 *score* needs — the file that continues a piece knows where the previous file
@@ -257,6 +257,45 @@ rendered page with what the reader sees on paper agrees with the printed footer.
 break. `%%ceolkit:pagenumber N` sets the page number *without* starting a new page,
 so it is only meaningful before any output has been produced (i.e., in the
 file preamble or at the very start of a tune header).
+
+---
+
+## `%%footer` placeholders
+
+**Syntax:** `$<letter>` inside a `%%footer` template
+
+**Scope:** the footer template it is written in
+
+### Description
+
+CeolKit substitutes exactly four `$` placeholders:
+
+| Placeholder | Value |
+|-------------|-------|
+| `$P` | the current page number, as set by [`%%ceolkit:pagenumber`](#ceolkitpagenumber) |
+| `$T` | the first tune's title |
+| `$D` | the render date, formatted by `%%dateformat` |
+| `$d` | the same as `$D` |
+
+That set is deliberately narrower than abcm2ps's, which also defines `$F`, `$I<x>`,
+`$V`, `$P0` and `$P1`. None of those are implemented here, and neither is anything
+outside the table above.
+
+### Anything else is engraved literally, and diagnosed
+
+A `$` followed by any other letter is not a placeholder. It stays in the literal text
+and is engraved as written — under the default `TextRendering.outlines` as artwork, with
+nothing downstream able to tell what was meant — so the parser emits a warning for each
+distinct one:
+
+```
+warning: '$X' is not a footer placeholder; it will be engraved literally
+```
+
+That covers both an abcm2ps placeholder CeolKit does not implement and a typo such as
+`$p`. Two things are *not* diagnosed, because neither is a token: a `$` not followed by
+a letter (`$5`, a trailing `$`) is ordinary text, and `${name}` is a
+[consumer-substitutable span](#consumer-substitutable-footer-spans).
 
 ---
 

--- a/Sources/CeolKitModel/Diagnostic.swift
+++ b/Sources/CeolKitModel/Diagnostic.swift
@@ -68,6 +68,11 @@ public enum DiagnosticCode: String, Codable, Sendable {
     // Directives
     case unknownDirective
     case redundantDirective
+    /// A `%%footer` template contains a `$`-token CeolKit does not substitute — an
+    /// abcm2ps placeholder that is not implemented here, or a typo such as `$p`.  The
+    /// characters are engraved literally, and under the default outline mode they are
+    /// engraved as artwork, so nothing downstream can tell what was meant.
+    case unknownFooterPlaceholder
     /// A `%%score` / `%%staves` payload did not parse (ABC v2.2 §11.1).  The whole
     /// directive is dropped rather than stored as a partial tree.
     case invalidStaffPlan

--- a/Sources/CeolKitParser/Semantic/SemanticPass.swift
+++ b/Sources/CeolKitParser/Semantic/SemanticPass.swift
@@ -18,7 +18,9 @@ struct SemanticPass {
         for line in file.filePreamble {
             if case .directive(let name, let payload, let src) = line {
                 if name == "footer" {
-                    currentFooter = stripQuotes(payload.trimmingCharacters(in: .whitespaces))
+                    let footer = stripQuotes(payload.trimmingCharacters(in: .whitespaces))
+                    diagnoseFooterPlaceholders(footer, source: src, into: &diagnostics)
+                    currentFooter = footer
                 } else if isCeolKitDirective(name) || isStandardDirective(name) {
                     var tempDiags: [Diagnostic] = []
                     if let d = parseCeolKitDirective(name: name, payload: payload, source: src, diagnostics: &tempDiags) {
@@ -52,8 +54,10 @@ struct SemanticPass {
         var tunes: [Tune] = []
         for (idx, abcTune) in file.tunes.enumerated() {
             // Update footer from tune header directives (last-wins across document).
-            for (name, payload, _) in abcTune.headerDirectives where name == "footer" {
-                currentFooter = stripQuotes(payload.trimmingCharacters(in: .whitespaces))
+            for (name, payload, src) in abcTune.headerDirectives where name == "footer" {
+                let footer = stripQuotes(payload.trimmingCharacters(in: .whitespaces))
+                diagnoseFooterPlaceholders(footer, source: src, into: &diagnostics)
+                currentFooter = footer
             }
             let (tune, tuneDiags) = buildTune(abcTune, dialect: dialect)
             diagnostics += tuneDiags
@@ -1193,6 +1197,38 @@ struct SemanticPass {
             return nil
         default:
             return nil
+        }
+    }
+
+    /// The `$`-tokens a `%%footer` template may use.  `$d` is a second spelling of `$D`.
+    private static let footerPlaceholders: Set<Character> = ["P", "T", "D", "d"]
+
+    /// Warns about every other `$`-token in a `%%footer` template (issue #141).
+    ///
+    /// The renderer substitutes `footerPlaceholders` and leaves the rest of the template in
+    /// the literal text, so `%%footer "$X"` engraves the characters `$X` — and under the
+    /// default `TextRendering.outlines` it engraves them as artwork, which nothing downstream
+    /// can read back.  Parse time is the only place anyone gets told.  This catches both an
+    /// abcm2ps placeholder CeolKit does not implement (`$F`, `$V`, `$P0`) and a typo such as
+    /// `$p`; a `$` not followed by a letter (`$5`, a trailing `$`) is ordinary text, and
+    /// `${name}` is a consumer-substitutable span, so neither is a token at all.
+    ///
+    /// One warning per distinct token: every occurrence shares the directive's source range,
+    /// so repeating them would be noise pointing at the same line.
+    private func diagnoseFooterPlaceholders(_ template: String, source: SourceRange,
+                                            into diagnostics: inout [Diagnostic]) {
+        var seen: Set<Character> = []
+        for match in template.matches(of: /\$([A-Za-z])/) {
+            guard let token = match.1.first,
+                  !Self.footerPlaceholders.contains(token),
+                  seen.insert(token).inserted else { continue }
+            diagnostics.append(Diagnostic(
+                severity: .warning,
+                code: .unknownFooterPlaceholder,
+                message: "'$\(token)' is not a footer placeholder; it will be engraved literally",
+                source: source,
+                hint: "CeolKit substitutes $P, $T, $D and $d in %%footer."
+            ))
         }
     }
 

--- a/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
+++ b/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
@@ -311,16 +311,40 @@ public struct SVGRenderer: CeolKitRenderer {
                                         graceNoteSpacing: graceNoteSpacing))
         }
 
+        let firstPageNumber = Self.firstPageNumber(of: score)
         let emitter = SVGEmitter(config: effectiveConfig, metadata: metadata,
-                                 stemDirection: documentStemDirection)
+                                 stemDirection: documentStemDirection,
+                                 firstPageNumber: firstPageNumber)
         let layout = engine.layout(tuneBlocks)
-        let finalLayout = attachFooters(layout, score: score, config: effectiveConfig)
+        let finalLayout = attachFooters(layout, score: score, config: effectiveConfig,
+                                        firstPageNumber: firstPageNumber)
         return try emitter.emit(finalLayout)
+    }
+
+    // MARK: - Page numbering
+
+    /// The number the document's first page prints, per `%%ceolkit:pagenumber` (issue #138).
+    ///
+    /// Last-wins, and read only from the first tune: the directive sets the number *before
+    /// any output has been produced*, so the file preamble and the first tune's header are
+    /// the only places it can mean anything, and the parser folds preamble directives into
+    /// the first tune's list in source order, which puts both in one place.  A copy in a
+    /// later tune's header would be asking to renumber pages already engraved — that is
+    /// `%%newpage`'s job, not this directive's — and is ignored.
+    ///
+    /// Defaults to 1, which is what every document that does not use the directive gets, so
+    /// the ordinary page number is `pageIndex + 1` exactly as it always was.
+    static func firstPageNumber(of score: Score) -> Int {
+        score.tunes.first?.directives.compactMap { scope -> Int? in
+            if case .pageNumber(let n) = scope.directive { return n }
+            return nil
+        }.last ?? 1
     }
 
     // MARK: - Footer
 
-    private func attachFooters(_ layout: ResolvedLayout, score: Score, config: SVGRenderConfig) -> ResolvedLayout {
+    private func attachFooters(_ layout: ResolvedLayout, score: Score, config: SVGRenderConfig,
+                               firstPageNumber: Int) -> ResolvedLayout {
         guard let template = score.footer, !template.isEmpty else { return layout }
         // Find the last %%dateformat directive (last-wins across preamble and tune header).
         let dateFormat = score.tunes.first?.directives.compactMap { scope -> String? in
@@ -329,7 +353,8 @@ public struct SVGRenderer: CeolKitRenderer {
         }.last
         let pageCount = layout.pages.count
         let updatedPages = layout.pages.enumerated().map { pageIndex, page -> ResolvedPage in
-            let rows = buildFooterRows(template: template, pageNumber: pageIndex + 1,
+            let rows = buildFooterRows(template: template,
+                                       pageNumber: firstPageNumber + pageIndex,
                                        pageCount: pageCount, score: score, config: config,
                                        dateFormat: dateFormat)
             return ResolvedPage(systems: page.systems, titleRows: page.titleRows, footerRows: rows)

--- a/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
+++ b/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
@@ -340,17 +340,14 @@ public struct SVGRenderer: CeolKitRenderer {
     private func buildFooterRows(template: String, pageNumber: Int, pageCount: Int,
                                   score: Score, config: SVGRenderConfig,
                                   dateFormat: String? = nil) -> [ResolvedTitleRow] {
-        let title   = score.tunes.first?.titles.first?.value ?? ""
-        let dateStr = Self.currentDateString(format: dateFormat)
+        let context = FooterContext(
+            pageNumber: pageNumber, pageCount: pageCount,
+            title: score.tunes.first?.titles.first?.value ?? "",
+            date: Self.currentDateString(format: dateFormat))
+        let columns = FooterTemplate.columns(FooterTemplate.segments(of: template,
+                                                                     context: context))
+            .map(FooterTemplate.trimmed)
 
-        var text = template
-            .replacing(/\$P/, with: String(pageNumber))
-            .replacing(/\$T/, with: title)
-            .replacing(/\$D/, with: dateStr)
-            .replacing(/\$d/, with: dateStr)
-        text = text.replacing(/\\t/, with: "\t")
-
-        let parts     = text.components(separatedBy: "\t")
         let fontSize  = 12.0
         // Shift baseline up by the descender depth so the bottom of descenders (p, g, y, …)
         // lands precisely at the bottom margin line, not below it.
@@ -360,29 +357,69 @@ public struct SVGRenderer: CeolKitRenderer {
         let centerX   = config.pageSize.width / 2.0
         let rightX    = config.pageSize.width - config.margins.right
 
-        var items: [ResolvedTitleRow.Item] = []
-        switch parts.count {
+        let placements: [(column: [FooterSegment], x: Double, anchor: TextAnchor)]
+        switch columns.count {
         case 1:
-            let t = parts[0].trimmingCharacters(in: .whitespaces)
-            if !t.isEmpty {
-                items.append(.init(text: t, x: centerX, baselineY: baselineY,
-                                   anchor: .middle, fontSize: fontSize))
-            }
+            placements = [(columns[0], centerX, .middle)]
         case 2:
-            let l = parts[0].trimmingCharacters(in: .whitespaces)
-            let r = parts[1].trimmingCharacters(in: .whitespaces)
-            if !l.isEmpty { items.append(.init(text: l, x: leftX,  baselineY: baselineY, anchor: .start, fontSize: fontSize)) }
-            if !r.isEmpty { items.append(.init(text: r, x: rightX, baselineY: baselineY, anchor: .end,   fontSize: fontSize)) }
+            placements = [(columns[0], leftX,  .start),
+                          (columns[1], rightX, .end)]
         default:
-            let l = parts[0].trimmingCharacters(in: .whitespaces)
-            let c = parts[1].trimmingCharacters(in: .whitespaces)
-            let r = parts[2].trimmingCharacters(in: .whitespaces)
-            if !l.isEmpty { items.append(.init(text: l, x: leftX,   baselineY: baselineY, anchor: .start,  fontSize: fontSize)) }
-            if !c.isEmpty { items.append(.init(text: c, x: centerX, baselineY: baselineY, anchor: .middle, fontSize: fontSize)) }
-            if !r.isEmpty { items.append(.init(text: r, x: rightX,  baselineY: baselineY, anchor: .end,    fontSize: fontSize)) }
+            placements = [(columns[0], leftX,   .start),
+                          (columns[1], centerX, .middle),
+                          (columns[2], rightX,  .end)]
         }
 
+        let items = placements.flatMap {
+            layOutFooterColumn($0.column, x: $0.x, anchor: $0.anchor,
+                               baselineY: baselineY, fontSize: fontSize)
+        }
         return items.isEmpty ? [] : [ResolvedTitleRow(items: items)]
+    }
+
+    /// Places one footer column, splitting it into separate items only where the author
+    /// marked a `${…}` span.
+    ///
+    /// A column carrying no mark is laid out exactly as it always was — one item at the
+    /// column's own anchor — so ordinary footers are byte-for-byte unchanged and no font is
+    /// read to produce them.
+    private func layOutFooterColumn(_ segments: [FooterSegment], x: Double, anchor: TextAnchor,
+                                     baselineY: Double, fontSize: Double)
+    -> [ResolvedTitleRow.Item] {
+        let text = segments.map(\.text).joined()
+        func wholeColumn(tag: String? = nil) -> [ResolvedTitleRow.Item] {
+            guard tag != nil || !text.isEmpty else { return [] }
+            return [.init(text: text, x: x, baselineY: baselineY, anchor: anchor,
+                          fontSize: fontSize, tag: tag)]
+        }
+
+        guard segments.contains(where: { $0.tagName != nil }) else { return wholeColumn() }
+        // A column that is nothing *but* the mark keeps the column's own anchor, so a
+        // consumer stamping a wider string over it grows the way the column does — leftwards
+        // at the right margin, outwards from the centre — instead of running off the page.
+        if segments.count == 1, let name = segments[0].tagName { return wholeColumn(tag: name) }
+
+        // A mark mixed in with other text has to become an element of its own, which means
+        // measuring what precedes it. Without the bundled face there is nothing to measure
+        // with, so the column falls back to one untagged run: the default text, correctly
+        // drawn, and no substitution point — better than a footer laid out by guesswork.
+        guard let face = OutlineFontSet.textFace() else { return wholeColumn() }
+        var penX: Double
+        switch anchor {
+        case .start:  penX = x
+        case .middle: penX = x - face.width(of: text, fontSize: fontSize) / 2
+        case .end:    penX = x - face.width(of: text, fontSize: fontSize)
+        }
+
+        var items: [ResolvedTitleRow.Item] = []
+        for segment in segments {
+            if segment.tagName != nil || !segment.text.isEmpty {
+                items.append(.init(text: segment.text, x: penX, baselineY: baselineY,
+                                   anchor: .start, fontSize: fontSize, tag: segment.tagName))
+            }
+            penX += face.width(of: segment.text, fontSize: fontSize)
+        }
+        return items
     }
 
     private static func currentDateString(format: String? = nil, date: Date = Date()) -> String {

--- a/Sources/CeolKitSVGRenderer/Emission/SVGBuilder.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGBuilder.swift
@@ -31,6 +31,9 @@ struct SVGBuilder: Sendable {
     /// Ids of the non-empty glyphs, in the order they were first drawn, so that the
     /// emitted `<defs>` block is stable rather than dictionary-ordered.
     private var glyphOrder: [String] = []
+    /// How many times each `${…}` mark has been wrapped in this document, so repeats of one
+    /// name still get unique `id`s — see ``tagGroup(name:x:y:fontFamily:fontSize:textAnchor:_:)``.
+    private var tagCounts: [String: Int] = [:]
 
     init(textRendering: TextRendering = .fontFace, fonts: OutlineFontSet? = nil) {
         self.textRendering = textRendering
@@ -131,6 +134,52 @@ struct SVGBuilder: Sendable {
         let inner = elements[start...].map { "  " + $0 }
         elements.replaceSubrange(start..., with:
             ["<g transform=\"\(esc(transform))\">"] + inner + ["</g>"])
+    }
+
+    /// Wraps everything `body` draws in a `<g>` that names a consumer-substitutable span
+    /// and advertises how CeolKit drew it (issue #137).
+    ///
+    /// The `data-*` attributes are the contract with a downstream consumer; the group's
+    /// contents are CeolKit's own rendering of the span's default value, in whatever mode
+    /// the document is being emitted. A consumer that ignores the group gets exactly the
+    /// output it always got; one that means to substitute empties the group and draws its
+    /// own text at the advertised anchor, which needs the position, size and anchor rather
+    /// than the face — the point of the mark, since `.outlines` leaves no text to rewrite.
+    ///
+    /// Unlike ``group(transform:)`` this is emitted even when it wraps nothing: an author
+    /// who marked a name CeolKit has no value for still gets the positioned, empty group a
+    /// consumer needs to stamp into.
+    mutating func tagGroup(
+        name: String,
+        x: Double, y: Double,
+        fontFamily: String,
+        fontSize: Double,
+        textAnchor: String,
+        _ body: (inout SVGBuilder) -> Void
+    ) {
+        var attrs = "id=\"\(esc(tagID(for: name)))\" class=\"ceolkit-tag\""
+        attrs += " data-ceolkit-tag=\"\(esc(name))\""
+        attrs += " data-x=\"\(fmt(x))\" data-y=\"\(fmt(y))\""
+        attrs += " data-font-size=\"\(fmt(fontSize))\""
+        attrs += " data-font-family=\"\(esc(fontFamily))\""
+        attrs += " data-text-anchor=\"\(esc(textAnchor))\""
+        let start = elements.count
+        body(&self)
+        let inner = elements[start...].map { "  " + $0 }
+        elements.replaceSubrange(start..., with: ["<g \(attrs)>"] + inner + ["</g>"])
+    }
+
+    /// A document-unique `id` for a mark.
+    ///
+    /// Nothing stops a template from marking the same name twice — a page number at both
+    /// margins, say — and duplicate `id`s would make the document ill-formed. The first
+    /// occurrence gets the plain id a consumer would guess; later ones are suffixed.
+    /// `data-ceolkit-tag` carries the name unchanged on every one of them, so a consumer
+    /// keying off that finds them all.
+    private mutating func tagID(for name: String) -> String {
+        let count = (tagCounts[name] ?? 0) + 1
+        tagCounts[name] = count
+        return count == 1 ? "ceolkit-tag-\(name)" : "ceolkit-tag-\(name)-\(count)"
     }
 
     mutating func path(

--- a/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
@@ -356,17 +356,39 @@ struct SVGEmitter: Sendable {
     private func emitFooterBlock(_ rows: [ResolvedTitleRow], builder: inout SVGBuilder) {
         for row in rows {
             for item in row.items {
-                builder.text(
-                    item.text,
+                guard let tag = item.tag else {
+                    emitFooterItem(item, builder: &builder)
+                    continue
+                }
+                // A `${…}` span the author marked for a downstream consumer (issue #137).
+                // CeolKit draws its own value inside the group exactly as it would have
+                // drawn it loose, so a standalone render is unchanged; the group is what
+                // makes the span findable and replaceable in every rendering mode.
+                builder.tagGroup(
+                    name: tag,
                     x: item.x,
                     y: item.baselineY,
                     fontFamily: "Libertinus Serif",
                     fontSize: item.fontSize,
-                    textAnchor: item.anchor.rawValue,
-                    className: "footer"
-                )
+                    textAnchor: item.anchor.rawValue
+                ) {
+                    guard !item.text.isEmpty else { return }
+                    emitFooterItem(item, builder: &$0)
+                }
             }
         }
+    }
+
+    private func emitFooterItem(_ item: ResolvedTitleRow.Item, builder: inout SVGBuilder) {
+        builder.text(
+            item.text,
+            x: item.x,
+            y: item.baselineY,
+            fontFamily: "Libertinus Serif",
+            fontSize: item.fontSize,
+            textAnchor: item.anchor.rawValue,
+            className: "footer"
+        )
     }
 
     // MARK: - System

--- a/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
@@ -80,6 +80,9 @@ struct SVGEmitter: Sendable {
     /// order — carried from ``ResolvedSystem/voiceStemDirections``, so its count is how many
     /// voices share the staff.  Empty on the page-level emitter, which draws nothing itself.
     let voiceStemDirections: [StemDirection]
+    /// The number the first page prints, per `%%ceolkit:pagenumber` (issue #138).  1 for a
+    /// document that does not use the directive, which numbers pages from 1 as before.
+    let firstPageNumber: Int
     let accidentalMetrics: AccidentalMetrics
     /// Resolves the notehead, dot and accidental collisions of one column of a shared staff
     /// (issue #79).  Consulted only where a staff carries more than one voice.
@@ -88,12 +91,14 @@ struct SVGEmitter: Sendable {
     init(config: SVGRenderConfig, metadata: BravuraMetadata,
          stemDirection: StemDirection = .auto,
          systemStemDirection: StemDirection? = nil,
-         voiceStemDirections: [StemDirection] = []) {
+         voiceStemDirections: [StemDirection] = [],
+         firstPageNumber: Int = 1) {
         self.config = config
         self.metadata = metadata
         self.documentStemDirection = stemDirection
         self.stemDirection = systemStemDirection ?? stemDirection
         self.voiceStemDirections = voiceStemDirections
+        self.firstPageNumber = firstPageNumber
         let accidentalMetrics = AccidentalMetrics(config: config, metadata: metadata)
         self.accidentalMetrics = accidentalMetrics
         self.collisions = NoteheadCollisions(
@@ -124,7 +129,7 @@ struct SVGEmitter: Sendable {
         var documents: [String] = []
         documents.reserveCapacity(layout.pages.count)
         for (pageIndex, page) in layout.pages.enumerated() {
-            let document = emitPage(page, pageNumber: pageIndex + 1, layout: layout,
+            let document = emitPage(page, pageNumber: firstPageNumber + pageIndex, layout: layout,
                                      embeddedFaces: embeddedFaces, fonts: fonts,
                                      pendingTies: &pendingTies, pendingSlurs: &pendingSlurs)
             documents.append(document)
@@ -183,7 +188,8 @@ struct SVGEmitter: Sendable {
         systemConfig.graceNoteSpacing = system.graceNoteSpacing
         return SVGEmitter(config: systemConfig, metadata: metadata,
                           stemDirection: documentStemDirection, systemStemDirection: systemStem,
-                          voiceStemDirections: system.voiceStemDirections)
+                          voiceStemDirections: system.voiceStemDirections,
+                          firstPageNumber: firstPageNumber)
     }
 
     // MARK: - Voices on a staff
@@ -320,6 +326,11 @@ struct SVGEmitter: Sendable {
     /// Emits the `ceolkit-meta` comment (issue #25) listing each staff system's
     /// originating ABC source line and page Y coordinate, so editor consumers
     /// (e.g. ScoreEdit) can synchronise scroll position with the source.
+    ///
+    /// `page` is the number the page *prints* — the same value `$P` engraves into the footer,
+    /// offset by `%%ceolkit:pagenumber` where the document sets one (issue #138) — so a
+    /// consumer pairing a rendered page with what the reader sees on paper agrees with the
+    /// footer instead of drifting from it.
     ///
     /// One anchor per staff drawn, including each staff of a multi-voice system — the
     /// geometry reader pairs anchors with staves positionally, so the two counts have to

--- a/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
@@ -362,15 +362,23 @@ public struct ResolvedTitleRow: Sendable {
         public let anchor: TextAnchor
         public let fontSize: Double
         public let isItalic: Bool
+        /// The name of the `${…}` mark this item stands for, or `nil` on ordinary text.
+        ///
+        /// Set only on footer items.  ``text`` is then CeolKit's own value for the mark —
+        /// what gets drawn where nobody replaces it — and the emitter wraps the item in a
+        /// group a downstream consumer can find and redraw (issue #137).
+        public let tag: String?
 
         public init(text: String, x: Double, baselineY: Double,
-                    anchor: TextAnchor, fontSize: Double, isItalic: Bool = false) {
+                    anchor: TextAnchor, fontSize: Double, isItalic: Bool = false,
+                    tag: String? = nil) {
             self.text = text
             self.x = x
             self.baselineY = baselineY
             self.anchor = anchor
             self.fontSize = fontSize
             self.isItalic = isItalic
+            self.tag = tag
         }
     }
 

--- a/Sources/CeolKitSVGRenderer/TitleBlock/FooterTemplate.swift
+++ b/Sources/CeolKitSVGRenderer/TitleBlock/FooterTemplate.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// One piece of a `%%footer` template once the `${…}` marks have been read out of it.
+enum FooterSegment: Equatable, Sendable {
+    /// Text CeolKit engraves and owns.
+    case literal(String)
+    /// A span the author marked `${name}` for a downstream consumer to replace, carrying the
+    /// text CeolKit draws where nobody does.
+    case tag(name: String, text: String)
+
+    var text: String {
+        switch self {
+        case .literal(let text):  return text
+        case .tag(_, let text):   return text
+        }
+    }
+
+    /// The mark's name, or `nil` on a literal.
+    var tagName: String? {
+        if case .tag(let name, _) = self { return name }
+        return nil
+    }
+}
+
+/// What a footer template's placeholders resolve to on one page.
+struct FooterContext: Sendable {
+    let pageNumber: Int
+    let pageCount: Int
+    let title: String
+    let date: String
+
+    /// The value CeolKit draws into `${name}` where no consumer replaces it.
+    ///
+    /// A name CeolKit knows nothing about — a binder title, a section name — resolves to the
+    /// empty string.  The mark still reaches the SVG as a positioned but empty group, which
+    /// is exactly what a consumer meaning to stamp its own text there wants: CeolKit has no
+    /// value for it and should not invent one.
+    func value(forTag name: String) -> String {
+        switch name.lowercased() {
+        case "pagenumber": return String(pageNumber)
+        case "pagecount":  return String(pageCount)
+        case "title":      return title
+        case "date":       return date
+        default:           return ""
+        }
+    }
+}
+
+/// Reads a `%%footer` template into the spans that make it up (issue #137).
+///
+/// `${name}` marks a span as *consumer-substitutable*: CeolKit still draws its own value
+/// there, but the renderer emits that span as one findable, self-describing element instead
+/// of as loose glyphs, so a tool assembling pages from several separately-rendered files can
+/// replace it without owning the font.  Everything else in the template is ordinary text.
+enum FooterTemplate {
+    /// A mark's name is an identifier, so that a `${` appearing in ordinary footer text
+    /// cannot be mistaken for one.  Anything that does not parse as a mark — an unclosed
+    /// brace, a name starting with a digit — stays in the literal text exactly as written,
+    /// which is what an author who did not mean a mark expects to see engraved.
+    ///
+    /// Computed rather than stored: a `Regex` is not `Sendable`, so a `static let` holding
+    /// one is a mutable global the concurrency checker rejects.
+    private static var mark: Regex<(Substring, Substring)> { /\$\{([A-Za-z][A-Za-z0-9_.-]*)\}/ }
+
+    /// Splits `template` into literal and marked spans, with every `$P`/`$T`/`$D`/`$d` in the
+    /// literals resolved and `\t` unescaped.
+    ///
+    /// Marks are read out of the *raw* template, before the other placeholders expand, so a
+    /// tune whose title happens to contain `${…}` cannot conjure a substitution point.
+    static func segments(of template: String, context: FooterContext) -> [FooterSegment] {
+        var segments: [FooterSegment] = []
+        var cursor = template.startIndex
+        for match in template.matches(of: mark) {
+            if cursor < match.range.lowerBound {
+                segments.append(.literal(expand(String(template[cursor..<match.range.lowerBound]),
+                                                context)))
+            }
+            let name = String(match.1)
+            segments.append(.tag(name: name, text: context.value(forTag: name)))
+            cursor = match.range.upperBound
+        }
+        if cursor < template.endIndex {
+            segments.append(.literal(expand(String(template[cursor...]), context)))
+        }
+        return segments
+    }
+
+    /// Splits `segments` at tab characters into the footer's columns — one, two, or three,
+    /// as `buildFooterRows` has always read a template.  A mark never spans a tab, so it
+    /// always belongs wholly to one column.
+    static func columns(_ segments: [FooterSegment]) -> [[FooterSegment]] {
+        var columns: [[FooterSegment]] = [[]]
+        for segment in segments {
+            guard case .literal(let text) = segment else {
+                columns[columns.count - 1].append(segment)
+                continue
+            }
+            for (index, piece) in text.components(separatedBy: "\t").enumerated() {
+                if index > 0 { columns.append([]) }
+                if !piece.isEmpty { columns[columns.count - 1].append(.literal(piece)) }
+            }
+        }
+        return columns
+    }
+
+    /// Strips the whitespace a column is padded with, the way trimming the whole column
+    /// string used to.  Only the literal ends are touched: a mark's default value is a value,
+    /// not padding, and a consumer comparing what it reads against what it stamps should not
+    /// have to know that CeolKit trimmed it.
+    static func trimmed(_ column: [FooterSegment]) -> [FooterSegment] {
+        var column = column
+        if case .literal(let text)? = column.first {
+            var trimmed = text
+            while let first = trimmed.first, first.isWhitespace { trimmed.removeFirst() }
+            column[0] = .literal(trimmed)
+        }
+        if case .literal(let text)? = column.last {
+            var trimmed = text
+            while let last = trimmed.last, last.isWhitespace { trimmed.removeLast() }
+            column[column.count - 1] = .literal(trimmed)
+        }
+        return column.filter { $0.tagName != nil || !$0.text.isEmpty }
+    }
+
+    private static func expand(_ text: String, _ context: FooterContext) -> String {
+        text.replacing(/\$P/, with: String(context.pageNumber))
+            .replacing(/\$T/, with: context.title)
+            .replacing(/\$D/, with: context.date)
+            .replacing(/\$d/, with: context.date)
+            .replacing(/\\t/, with: "\t")
+    }
+}

--- a/Tests/CeolKitParserTests/Extensions/StandardDirectiveTests.swift
+++ b/Tests/CeolKitParserTests/Extensions/StandardDirectiveTests.swift
@@ -316,6 +316,65 @@ struct StandardDirectiveTests {
         #expect(result.score.footer == "left\\tcenter\\tright")
     }
 
+    // MARK: %%footer placeholders (issue #141)
+
+    @Test("Every recognised $ placeholder passes without a warning")
+    func footerKnownPlaceholdersSilent() {
+        let abc = "%%footer \"$T\\t$P of $D\\t$d\"\nX:1\nT:T\nM:4/4\nL:1/4\nK:C\nC|"
+        let result = parse(abc)
+        #expect(result.score.diagnostics.allSatisfy { $0.code != .unknownFooterPlaceholder })
+    }
+
+    @Test("An unrecognised $ token warns and names itself")
+    func footerUnknownPlaceholderWarns() {
+        let abc = "%%footer \"$Q\"\nX:1\nT:T\nM:4/4\nL:1/4\nK:C\nC|"
+        let result = parse(abc)
+        let warnings = result.score.diagnostics.filter { $0.code == .unknownFooterPlaceholder }
+        #expect(warnings.count == 1)
+        #expect(warnings.first?.severity == .warning)
+        #expect(warnings.first?.message.contains("$Q") == true)
+    }
+
+    @Test("A typo differing only in case is caught")
+    func footerPlaceholderCaseTypoWarns() {
+        let abc = "%%footer \"Page $p\"\nX:1\nT:T\nM:4/4\nL:1/4\nK:C\nC|"
+        let result = parse(abc)
+        let warnings = result.score.diagnostics.filter { $0.code == .unknownFooterPlaceholder }
+        #expect(warnings.count == 1)
+        #expect(warnings.first?.message.contains("$p") == true)
+    }
+
+    @Test("A repeated unknown token warns once, distinct ones once each")
+    func footerUnknownPlaceholdersDeduplicated() {
+        let abc = "%%footer \"$X $X $V\"\nX:1\nT:T\nM:4/4\nL:1/4\nK:C\nC|"
+        let result = parse(abc)
+        let warnings = result.score.diagnostics.filter { $0.code == .unknownFooterPlaceholder }
+        #expect(warnings.count == 2)
+    }
+
+    @Test("A $ that is not followed by a letter is ordinary text")
+    func footerBareDollarNotDiagnosed() {
+        let abc = "%%footer \"Price: $5, or $\"\nX:1\nT:T\nM:4/4\nL:1/4\nK:C\nC|"
+        let result = parse(abc)
+        #expect(result.score.diagnostics.allSatisfy { $0.code != .unknownFooterPlaceholder })
+    }
+
+    @Test("A ${name} span is not mistaken for a placeholder")
+    func footerTagSpanNotDiagnosed() {
+        let abc = "%%footer \"${bindername}\\t${pagenumber}\"\nX:1\nT:T\nM:4/4\nL:1/4\nK:C\nC|"
+        let result = parse(abc)
+        #expect(result.score.diagnostics.allSatisfy { $0.code != .unknownFooterPlaceholder })
+    }
+
+    @Test("An unrecognised $ token in a tune header warns too")
+    func footerUnknownPlaceholderInTuneHeaderWarns() {
+        let abc = "X:1\nT:T\n%%footer \"$F\"\nM:4/4\nL:1/4\nK:C\nC|"
+        let result = parse(abc)
+        let warnings = result.score.diagnostics.filter { $0.code == .unknownFooterPlaceholder }
+        #expect(warnings.count == 1)
+        #expect(warnings.first?.message.contains("$F") == true)
+    }
+
     // MARK: %%dateformat
 
     @Test("%%dateformat does not emit unknownDirective warning")

--- a/Tests/CeolKitSVGRendererTests/FooterTagTests.swift
+++ b/Tests/CeolKitSVGRendererTests/FooterTagTests.swift
@@ -1,0 +1,148 @@
+//
+//  FooterTagTests.swift
+//  CeolKitSVGRendererTests
+//
+//  Consumer-substitutable footer spans — issue #137.
+//
+
+import CeolKitModel
+import CeolKitParser
+import Foundation
+import Testing
+@testable import CeolKitSVGRenderer
+
+private func parse(_ source: String) -> ParseResult {
+    CeolKitParser().parse(source, options: .default)
+}
+
+private func render(_ footer: String, textRendering: TextRendering = .fontFace) throws -> String {
+    let abc = """
+    %%footer "\(footer)"
+    X:1
+    T:Marked
+    M:4/4
+    L:1/4
+    K:C
+    CDEF|
+    """
+    var config = SVGRenderConfig()
+    config.textRendering = textRendering
+    return try SVGRenderer(config: config).render(parse(abc).score).joined()
+}
+
+private let context = FooterContext(pageNumber: 4, pageCount: 9, title: "Reel", date: "1 May")
+
+@Suite("Footer substitution marks (#137)")
+struct FooterTagTests {
+
+    // MARK: - Template reading
+
+    @Test func aMarkBecomesItsOwnSegmentCarryingCeolKitsValue() {
+        let segments = FooterTemplate.segments(of: "Page ${pagenumber}", context: context)
+        #expect(segments == [.literal("Page "), .tag(name: "pagenumber", text: "4")])
+    }
+
+    @Test func knownNamesResolveToTheValuesTheOtherPlaceholdersUse() {
+        let segments = FooterTemplate.segments(
+            of: "${pagenumber}${pagecount}${title}${date}", context: context)
+        #expect(segments.map(\.text) == ["4", "9", "Reel", "1 May"])
+    }
+
+    @Test func aNameCeolKitHasNoValueForStillMarksTheSpan() {
+        let segments = FooterTemplate.segments(of: "${bindername}", context: context)
+        // Empty rather than invented: the consumer owns the text, CeolKit only owns the spot.
+        #expect(segments == [.tag(name: "bindername", text: "")])
+    }
+
+    @Test func placeholdersInsideTheMarkedValuesCannotConjureAMark() {
+        // A tune whose title contains ${…} must engrave it, not turn it into a
+        // substitution point: marks are read from the raw template, before $T expands.
+        let sneaky = FooterContext(pageNumber: 1, pageCount: 1,
+                                   title: "${pagenumber}", date: "1 May")
+        let segments = FooterTemplate.segments(of: "$T", context: sneaky)
+        #expect(segments == [.literal("${pagenumber}")])
+    }
+
+    @Test(arguments: ["${1bad}", "${un closed", "${}", "$ {pagenumber}"])
+    func textThatIsNotAMarkIsLeftAlone(_ template: String) {
+        let segments = FooterTemplate.segments(of: template, context: context)
+        #expect(segments == [.literal(template)])
+    }
+
+    @Test func columnsSplitAtTabsAndAMarkStaysWhollyInsideOne() {
+        let segments = FooterTemplate.segments(of: "a\\t${x}b\\tc", context: context)
+        let columns = FooterTemplate.columns(segments)
+        #expect(columns.count == 3)
+        #expect(columns[0] == [.literal("a")])
+        #expect(columns[1] == [.tag(name: "x", text: ""), .literal("b")])
+        #expect(columns[2] == [.literal("c")])
+    }
+
+    @Test func onlyTheLiteralEndsOfAColumnAreTrimmed() {
+        let column = FooterTemplate.trimmed(FooterTemplate.segments(
+            of: "   Page ${pagenumber}   ", context: context))
+        #expect(column == [.literal("Page "), .tag(name: "pagenumber", text: "4")])
+    }
+
+    // MARK: - Emission
+
+    @Test func aMarkedSpanIsWrappedInAFindableSelfDescribingGroup() throws {
+        let svg = try render("Page ${pagenumber}")
+        #expect(svg.contains("<g id=\"ceolkit-tag-pagenumber\" class=\"ceolkit-tag\""))
+        #expect(svg.contains("data-ceolkit-tag=\"pagenumber\""))
+        #expect(svg.contains("data-font-size=\"12\""))
+        #expect(svg.contains("data-font-family=\"Libertinus Serif\""))
+    }
+
+    @Test func theGroupCarriesCeolKitsOwnRenderingOfTheDefaultValue() throws {
+        let svg = try render("Page ${pagenumber}")
+        // A consumer that ignores the group gets exactly today's output: "Page" beside "1".
+        #expect(svg.contains(">Page </text>"))
+        #expect(svg.contains(">1</text>"))
+    }
+
+    @Test func theSpanIsWrappedInOutlineModeToo() throws {
+        // The whole point: `.outlines` leaves no text to rewrite, so the group is the only
+        // thing a consumer has to work with — it must be there in every mode.
+        let svg = try render("Page ${pagenumber}", textRendering: .outlines)
+        #expect(svg.contains("data-ceolkit-tag=\"pagenumber\""))
+        #expect(!svg.contains("<text"))
+    }
+
+    @Test func aMarkCeolKitCannotFillLeavesAnEmptyGroupAtTheRightSpot() throws {
+        let svg = try render("${bindername}", textRendering: .outlines)
+        #expect(svg.contains("data-ceolkit-tag=\"bindername\""))
+        #expect(svg.contains("data-x=\"306\""))
+        #expect(svg.contains("data-text-anchor=\"middle\""))
+    }
+
+    @Test func aColumnThatIsNothingButTheMarkKeepsTheColumnsAnchor() throws {
+        // A wider replacement then grows leftwards from the right margin instead of off
+        // the page.
+        let svg = try render("$T\\t\\t${pagenumber}")
+        #expect(svg.contains("data-text-anchor=\"end\""))
+        #expect(svg.contains("data-x=\"576\""))
+    }
+
+    @Test func aMarkMixedWithTextIsPlacedAfterTheTextItFollows() throws {
+        let svg = try render("Page ${pagenumber}")
+        let literalX = try #require(svg.firstMatch(of: #/<text x="([0-9.]+)"[^>]*>Page /#))
+        let tagX = try #require(svg.firstMatch(of: #/data-ceolkit-tag="pagenumber" data-x="([0-9.]+)"/#))
+        #expect(Double(tagX.1)! > Double(literalX.1)!)
+        // Centred column: the run as a whole still straddles the page centre.
+        #expect(Double(literalX.1)! < 306)
+    }
+
+    @Test func repeatsOfOneNameGetUniqueIdsAndTheSameTagName() throws {
+        let svg = try render("${pagenumber}\\t\\t${pagenumber}")
+        #expect(svg.contains("id=\"ceolkit-tag-pagenumber\""))
+        #expect(svg.contains("id=\"ceolkit-tag-pagenumber-2\""))
+        #expect(svg.ranges(of: "data-ceolkit-tag=\"pagenumber\"").count == 2)
+    }
+
+    @Test func anUnmarkedFooterIsUntouched() throws {
+        let svg = try render("Page $P")
+        #expect(!svg.contains("ceolkit-tag"))
+        #expect(svg.contains(">Page 1</text>"))
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/PageNumberTests.swift
+++ b/Tests/CeolKitSVGRendererTests/PageNumberTests.swift
@@ -1,0 +1,134 @@
+//
+//  PageNumberTests.swift
+//  CeolKitSVGRendererTests
+//
+//  %%ceolkit:pagenumber reaching the page it numbers — issue #138.
+//
+
+import CeolKitModel
+import CeolKitParser
+import Foundation
+import Testing
+@testable import CeolKitSVGRenderer
+
+private func parse(_ source: String) -> ParseResult {
+    CeolKitParser().parse(source, options: .default)
+}
+
+/// One short tune, whose footer prints whatever the placeholders resolve to.
+private func oneTune(_ preamble: String, footer: String = "P=$P") -> String {
+    """
+    \(preamble)
+    %%footer "\(footer)"
+    X:1
+    T:A
+    M:4/4
+    L:1/8
+    K:G
+    GABG|DEFD|
+    """
+}
+
+/// Enough music to fill several pages of a page size deliberately made short.
+private func longTune(_ preamble: String) -> String {
+    let body = Array(repeating: "GABG|DEFD|GABG|D4|", count: 40).joined(separator: "\n")
+    return """
+    \(preamble)
+    %%footer "P=$P"
+    X:1
+    T:A
+    M:4/4
+    L:1/8
+    K:G
+    \(body)
+    """
+}
+
+private func footers(of abc: String, pageSize: PageSize = .letter) throws -> [String] {
+    var config = SVGRenderConfig()
+    config.pageSize = pageSize
+    config.textRendering = .fontFace
+    return try SVGRenderer(config: config).render(parse(abc).score).map { page in
+        page.firstMatch(of: #/class="footer">([^<]*)</#).map { String($0.1) } ?? ""
+    }
+}
+
+@Suite("%%ceolkit:pagenumber (#138)")
+struct PageNumberTests {
+
+    @Test func theFirstPagePrintsTheNumberTheDirectiveAsksFor() throws {
+        #expect(try footers(of: oneTune("%%ceolkit:pagenumber 3")) == ["P=3"])
+    }
+
+    @Test func withoutTheDirectivePagesStillNumberFromOne() throws {
+        #expect(try footers(of: oneTune("%%dateformat \"%Y\"")) == ["P=1"])
+    }
+
+    @Test func laterPagesCarryOnFromTheStatedNumber() throws {
+        // A short page forces several of them, so the sequence — not just the first page —
+        // is what gets checked.
+        let printed = try footers(of: longTune("%%ceolkit:pagenumber 17"),
+                                  pageSize: PageSize(width: 612, height: 300))
+        try #require(printed.count > 2, "the fixture must span several pages to be worth testing")
+        #expect(printed == (0..<printed.count).map { "P=\(17 + $0)" })
+    }
+
+    @Test func theDirectiveWorksInTheFirstTunesHeaderToo() throws {
+        let abc = """
+        %%footer "P=$P"
+        X:1
+        T:A
+        %%ceolkit:pagenumber 5
+        M:4/4
+        L:1/8
+        K:G
+        GABG|
+        """
+        #expect(try footers(of: abc) == ["P=5"])
+    }
+
+    @Test func theLastStatementOfTheNumberWins() throws {
+        #expect(try footers(of: oneTune("%%ceolkit:pagenumber 3\n%%ceolkit:pagenumber 8"))
+                == ["P=8"])
+    }
+
+    @Test func aCopyInALaterTunesHeaderIsIgnored() throws {
+        // The directive sets the number *before any output has been produced*.  A second
+        // tune's header is past that point, and renumbering pages already engraved is
+        // %%newpage's job, not this directive's.
+        let abc = """
+        %%footer "P=$P"
+        X:1
+        T:A
+        M:4/4
+        L:1/8
+        K:G
+        GABG|
+
+        X:2
+        T:B
+        %%ceolkit:pagenumber 9
+        M:4/4
+        L:1/8
+        K:G
+        GABG|
+        """
+        #expect(try footers(of: abc).first == "P=1")
+    }
+
+    @Test func theScrollSyncMetadataAgreesWithTheFooter() throws {
+        var config = SVGRenderConfig()
+        config.textRendering = .fontFace
+        let pages = try SVGRenderer(config: config)
+            .render(parse(oneTune("%%ceolkit:pagenumber 3")).score)
+        #expect(pages[0].contains("\"page\": 3"))
+    }
+
+    @Test func aSubstitutionMarkInheritsTheSameNumber() throws {
+        // ${pagenumber} is documented as "the same value as $P" (#137), so the offset has to
+        // reach it too — a binder compiler reading the default has to see what was drawn.
+        let printed = try footers(of: oneTune("%%ceolkit:pagenumber 4",
+                                              footer: "${pagenumber}"))
+        #expect(printed == ["4"])
+    }
+}


### PR DESCRIPTION
Two footer fixes that turned out to be one story: a consumer assembling pages from several
separately-rendered files cannot correct the page numbers CeolKit engraves, and the directive
that looks like it should have helped never worked.

## `${name}` marks a footer span as the consumer's (#137)

Outlining is a one-way door. Under the default `.outlines` a footer reading `Page 1` leaves
the renderer as six `<use>` elements and no text anywhere in the document, so a post-processor
has nothing to rewrite — and only CeolKit still has the font, the metrics and the layout
needed to draw a different string in that spot.

`${name}` in a `%%footer` template now marks a span as substitutable. CeolKit still draws its
own value there, but the renderer wraps that span in a group carrying the name and the
position, size, family and anchor it drew at:

```xml
<g id="ceolkit-tag-pagenumber" class="ceolkit-tag" data-ceolkit-tag="pagenumber"
   data-x="576" data-y="753.048" data-font-size="12"
   data-font-family="Libertinus Serif" data-text-anchor="end">
  <text …>1</text>   <!-- or the outlined <use> run, per mode -->
</g>
```

A consumer empties the group and stamps its own text at the advertised anchor, which needs the
position and size rather than the face. The `data-*` attributes are the contract; the group's
contents are CeolKit's.

- `pagenumber`, `pagecount`, `title` and `date` carry CeolKit values. Any other name draws
  nothing and leaves a positioned, empty group — a binder name is not CeolKit's to invent.
- The wrapper is identical in `.outlines`, `.fontFace` and `.both`, so a consumer never has to
  care which mode produced the file, and `.outlines` stays the default with no hole in the
  guarantee it exists to give.
- A column that is nothing but the mark keeps that column's own anchor, so a wider replacement
  grows the way the column does rather than off the page. A mark mixed with text is measured
  into place after what precedes it, and the consumer owns the overflow — so a page number a
  consumer will rewrite wants a column of its own, which the docs say.
- Repeats of one name get suffixed `id`s; `data-ceolkit-tag` carries the bare name on all of
  them.
- Marks are read from the raw template before `$T`/`$P` expand, so a title containing `${…}`
  cannot conjure a substitution point. Anything that is not a mark (`${1st}`, an unclosed
  `${`) is engraved literally.

A column with no mark in it takes exactly the path it always did — ordinary footers are
unchanged, and no font is read to lay one out.

## `%%ceolkit:pagenumber` reaches the page it numbers (#138)

The directive was parsed, validated and then dropped: `$P` came from `pageIndex + 1` and
nothing else, so every document numbered from 1 and nothing warned — including the "start
numbering from page 3" example in EXTENSIONS.md, which printed "Page 1".

The renderer now reads the last `.pageNumber` directive out of the first tune (the parser
folds preamble directives into that list in source order, so the preamble and the first tune's
header are one sequence) and uses it as the base. It reaches `$P`, `${pagenumber}`, and the
`page` field of the `ceolkit-meta` scroll-sync comment, so an editor pairing a rendered page
with what the reader sees on paper agrees with the printed footer instead of drifting from it.

A copy in a later tune's header is ignored: the number is set before any output has been
produced, and renumbering pages already engraved is `%%newpage`'s job (#140). A document that
does not use the directive gets a base of 1 — the `pageIndex + 1` it always got.

## Documentation

EXTENSIONS.md gains a "Consumer-substitutable footer spans" section, cross-referenced from
`%%ceolkit:pagenumber` in both directions, since a reader arriving at one almost certainly
wants to know why the other did not do the job. `%%ceolkit:pagenumber` also gains a "Where it
is read" section, and its "Interaction with `%%newpage`" section is now caveated as describing
a directive CeolKit does not yet support (#140).

## Testing

`swift build` and `swift test` clean: **1179 tests, all passing**, of which 23 are new —
`FooterTagTests` (15) and `PageNumberTests` (8). The page-number sequence is checked across a
fixture that spans several pages, not just on page 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jcPEbVn1io17Pn2p274Fa
