### PR TITLE
Fix #140 — %%newpage starts a page, and can renumber it

### DIFF
--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -146,6 +146,62 @@ it belongs to its voice and goes wherever that voice goes.
 
 ---
 
+## §11.4.7 Page breaks — `%%newpage`
+
+**Syntax:** `%%newpage [<int>]` — start a new page, optionally renumbering it from `<int>`.
+
+§11.4.7 lists `%%newpage` among the separation directives and §11.6 leaves the parameters to
+the implementation; `abcm2ps` and `abc2svg` both answer to it, and CeolKit uses their
+spelling — unprefixed, and with the same optional integer. §11.0.1 asks that a directive
+implemented in more than one program converge rather than fork, and a file that page-breaks
+correctly in `abcm2ps` should not need editing to page-break here.
+
+### Where it may be written
+
+| Written in | Breaks before |
+| --- | --- |
+| the file header | the first tune — which prints no break, since nothing has been engraved yet |
+| the gap between two tunes | the tune below it |
+| a tune header | that tune |
+| the tune body | the stave it stands above |
+| below a tune's last stave | whatever follows the tune |
+
+Like a staff plan, a break in the body takes effect from the start of the **stave** (one
+source line of music) it is written in, and one written part-way through a stave — between
+the voices of a multi-voice system, say — snaps back to the start of it with a
+`pageBreakSnappedToStave` warning. A page break is a system break, and the staves of a
+system are laid out together, so it cannot fall part-way through one.
+
+A `%%newpage` past the last tune in the file has nothing left to move onto a fresh page. It
+is dropped, with a `pageBreakAfterLastTune` info diagnostic, rather than leaving a blank
+page behind it — and for the same reason one at the very top of a file breaks nothing: an
+empty page is not something to break away from.
+
+### The optional page number
+
+`%%newpage N` renumbers the page it opens to `N`, and the count carries on from there, so
+the page after a `%%newpage 20` is 21. `N` must be an integer of 1 or more.
+
+An argument that is not one — `%%newpage frog`, `%%newpage 0` — produces an
+`invalidPageNumber` warning and **the page break still happens**; only the renumbering is
+dropped. The argument is optional, so a bad one is a mistyped option on a directive that is
+otherwise perfectly clear, and refusing to break the page would lose the part the author got
+right.
+
+The number reaches the `$P` and `${pagenumber}` footer substitutions and the `page` field of
+the `ceolkit-meta` scroll-sync comment, exactly as
+[`%%ceolkit:pagenumber`](EXTENSIONS.md#ceolkitpagenumber) does. The two compose: that
+directive names the document's opening page, and each `%%newpage N` renames the one it
+opens.
+
+### What CeolKit does not do
+
+`%%newpage` is the only one of §11.4.7's separation directives CeolKit implements. `%%sep`
+and `%%vskip` are still reported as unsupported and ignored, which is what §11.0.2 asks of a
+directive an application does not recognise.
+
+---
+
 ## Worked examples in the test suite
 
 The standard's own multi-voice examples are checked in end to end, parser and renderer, so

--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -248,15 +248,28 @@ rendered page with what the reader sees on paper agrees with the printed footer.
 
 ### Interaction with `%%newpage`
 
-> **Not yet implemented.** `%%newpage` is not supported — it reports
-> `info: Unsupported stylesheet directive '%%newpage'` and no page break occurs. It is
-> requested as [#140](https://github.com/sbeitzel/CeolKit/issues/140); this section
-> describes what the two directives will mean together once it lands.
+`%%newpage N` also sets the page number, as a side-effect of forcing a page break —
+see [CONFORMANCE.md → `%%newpage`](CONFORMANCE.md#1147-page-breaks--newpage).
+`%%ceolkit:pagenumber N` sets the page number *without* starting a new page, so it is
+only meaningful before any output has been produced (i.e., in the file preamble or at
+the very start of a tune header).
 
-`%%newpage N` also sets the page number as a side-effect of forcing a page
-break. `%%ceolkit:pagenumber N` sets the page number *without* starting a new page,
-so it is only meaningful before any output has been produced (i.e., in the
-file preamble or at the very start of a tune header).
+The two compose rather than competing: `%%ceolkit:pagenumber` names the opening page and
+each `%%newpage N` renames the one it opens, with the count carrying on from there.
+
+```abc
+%%ceolkit:pagenumber 3
+%%footer "$P"
+X:1
+...
+
+%%newpage 20
+X:2
+...
+```
+
+Page 1 of the output prints "3"; the page tune 2 starts on prints "20", and the page after
+that "21".
 
 ---
 

--- a/Sources/CeolKitModel/Diagnostic.swift
+++ b/Sources/CeolKitModel/Diagnostic.swift
@@ -80,6 +80,13 @@ public enum DiagnosticCode: String, Codable, Sendable {
     /// change without splitting the system.  It takes effect from the start of the stave
     /// enclosing it instead — see `StaffPlanChange`.
     case staffPlanSnappedToStave
+    /// A `%%newpage` was written part-way through a stave, where a page cannot break without
+    /// splitting the system.  It takes effect from the start of the stave enclosing it
+    /// instead — see `PageBreak`.
+    case pageBreakSnappedToStave
+    /// A `%%newpage` stands after the last tune in the file, so there is nothing left for it
+    /// to move onto a fresh page.  It is dropped.
+    case pageBreakAfterLastTune
     /// A `%%score` / `%%staves` names a voice the tune does not declare anywhere.  The rest
     /// of the plan is honoured.
     case staffPlanVoiceNotFound

--- a/Sources/CeolKitModel/PageBreak.swift
+++ b/Sources/CeolKitModel/PageBreak.swift
@@ -1,0 +1,43 @@
+//
+//  PageBreak.swift
+//  CeolKit
+//
+//  Created by Stephen Beitzel on 9/3/26.
+//
+
+import Foundation
+
+/// A `%%newpage` and the point in the tune it breaks before (ABC v2.2 §11.4.7, issue #140).
+///
+/// `%%newpage` is one of the two directives whose *position* is part of what it means — the
+/// other is `%%score` (see ``StaffPlanChange``).  Every other directive CeolKit implements
+/// flattens to a last-wins scalar for the whole tune; this one says "the music from here on
+/// starts a fresh page", which is a statement about a place.
+///
+/// The unit is the **stave** — one source line of music, the same unit ``Voice/staves`` is
+/// indexed in — because a page break is a system break, and the staves of a system are laid
+/// out together.  A break written part-way through a stave is snapped back to the start of
+/// the stave enclosing it, with a ``DiagnosticCode/pageBreakSnappedToStave`` diagnostic
+/// saying so, on the same reasoning as a staff plan: the music after the directive is what
+/// the author wanted moved, and moving the whole stave moves all of it.
+public struct PageBreak: Hashable, Sendable {
+    /// Index of the stave this break falls *before*, counted from zero at the start of the
+    /// tune body.  A break written before any of the tune's music — in the file preamble
+    /// ahead of it, or in its header — is 0, and one written after all of it is the tune's
+    /// stave count, which puts the break between this tune and the next.
+    public let beforeStave: Int
+
+    /// The number the new page prints, from `%%newpage N`, or `nil` for a plain `%%newpage`
+    /// that leaves the count alone.  Numbering carries on from here, so the page after a
+    /// `%%newpage 20` is 21.
+    public let restartingAt: Int?
+
+    /// Where the directive was written, which is not where it takes effect once it snaps.
+    public let source: SourceRange
+
+    public init(beforeStave: Int, restartingAt: Int?, source: SourceRange) {
+        self.beforeStave = beforeStave
+        self.restartingAt = restartingAt
+        self.source = source
+    }
+}

--- a/Sources/CeolKitModel/Tune.swift
+++ b/Sources/CeolKitModel/Tune.swift
@@ -29,6 +29,14 @@ public struct Tune: Sendable {
     /// plan both govern from stave 0 — and the later one wins, as it does for every other
     /// directive.
     public let staffPlans: [StaffPlanChange]
+    /// Every `%%newpage` that reaches this tune, in source order, each paired with the stave
+    /// it breaks before — see ``PageBreak``.  Empty when the tune asks for no page break,
+    /// which is almost every tune.
+    ///
+    /// Unlike ``directives``, these are not also stored as ``CeolKitDirective`` values: a
+    /// page break has no meaning apart from where it falls, so the positional view is the
+    /// only one.
+    public let pageBreaks: [PageBreak]
     public let source: SourceRange
 
     public init(
@@ -45,6 +53,7 @@ public struct Tune: Sendable {
         macros: [MacroDefinition],
         directives: [CeolKitDirectiveScope],
         staffPlans: [StaffPlanChange] = [],
+        pageBreaks: [PageBreak] = [],
         source: SourceRange
     ) {
         self.reference = reference
@@ -60,6 +69,7 @@ public struct Tune: Sendable {
         self.macros = macros
         self.directives = directives
         self.staffPlans = staffPlans
+        self.pageBreaks = pageBreaks
         self.source = source
     }
 

--- a/Sources/CeolKitParser/Semantic/BodyContext.swift
+++ b/Sources/CeolKitParser/Semantic/BodyContext.swift
@@ -672,6 +672,9 @@ struct BodyContext {
     /// `%%score` / `%%staves` met in the body, in source order, each already carrying the
     /// stave it governs from.
     var bodyStaffPlans: [StaffPlanChange] = []
+    /// `%%newpage` met in the body, in source order, each already carrying the stave it
+    /// breaks before.
+    var bodyPageBreaks: [PageBreak] = []
     var hasExplicitVoice: Bool = false
     /// The `&` that opened each temporary voice (§7.4).  Its presence is also what says a
     /// layer exists at all: the states themselves live in `voices`, keyed by `VoiceKey`.

--- a/Sources/CeolKitParser/Semantic/SemanticPass.swift
+++ b/Sources/CeolKitParser/Semantic/SemanticPass.swift
@@ -14,6 +14,11 @@ struct SemanticPass {
         // filePreamble contains both the initial preamble and any inter-tune gaps (lines between
         // tunes that fall outside any tune header), so scanning it here covers both.
         var preambleCeolKitDirectives: [CeolKitDirectiveScope] = []
+        // `%%newpage` met outside any tune, in source order.  Unlike everything else in the
+        // preamble these are *not* promoted to the first tune: a break written in the gap
+        // between two tunes belongs to the one that follows it, so each is matched to its
+        // tune by source line in the walk below.
+        var preambleBreaks: [PageBreak] = []
         var currentFooter: String? = nil
         for line in file.filePreamble {
             if case .directive(let name, let payload, let src) = line {
@@ -21,6 +26,11 @@ struct SemanticPass {
                     let footer = stripQuotes(payload.trimmingCharacters(in: .whitespaces))
                     diagnoseFooterPlaceholders(footer, source: src, into: &diagnostics)
                     currentFooter = footer
+                } else if name == "newpage" {
+                    preambleBreaks.append(PageBreak(
+                        beforeStave: 0,
+                        restartingAt: parseNewPage(payload, source: src, diagnostics: &diagnostics),
+                        source: src))
                 } else if isCeolKitDirective(name) || isStandardDirective(name) {
                     var tempDiags: [Diagnostic] = []
                     if let d = parseCeolKitDirective(name: name, payload: payload, source: src, diagnostics: &tempDiags) {
@@ -52,6 +62,7 @@ struct SemanticPass {
         let fileSource = file.tunes.first?.source ?? .emptySourceRange
 
         var tunes: [Tune] = []
+        var previousTuneLine = Int.min
         for (idx, abcTune) in file.tunes.enumerated() {
             // Update footer from tune header directives (last-wins across document).
             for (name, payload, src) in abcTune.headerDirectives where name == "footer" {
@@ -59,9 +70,17 @@ struct SemanticPass {
                 diagnoseFooterPlaceholders(footer, source: src, into: &diagnostics)
                 currentFooter = footer
             }
+            // The preamble breaks standing between the previous tune and this one: they move
+            // *this* tune onto a fresh page, so they are its own, at stave 0.
+            let tuneLine = abcTune.source.line
+            let ownedBreaks = preambleBreaks.filter {
+                $0.source.line > previousTuneLine && $0.source.line < tuneLine
+            }
+            previousTuneLine = tuneLine
             let (tune, tuneDiags) = buildTune(abcTune, dialect: dialect)
             diagnostics += tuneDiags
-            if idx == 0 && !preambleCeolKitDirectives.isEmpty {
+            let extraDirectives = idx == 0 ? preambleCeolKitDirectives : []
+            if !extraDirectives.isEmpty || !ownedBreaks.isEmpty {
                 tunes.append(Tune(
                     reference: tune.reference,
                     titles: tune.titles,
@@ -74,13 +93,23 @@ struct SemanticPass {
                     voices: tune.voices,
                     userSymbols: tune.userSymbols,
                     macros: tune.macros,
-                    directives: preambleCeolKitDirectives + tune.directives,
-                    staffPlans: initialStaffPlans(from: preambleCeolKitDirectives) + tune.staffPlans,
+                    directives: extraDirectives + tune.directives,
+                    staffPlans: initialStaffPlans(from: extraDirectives) + tune.staffPlans,
+                    pageBreaks: ownedBreaks + tune.pageBreaks,
                     source: tune.source
                 ))
             } else {
                 tunes.append(tune)
             }
+        }
+
+        // A `%%newpage` past the last tune has nothing left to move onto a fresh page.
+        for orphan in preambleBreaks where orphan.source.line > previousTuneLine {
+            diagnostics.append(Diagnostic(
+                severity: .info, code: .pageBreakAfterLastTune,
+                message: "%%newpage after the last tune has nothing to break before; ignored",
+                source: orphan.source
+            ))
         }
 
         // Redundancy: %%flatbeams true is implied by %%ceolkit:pipeformat true.
@@ -140,7 +169,28 @@ struct SemanticPass {
         name == "landscape" || name == "flatbeams" || name == "writefields"
             || name == "dateformat" || name == "footer"
             || name == "straightflags" || name == "graceslurs"
-            || name == "score" || name == "staves"
+            || name == "score" || name == "staves" || name == "newpage"
+    }
+
+    /// The argument of a `%%newpage` (ABC v2.2 §11.4.7, issue #140): the number the new page
+    /// is to print, or `nil` for the bare directive, which leaves the count alone.
+    ///
+    /// The argument is optional, so a payload that does not parse is a bad *option* on a
+    /// directive that is otherwise perfectly clear.  The break is kept and only the
+    /// renumbering dropped — the author unmistakably asked for a page break, and refusing to
+    /// draw one because the number beside it was mistyped would lose the part they got right.
+    private func parseNewPage(_ payload: String, source: SourceRange,
+                              diagnostics: inout [Diagnostic]) -> Int? {
+        let trimmed = payload.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return nil }
+        if let n = Int(trimmed), n >= 1 { return n }
+        diagnostics.append(Diagnostic(
+            severity: .warning, code: .invalidPageNumber,
+            message: "%%newpage expects no argument or an integer ≥ 1 (got '\(trimmed)'); "
+                   + "the page break stands and the numbering is left alone",
+            source: source
+        ))
+        return nil
     }
 
     // MARK: - Tune builder
@@ -165,6 +215,16 @@ struct SemanticPass {
 
         // Process header directives (%%ceolkit:* etc.)
         let tuneDirectives = processDirectives(abcTune.headerDirectives, scope: .tuneGlobal, diagnostics: &diagnostics)
+
+        // A `%%newpage` in the header breaks before the tune's first stave — the whole tune
+        // starts a fresh page.
+        var headerBreaks: [PageBreak] = []
+        for (name, payload, src) in abcTune.headerDirectives where name == "newpage" {
+            headerBreaks.append(PageBreak(
+                beforeStave: 0,
+                restartingAt: parseNewPage(payload, source: src, diagnostics: &diagnostics),
+                source: src))
+        }
 
         // Resolve unitNoteLength from meter if not explicit
         if ctx.unitNoteLength == nil {
@@ -222,6 +282,7 @@ struct SemanticPass {
             macros: ctx.macros,
             directives: tuneDirectives + bodyCtx.bodyTuneDirectives,
             staffPlans: initialStaffPlans(from: tuneDirectives) + bodyCtx.bodyStaffPlans,
+            pageBreaks: headerBreaks + bodyCtx.bodyPageBreaks,
             source: abcTune.source
         )
         return (tune, diagnostics)
@@ -842,6 +903,21 @@ struct SemanticPass {
                 }
             }
             diagnostics += tempDiags
+        case "newpage":
+            // §11.4.7: the music from here on starts a fresh page.  Like a staff plan, and
+            // for the same reason — the staves of a system are laid out together — a break
+            // written part-way through one snaps back to the start of the stave enclosing it.
+            if ctx.hasStaveInProgress {
+                diagnostics.append(Diagnostic(
+                    severity: .warning, code: .pageBreakSnappedToStave,
+                    message: "%%newpage inside a stave takes effect from the start of that stave",
+                    source: source
+                ))
+            }
+            ctx.bodyPageBreaks.append(PageBreak(
+                beforeStave: ctx.currentStaveIndex,
+                restartingAt: parseNewPage(payload, source: source, diagnostics: &diagnostics),
+                source: source))
         case "landscape", "flatbeams", "ceolkit:justifylast", "ceolkit:scale",
              "ceolkit:gracenotespacing", "writefields",
              "dateformat", "footer", "straightflags", "graceslurs":

--- a/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
+++ b/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
@@ -99,6 +99,11 @@ public struct SVGRenderer: CeolKitRenderer {
             // boundary is always a system break; a staff plan cannot change mid-system.
             var groups: [SystemGroup] = []
             var headerWidths: [Double] = []
+            // The tune stave each system came from, parallel to `groups`.  `%%newpage` is
+            // written against a stave — one source line of music — and pagination happens in
+            // systems, so this is where the two are reconciled: it is the last point that
+            // still knows which systems the packer made out of which stave.
+            var staveOfGroup: [Int] = []
             // The key each voice is standing in, threaded across the regions: a `%%score` in
             // the body cuts the tune but does not reset it, so the region after one opens in
             // whatever key the music before it reached (#134).  Empty until a body `K:` moves
@@ -282,6 +287,15 @@ public struct SVGRenderer: CeolKitRenderer {
                          group.staves[staffIndex].headerKeyChange)
                     }
                 }
+                // Every stave but the region's last ends on a `.hard` break, which the
+                // breaker stamps on the last system it packed out of that stave.  Walking
+                // the systems it produced therefore recovers the stave each one came from,
+                // without the breaker having to carry the number through justification.
+                var stave = region.staves.lowerBound
+                for group in regionGroups {
+                    staveOfGroup.append(stave)
+                    if group.sourceForced { stave += 1 }
+                }
                 groups += regionGroups
             }
 
@@ -308,17 +322,38 @@ public struct SVGRenderer: CeolKitRenderer {
             ).build()
             tuneBlocks.append(TuneBlock(systemGroups: tuneGroups, titleRows: titleRows,
                                         titleBlockHeight: titleBlockHeight, scale: scale,
-                                        graceNoteSpacing: graceNoteSpacing))
+                                        graceNoteSpacing: graceNoteSpacing,
+                                        pageBreaks: Self.forcedPageBreaks(
+                                            tune.pageBreaks, staveOfGroup: staveOfGroup)))
         }
 
         let firstPageNumber = Self.firstPageNumber(of: score)
         let emitter = SVGEmitter(config: effectiveConfig, metadata: metadata,
                                  stemDirection: documentStemDirection,
                                  firstPageNumber: firstPageNumber)
-        let layout = engine.layout(tuneBlocks)
+        let layout = engine.layout(tuneBlocks, firstPageNumber: firstPageNumber)
         let finalLayout = attachFooters(layout, score: score, config: effectiveConfig,
                                         firstPageNumber: firstPageNumber)
         return try emitter.emit(finalLayout)
+    }
+
+    // MARK: - Page breaks
+
+    /// Resolves the tune's `%%newpage` directives from the staves they were written against
+    /// to the systems they stand in front of (issue #140).
+    ///
+    /// A break lands on the first system of its stave.  Where that stave produced no system
+    /// at all — a `%%score` region whose plan selects nothing is dropped whole — the break
+    /// moves down to the next system there is, which keeps the music the author wanted on a
+    /// fresh page on one.  A break past every system is kept, addressed one past the end:
+    /// there is nothing left in this tune to move, so what it moves is the next tune.
+    static func forcedPageBreaks(_ breaks: [PageBreak],
+                                 staveOfGroup: [Int]) -> [ForcedPageBreak] {
+        breaks.map { pageBreak in
+            let group = staveOfGroup.firstIndex { $0 >= pageBreak.beforeStave }
+                ?? staveOfGroup.count
+            return ForcedPageBreak(beforeGroup: group, pageNumber: pageBreak.restartingAt)
+        }
     }
 
     // MARK: - Page numbering
@@ -354,10 +389,11 @@ public struct SVGRenderer: CeolKitRenderer {
         let pageCount = layout.pages.count
         let updatedPages = layout.pages.enumerated().map { pageIndex, page -> ResolvedPage in
             let rows = buildFooterRows(template: template,
-                                       pageNumber: firstPageNumber + pageIndex,
+                                       pageNumber: page.pageNumber ?? firstPageNumber + pageIndex,
                                        pageCount: pageCount, score: score, config: config,
                                        dateFormat: dateFormat)
-            return ResolvedPage(systems: page.systems, titleRows: page.titleRows, footerRows: rows)
+            return ResolvedPage(systems: page.systems, titleRows: page.titleRows,
+                                footerRows: rows, pageNumber: page.pageNumber)
         }
         return ResolvedLayout(pageSize: layout.pageSize, margins: layout.margins, pages: updatedPages)
     }

--- a/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
@@ -129,7 +129,11 @@ struct SVGEmitter: Sendable {
         var documents: [String] = []
         documents.reserveCapacity(layout.pages.count)
         for (pageIndex, page) in layout.pages.enumerated() {
-            let document = emitPage(page, pageNumber: firstPageNumber + pageIndex, layout: layout,
+            // The engine stamped the number as it decided where the page fell — a
+            // `%%newpage N` both breaks and renumbers (#140).  Counting from
+            // `firstPageNumber` is the fallback for a layout assembled by hand.
+            let document = emitPage(page, pageNumber: page.pageNumber ?? firstPageNumber + pageIndex,
+                                     layout: layout,
                                      embeddedFaces: embeddedFaces, fonts: fonts,
                                      pendingTies: &pendingTies, pendingSlurs: &pendingSlurs)
             documents.append(document)

--- a/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
@@ -189,6 +189,28 @@ public struct SystemGroup: Sendable {
     public var columnCount: Int { staves[0].measures.count }
 }
 
+/// A `%%newpage` that reached the layout, resolved from the stave it was written against to
+/// the system it stands in front of (issue #140).
+///
+/// ``CeolKitModel/PageBreak`` counts staves, which is the unit the *source* breaks in; by the
+/// time a tune is a `TuneBlock` it has been packed into systems, and a system is the unit a
+/// *page* breaks in.  The renderer resolves one to the other while it still knows which
+/// systems came from which stave.
+public struct ForcedPageBreak: Hashable, Sendable {
+    /// Index into ``TuneBlock/systemGroups`` of the system this break falls in front of.
+    /// Equal to the group count for a break past the end of the tune, which puts it between
+    /// this tune and whatever follows.
+    public let beforeGroup: Int
+
+    /// The number the new page prints, from `%%newpage N`, or `nil` to carry on counting.
+    public let pageNumber: Int?
+
+    public init(beforeGroup: Int, pageNumber: Int?) {
+        self.beforeGroup = beforeGroup
+        self.pageNumber = pageNumber
+    }
+}
+
 /// Groups the justified systems and optional title block for a single tune.
 ///
 /// `titleRows` use `baselineY` values relative to the top of the tune's title area
@@ -208,24 +230,30 @@ public struct TuneBlock: Sendable {
     /// carried through unmultiplied.  The sizer reserved the group's width with this value,
     /// so the emitter has to draw with the same one.
     public let graceNoteSpacing: Double
+    /// The `%%newpage` breaks this tune asks for, in system order (issue #140).  Empty for
+    /// almost every tune, and an empty list is the pagination this engine has always done.
+    public let pageBreaks: [ForcedPageBreak]
 
     public init(systemGroups: [JustifiedSystemGroup], titleRows: [ResolvedTitleRow] = [],
                 titleBlockHeight: Double = 0, scale: Double = 1.0,
-                graceNoteSpacing: Double = SVGRenderConfig().graceNoteSpacing) {
+                graceNoteSpacing: Double = SVGRenderConfig().graceNoteSpacing,
+                pageBreaks: [ForcedPageBreak] = []) {
         self.systemGroups = systemGroups
         self.titleRows = titleRows
         self.titleBlockHeight = titleBlockHeight
         self.scale = scale
         self.graceNoteSpacing = graceNoteSpacing
+        self.pageBreaks = pageBreaks
     }
 
     /// Convenience for single-voice music: each system becomes a group of one staff.
     public init(systems: [JustifiedSystem], titleRows: [ResolvedTitleRow] = [],
                 titleBlockHeight: Double = 0, scale: Double = 1.0,
-                graceNoteSpacing: Double = SVGRenderConfig().graceNoteSpacing) {
+                graceNoteSpacing: Double = SVGRenderConfig().graceNoteSpacing,
+                pageBreaks: [ForcedPageBreak] = []) {
         self.init(systemGroups: systems.map { JustifiedSystemGroup(staves: [$0]) },
                   titleRows: titleRows, titleBlockHeight: titleBlockHeight,
-                  scale: scale, graceNoteSpacing: graceNoteSpacing)
+                  scale: scale, graceNoteSpacing: graceNoteSpacing, pageBreaks: pageBreaks)
     }
 }
 
@@ -344,12 +372,20 @@ public struct ResolvedPage: Sendable {
     public let titleRows: [ResolvedTitleRow]
     /// Pre-positioned footer rows; present on every page that has a %%footer template.
     public let footerRows: [ResolvedTitleRow]
+    /// The number this page prints, once something has decided what it is.
+    ///
+    /// Pagination and numbering are the same walk — `%%newpage N` both breaks the page and
+    /// says what the new one is called (issue #140) — so the engine that makes the pages is
+    /// the only thing in a position to number them.  `nil` on a layout assembled by hand,
+    /// where the emitter falls back to counting from its own `firstPageNumber`.
+    public let pageNumber: Int?
 
     public init(systems: [ResolvedSystem], titleRows: [ResolvedTitleRow] = [],
-                footerRows: [ResolvedTitleRow] = []) {
+                footerRows: [ResolvedTitleRow] = [], pageNumber: Int? = nil) {
         self.systems = systems
         self.titleRows = titleRows
         self.footerRows = footerRows
+        self.pageNumber = pageNumber
     }
 }
 

--- a/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
@@ -111,15 +111,47 @@ public struct VerticalLayoutEngine: Sendable {
     /// Lays out a sequence of tune blocks, each with its own optional title block.
     ///
     /// Tunes share pages when they fit; a new page opens only when the current page
-    /// cannot accommodate a tune's title block and its first system together.
+    /// cannot accommodate a tune's title block and its first system together, or when a
+    /// `%%newpage` in the source demands one (issue #140).
     /// Each tune's title rows are offset from their tune-relative `baselineY` values
     /// by the actual page y-origin at the moment they are placed.
-    public func layout(_ tuneBlocks: [TuneBlock]) -> ResolvedLayout {
+    ///
+    /// - Parameter firstPageNumber: what the document's opening page is called, from
+    ///   `%%ceolkit:pagenumber`.  Every page is stamped with the number it prints as it is
+    ///   closed, because a `%%newpage N` renumbers *and* breaks, and only the walk that
+    ///   decides where the pages fall can honour both at once.
+    public func layout(_ tuneBlocks: [TuneBlock], firstPageNumber: Int = 1) -> ResolvedLayout {
         var pages: [ResolvedPage] = []
         var pageSystems: [ResolvedSystem] = []
         var pageTitleRows: [ResolvedTitleRow] = []
         var y = config.margins.top
         var previousAbcLine: Int?
+        var pageNumber = firstPageNumber
+
+        /// Closes the page being built and opens an empty one below it.
+        func flushPage() {
+            pages.append(ResolvedPage(systems: pageSystems, titleRows: pageTitleRows,
+                                      pageNumber: pageNumber))
+            pageNumber += 1
+            pageSystems = []
+            pageTitleRows = []
+            y = config.margins.top
+        }
+
+        /// Applies whatever `%%newpage` stands in front of system `gi` of `block`.
+        ///
+        /// A break onto a page nothing has been drawn on yet is not a break: there is
+        /// nothing to move.  `%%newpage N` at the head of a document therefore renames the
+        /// page it already opens rather than leaving a blank one behind it — which is also
+        /// what makes it agree with `%%ceolkit:pagenumber` written in the same place.
+        func applyForcedBreak(before gi: Int, of block: TuneBlock) {
+            let landing = block.pageBreaks.filter { $0.beforeGroup == gi }
+            guard !landing.isEmpty else { return }
+            if !pageSystems.isEmpty || !pageTitleRows.isEmpty { flushPage() }
+            // Several can land on one system — one in the gap before a tune and another in
+            // its header — and the last number written wins, as it does for every directive.
+            if let restart = landing.compactMap(\.pageNumber).last { pageNumber = restart }
+        }
 
         for block in tuneBlocks {
             let groups = block.systemGroups
@@ -136,6 +168,10 @@ public struct VerticalLayoutEngine: Sendable {
             let systemGap   = tuneConfig.systemGap
             let tuneGap     = tuneConfig.tuneGap
 
+            // A `%%newpage` standing before the tune moves its title block too, so it is
+            // honoured ahead of everything else this block does.
+            applyForcedBreak(before: 0, of: block)
+
             // If the current page already has content, check whether the entire tune
             // fits in the remaining space. If not, close the current page. Tunes that
             // are taller than a full page are still forced to a fresh page here; the
@@ -143,10 +179,7 @@ public struct VerticalLayoutEngine: Sendable {
             if !pageSystems.isEmpty {
                 let tuneH = totalHeight(of: block, endingRuns: endingRuns)
                 if y + tuneH > config.pageSize.height - config.margins.bottom {
-                    pages.append(ResolvedPage(systems: pageSystems, titleRows: pageTitleRows))
-                    pageSystems = []
-                    pageTitleRows = []
-                    y = config.margins.top
+                    flushPage()
                 }
             }
 
@@ -164,13 +197,14 @@ public struct VerticalLayoutEngine: Sendable {
                 let metrics = groupMetrics(of: group, config: tuneConfig,
                                            endingRuns: endingRuns[gi])
 
+                // The tune's own breaks, resolved to the system each stands in front of.
+                // Group 0 was dealt with above, before the title block was placed.
+                if gi > 0 { applyForcedBreak(before: gi, of: block) }
+
                 // A group breaks to the next page whole: splitting it would separate staves
                 // that only mean anything read together.
                 if !pageSystems.isEmpty && y + metrics.totalHeight > config.pageSize.height - config.margins.bottom {
-                    pages.append(ResolvedPage(systems: pageSystems, titleRows: pageTitleRows))
-                    pageSystems = []
-                    pageTitleRows = []
-                    y = config.margins.top
+                    flushPage()
                 }
 
                 // Every staff in the group reports the group's line, so the anchor sequence
@@ -186,10 +220,14 @@ public struct VerticalLayoutEngine: Sendable {
                 let isLastInBlock = gi == groups.count - 1
                 y += metrics.totalHeight + (isLastInBlock ? tuneGap : systemGap)
             }
+
+            // A `%%newpage` written past the tune's last stave — at the foot of its body
+            // rather than in the gap below it — puts whatever follows on a fresh page.
+            if !groups.isEmpty { applyForcedBreak(before: groups.count, of: block) }
         }
 
         if !pageSystems.isEmpty || !pageTitleRows.isEmpty {
-            pages.append(ResolvedPage(systems: pageSystems, titleRows: pageTitleRows))
+            flushPage()
         }
 
         return ResolvedLayout(

--- a/Sources/ckprobe/Report.swift
+++ b/Sources/ckprobe/Report.swift
@@ -39,9 +39,19 @@ struct Report: Codable {
         let staves: [[String]]
     }
 
+    /// One `%%newpage` and the stave it breaks before, so that a body break's position can
+    /// be read off without re-deriving it from the source.
+    struct PageBreak: Codable {
+        let beforeStave: Int
+        let line: Int
+        /// The number the new page prints, or `nil` where the directive carried none.
+        let restartingAt: Int?
+    }
+
     struct Tune: Codable {
         let directives: [String]
         let staffPlans: [StaffPlanChange]
+        let pageBreaks: [PageBreak]
         let voices: [Voice]
     }
 
@@ -69,6 +79,10 @@ extension Report {
                         line: change.source.line,
                         staves: change.plan.layout.staves.map { $0.map(name) }
                     )
+                },
+                pageBreaks: tune.pageBreaks.map {
+                    PageBreak(beforeStave: $0.beforeStave, line: $0.source.line,
+                              restartingAt: $0.restartingAt)
                 },
                 voices: tune.voices.map { voice in
                     Voice(staves: voice.staves.map { stave in
@@ -106,6 +120,11 @@ extension Report {
                 let staves = plan.staves.map { $0.joined(separator: "+") }.joined(separator: " / ")
                 out.append("  tune[\(tuneIndex)] staffPlan from stave \(plan.effectiveFromStave)"
                            + " (line \(plan.line)): \(staves)")
+            }
+            for pageBreak in tune.pageBreaks {
+                let restart = pageBreak.restartingAt.map { ", renumbering from \($0)" } ?? ""
+                out.append("  tune[\(tuneIndex)] newpage before stave \(pageBreak.beforeStave)"
+                           + " (line \(pageBreak.line))\(restart)")
             }
             for (voiceIndex, voice) in tune.voices.enumerated() {
                 let counts = voice.staves.map(\.measureCount)

--- a/Tests/CeolKitParserTests/Extensions/NewPageDirectiveTests.swift
+++ b/Tests/CeolKitParserTests/Extensions/NewPageDirectiveTests.swift
@@ -1,0 +1,228 @@
+// Where a %%newpage takes effect (ABC v2.2 §11.4.7, issue #140).
+// Parser and model only — pagination itself is checked in the renderer's NewPageTests.
+import Testing
+import CeolKitModel
+import CeolKitParser
+
+@Suite("%%newpage position (#140)")
+struct NewPageDirectiveTests {
+
+    // MARK: - Helpers
+
+    private func breaks(_ abc: String, tune index: Int = 0) -> [PageBreak] {
+        let tunes = parse(abc).score.tunes
+        guard tunes.indices.contains(index) else { return [] }
+        return tunes[index].pageBreaks
+    }
+
+    private func diagnostics(_ abc: String, code: DiagnosticCode) -> [Diagnostic] {
+        parse(abc).score.diagnostics.filter { $0.code == code }
+    }
+
+    // MARK: - Nothing to report
+
+    @Test("A tune with no %%newpage asks for no break")
+    func noDirective() {
+        #expect(breaks("""
+        X:1
+        L:1/4
+        K:C
+        CDEF|
+        """).isEmpty)
+    }
+
+    @Test("%%newpage no longer reports itself as an unsupported directive")
+    func noLongerUnknown() {
+        let unknown = diagnostics("""
+        %%newpage
+        X:1
+        L:1/4
+        K:C
+        CDEF|
+        """, code: .unknownDirective)
+        #expect(unknown.isEmpty)
+    }
+
+    // MARK: - Where the break lands
+
+    @Test("A header %%newpage breaks before the tune's first stave")
+    func headerBreak() throws {
+        let found = breaks("""
+        X:1
+        %%newpage
+        L:1/4
+        K:C
+        CDEF|
+        """)
+        try #require(found.count == 1)
+        #expect(found[0].beforeStave == 0)
+        #expect(found[0].restartingAt == nil)
+    }
+
+    @Test("A body %%newpage breaks before the stave that follows it")
+    func bodyBreak() throws {
+        let found = breaks("""
+        X:1
+        L:1/4
+        K:C
+        CDEF|
+        GABc|
+        %%newpage
+        CDEF|
+        """)
+        try #require(found.count == 1)
+        #expect(found[0].beforeStave == 2)
+    }
+
+    @Test("A %%newpage below the last stave breaks past the end of the tune")
+    func trailingBreak() throws {
+        let found = breaks("""
+        X:1
+        L:1/4
+        K:C
+        CDEF|
+        %%newpage
+        """)
+        try #require(found.count == 1)
+        #expect(found[0].beforeStave == 1)
+    }
+
+    @Test("A %%newpage in the gap between two tunes belongs to the tune below it")
+    func gapBreakBelongsToTheFollowingTune() throws {
+        let abc = """
+        X:1
+        L:1/4
+        K:C
+        CDEF|
+
+        %%newpage
+        X:2
+        L:1/4
+        K:C
+        GABc|
+        """
+        #expect(breaks(abc, tune: 0).isEmpty)
+        let second = breaks(abc, tune: 1)
+        try #require(second.count == 1)
+        #expect(second[0].beforeStave == 0)
+    }
+
+    @Test("A %%newpage past the last tune is dropped, and says so")
+    func orphanBreak() throws {
+        let abc = """
+        X:1
+        L:1/4
+        K:C
+        CDEF|
+
+        %%newpage
+        """
+        #expect(breaks(abc).isEmpty)
+        #expect(diagnostics(abc, code: .pageBreakAfterLastTune).count == 1)
+    }
+
+    // MARK: - Snapping
+
+    @Test("A %%newpage part way through a stave snaps back to the start of it")
+    func snapsToStave() throws {
+        let abc = """
+        X:1
+        L:1/4
+        V:1
+        V:2
+        K:C
+        [V:1]CDEF|
+        %%newpage
+        [V:2]GABc|
+        [V:1]CDEF|
+        [V:2]GABc|
+        """
+        let found = breaks(abc)
+        try #require(found.count == 1)
+        #expect(found[0].beforeStave == 0)
+        #expect(diagnostics(abc, code: .pageBreakSnappedToStave).count == 1)
+    }
+
+    @Test("A %%newpage on a line-set boundary does not snap, and is not warned about")
+    func boundaryDoesNotSnap() throws {
+        let abc = """
+        X:1
+        L:1/4
+        V:1
+        V:2
+        K:C
+        [V:1]CDEF|
+        [V:2]GABc|
+        %%newpage
+        [V:1]CDEF|
+        [V:2]GABc|
+        """
+        let found = breaks(abc)
+        try #require(found.count == 1)
+        #expect(found[0].beforeStave == 1)
+        #expect(diagnostics(abc, code: .pageBreakSnappedToStave).isEmpty)
+    }
+
+    // MARK: - The optional page number
+
+    @Test("%%newpage N carries the number the new page prints")
+    func carriesNumber() throws {
+        let found = breaks("""
+        X:1
+        %%newpage 20
+        L:1/4
+        K:C
+        CDEF|
+        """)
+        try #require(found.count == 1)
+        #expect(found[0].restartingAt == 20)
+    }
+
+    @Test("An argument that is not a page number leaves the break standing")
+    func badArgumentKeepsTheBreak() throws {
+        // The author unmistakably asked for a page break; only the renumbering is in doubt.
+        let abc = """
+        X:1
+        %%newpage frog
+        L:1/4
+        K:C
+        CDEF|
+        """
+        let found = breaks(abc)
+        try #require(found.count == 1)
+        #expect(found[0].restartingAt == nil)
+        #expect(diagnostics(abc, code: .invalidPageNumber).count == 1)
+    }
+
+    @Test("Page numbers below 1 are refused the same way")
+    func zeroIsRefused() throws {
+        let abc = """
+        X:1
+        %%newpage 0
+        L:1/4
+        K:C
+        CDEF|
+        """
+        let found = breaks(abc)
+        try #require(found.count == 1)
+        #expect(found[0].restartingAt == nil)
+        #expect(diagnostics(abc, code: .invalidPageNumber).count == 1)
+    }
+
+    // MARK: - Not a flattened directive
+
+    @Test("A page break is not also stored as a CeolKitDirective")
+    func notInDirectives() {
+        // It has no meaning apart from where it falls, so the positional list is the only
+        // view of it — nothing downstream should find a last-wins scalar to read instead.
+        let tune = parse("""
+        %%newpage 4
+        X:1
+        L:1/4
+        K:C
+        CDEF|
+        """).score.firstTune
+        let directives = tune?.directives ?? []
+        #expect(directives.isEmpty)
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/NewPageTests.swift
+++ b/Tests/CeolKitSVGRendererTests/NewPageTests.swift
@@ -1,0 +1,212 @@
+//
+//  NewPageTests.swift
+//  CeolKitSVGRendererTests
+//
+//  %%newpage reaching the page it breaks — issue #140.
+//
+
+import CeolKitModel
+import CeolKitParser
+import Foundation
+import Testing
+@testable import CeolKitSVGRenderer
+
+private func parse(_ source: String) -> ParseResult {
+    CeolKitParser().parse(source, options: .default)
+}
+
+private func render(_ abc: String) throws -> [String] {
+    var config = SVGRenderConfig()
+    config.textRendering = .fontFace
+    return try SVGRenderer(config: config).render(parse(abc).score)
+}
+
+/// What each page's footer prints, which is where `$P` lands.
+private func footers(of abc: String) throws -> [String] {
+    try render(abc).map { page in
+        page.firstMatch(of: #/class="footer">([^<]*)</#).map { String($0.1) } ?? ""
+    }
+}
+
+/// The systems on each page, named by the source line each was engraved from.
+///
+/// Read back out of the `ceolkit-meta` scroll-sync comment, which carries one anchor per
+/// system: it is the only per-system marker in the document that survives outlining, and it
+/// says *which* music landed on the page as well as how much.
+private func systemLines(of abc: String) throws -> [[Int]] {
+    try render(abc).map { page in
+        page.matches(of: #/"abcLine": (\d+)/#).compactMap { Int($0.1) }
+    }
+}
+
+@Suite("%%newpage (#140)")
+struct NewPageTests {
+
+    /// Two short tunes that would otherwise sit on one page together.
+    private func twoTunes(_ between: String) -> String {
+        """
+        X:1
+        T:First
+        M:4/4
+        L:1/8
+        K:G
+        GABG|DEFD|
+        \(between)
+        X:2
+        T:Second
+        M:4/4
+        L:1/8
+        K:G
+        GABG|DEFD|
+        """
+    }
+
+    // MARK: - Where the break falls
+
+    @Test func withoutTheDirectiveTwoShortTunesShareAPage() throws {
+        #expect(try render(twoTunes("")).count == 1)
+    }
+
+    @Test func aBreakBetweenTwoTunesPutsTheSecondOnItsOwnPage() throws {
+        let pages = try render(twoTunes("\n%%newpage"))
+        try #require(pages.count == 2)
+        #expect(pages[0].contains(">First<"))
+        #expect(pages[1].contains(">Second<"))
+    }
+
+    @Test func aBreakInATunesHeaderMovesThatTune() throws {
+        let pages = try render("""
+        X:1
+        T:First
+        M:4/4
+        L:1/8
+        K:G
+        GABG|DEFD|
+
+        X:2
+        %%newpage
+        T:Second
+        M:4/4
+        L:1/8
+        K:G
+        GABG|DEFD|
+        """)
+        try #require(pages.count == 2)
+        #expect(pages[1].contains(">Second<"))
+    }
+
+    @Test func aBreakBelowTheLastStaveOfATuneMovesWhateverFollows() throws {
+        // Written at the foot of tune 1's body rather than in the gap below it.  There is
+        // nothing of tune 1 left to move, so what it moves is tune 2.
+        let pages = try render(twoTunes("%%newpage"))
+        try #require(pages.count == 2)
+        #expect(pages[1].contains(">Second<"))
+    }
+
+    @Test func aBreakInTheBodySplitsTheTuneWhereItIsWritten() throws {
+        let pages = try systemLines(of: """
+        X:1
+        T:Split
+        M:4/4
+        L:1/8
+        K:G
+        GABG|DEFD|
+        %%newpage
+        GABG|DEFD|
+        GABG|DEFD|
+        """)
+        try #require(pages.count == 2)
+        // The stave above the directive stays behind; the two below it move.
+        #expect(pages[0] == [6])
+        #expect(pages[1] == [8, 9])
+    }
+
+    @Test func aBreakAheadOfEveryTuneLeavesNoBlankPageBehindIt() throws {
+        // Nothing has been engraved yet, so there is nothing to break away from.
+        #expect(try render("%%newpage\n" + twoTunes("")).count == 1)
+    }
+
+    // MARK: - Page numbering
+
+    @Test func aPlainBreakLeavesTheCountAlone() throws {
+        #expect(try footers(of: "%%footer \"P=$P\"\n" + twoTunes("\n%%newpage"))
+                == ["P=1", "P=2"])
+    }
+
+    @Test func newPageNRenumbersFromThere() throws {
+        #expect(try footers(of: "%%footer \"P=$P\"\n" + twoTunes("\n%%newpage 20"))
+                == ["P=1", "P=20"])
+    }
+
+    @Test func numberingCarriesOnFromTheRestartedNumber() throws {
+        let printed = try footers(of: """
+        %%footer "P=$P"
+        X:1
+        T:A
+        M:4/4
+        L:1/8
+        K:G
+        GABG|
+
+        %%newpage 20
+        X:2
+        T:B
+        M:4/4
+        L:1/8
+        K:G
+        GABG|
+
+        %%newpage
+        X:3
+        T:C
+        M:4/4
+        L:1/8
+        K:G
+        GABG|
+        """)
+        #expect(printed == ["P=1", "P=20", "P=21"])
+    }
+
+    @Test func aBreakAheadOfEveryTuneStillSetsTheOpeningNumber() throws {
+        // No page to break, but `%%newpage 7` still says what the first one is called —
+        // which is where it meets %%ceolkit:pagenumber written in the same place (#138).
+        #expect(try footers(of: "%%newpage 7\n%%footer \"P=$P\"\n" + twoTunes(""))
+                == ["P=7"])
+    }
+
+    @Test func theScrollSyncMetadataAgreesWithTheFooter() throws {
+        let pages = try render("%%footer \"P=$P\"\n" + twoTunes("\n%%newpage 20"))
+        try #require(pages.count == 2)
+        #expect(pages[0].contains("\"page\": 1"))
+        #expect(pages[1].contains("\"page\": 20"))
+    }
+
+    @Test func aBreakCarriesTheNumberEvenWhereTheNumberedTuneCameFirst() throws {
+        // %%ceolkit:pagenumber sets the opening number and %%newpage moves on from it: the
+        // two compose rather than competing (EXTENSIONS.md, "Interaction with %%newpage").
+        #expect(try footers(of: "%%ceolkit:pagenumber 3\n%%footer \"P=$P\"\n"
+                                + twoTunes("\n%%newpage"))
+                == ["P=3", "P=4"])
+    }
+
+    // MARK: - Resolving staves to systems
+
+    @Test func aBreakOnAStaveTheLayoutSplitLandsOnTheFirstOfItsSystems() throws {
+        // The stave after the break is too wide for one line, so the packer makes several
+        // systems out of it.  The break belongs in front of the first of them.
+        let bars = Array(repeating: "GABG|", count: 12).joined()
+        let pages = try systemLines(of: """
+        X:1
+        T:Wide
+        M:4/4
+        L:1/8
+        K:G
+        GABG|
+        %%newpage
+        \(bars)
+        """)
+        try #require(pages.count == 2)
+        #expect(pages[0] == [6])
+        #expect(pages[1].count > 1)
+    }
+}


### PR DESCRIPTION
Closes #140.

`%%newpage` is listed in ABC v2.2 §11.4.7 and implemented by both abcm2ps and abc2svg, so it lands under its established **unprefixed** name rather than as `%%ceolkit:newpage` — §11.0.2 asks implementers to protect portability, and a file that page-breaks in abcm2ps should not need editing to page-break here.

## Where it may be written

It is the second directive whose *position* is part of what it means (the other is `%%score`), so it is modelled the way that one is: a positional `PageBreak` on `Tune`, counted in staves, and deliberately **not** also a flattened `CeolKitDirective` — a page break has no meaning apart from where it falls.

| Written in | Breaks before |
| --- | --- |
| the file header | the first tune — which prints no break, since nothing has been engraved yet |
| the gap between two tunes | the tune below it |
| a tune header | that tune |
| the tune body | the stave it stands above |
| below a tune's last stave | whatever follows the tune |

A break written part-way through a stave snaps back to the start of it with a `pageBreakSnappedToStave` warning, on the same reasoning as a staff plan: a page break is a system break, and the staves of a system are laid out together. One past the last tune has nothing left to move and is dropped with `pageBreakAfterLastTune`.

## Numbering

`%%newpage N` renumbers the page it opens, and the count carries on from there. That made pagination and numbering one problem rather than two: `VerticalLayoutEngine` now stamps each page as it decides where the page falls (`ResolvedPage.pageNumber`), because only the walk that breaks the pages can honour a directive that breaks and renames at once. The footer, `$P`, `${pagenumber}` and the `ceolkit-meta` scroll-sync comment all read that stamp, so they cannot disagree.

`%%ceolkit:pagenumber` (#138) composes with it rather than competing: it names the document's opening page, and each `%%newpage N` renames the one it opens.

```abc
%%ceolkit:pagenumber 3
%%footer "$P"
X:1
…

%%newpage 20
X:2
…
```

prints 3, then 20, then 21.

## Recovery

An argument that is not a page number (`%%newpage frog`, `%%newpage 0`) warns with `invalidPageNumber` and **the break still happens**. The argument is optional, so a bad one is a mistyped option on a directive that is otherwise perfectly clear; refusing to break the page would lose the part the author got right.

## Docs and tooling

- CONFORMANCE.md gains a `§11.4.7 Page breaks — %%newpage` section.
- EXTENSIONS.md's "Interaction with `%%newpage`" loses its *Not yet implemented* block — it has been describing two directives, one broken and one absent, since #138 was filed. It now carries a worked example instead.
- `ckprobe` reports a tune's page breaks alongside its staff plans, in both the text and JSON output.

## Testing

26 new tests — `NewPageDirectiveTests` (parser: position, snapping, the optional number, the orphan case) and `NewPageTests` (renderer: pagination, numbering, and a break landing on a stave the packer split across several systems). Full suite: 1212 tests, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jcPEbVn1io17Pn2p274Fa