### PR TITLE
Release 1.4.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,30 @@ public enum Dialect {
 ```
 Dialect is fixed after stage 2 (from the version line / `I:abc-version`), except individual tunes may override it. It controls whether legacy syntax produces warnings vs. errors.
 
+## Release process
+
+Work lands on `develop`; `main` is the release branch and carries the tags. A release is
+five steps, and **the last one is not optional**:
+
+1. Verify `develop`: clean tree, `swift build`, `swift test`, CI green on the tip.
+2. Open a PR `develop` → `main` titled `Release X.Y.Z`, and merge it with a **merge commit**
+   (not squash, not rebase — the tags and the merge-back both depend on the shared history).
+3. Tag `main`: `git tag -a vX.Y.Z -m "Release X.Y.Z"` and push the tag.
+4. `gh release create vX.Y.Z --title "X.Y[.Z]" --notes-file <notes> --verify-tag`, then
+   append the generated PR list (`gh api -X POST repos/sbeitzel/CeolKit/releases/generate-notes
+   -f tag_name=vX.Y.Z -f previous_tag_name=<prev>`) above the `## Upgrading` section.
+5. **Merge `main` back into `develop` and push.** The release merge commit exists only on
+   `main`, so without this `develop` falls behind, and branch protection then refuses the
+   *next* release PR as "head branch is not up to date". Skipping it is what makes step 2
+   fail later, not now.
+
+Two notes on the mechanics:
+
+- Issues fixed on `develop` stay **open** until step 2 — GitHub only auto-closes
+  `Fix #NN` references when they reach the default branch. Do not close them by hand.
+- Version numbers live only in the git tag and the GitHub release. Nothing in `Package.swift`
+  or the sources needs editing.
+
 ## Open Questions (from spec §10)
 
 1. File-global directive bag shape on `Score` — flat array vs. dedicated `FilePreamble` struct

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -146,6 +146,62 @@ it belongs to its voice and goes wherever that voice goes.
 
 ---
 
+## §11.4.7 Page breaks — `%%newpage`
+
+**Syntax:** `%%newpage [<int>]` — start a new page, optionally renumbering it from `<int>`.
+
+§11.4.7 lists `%%newpage` among the separation directives and §11.6 leaves the parameters to
+the implementation; `abcm2ps` and `abc2svg` both answer to it, and CeolKit uses their
+spelling — unprefixed, and with the same optional integer. §11.0.1 asks that a directive
+implemented in more than one program converge rather than fork, and a file that page-breaks
+correctly in `abcm2ps` should not need editing to page-break here.
+
+### Where it may be written
+
+| Written in | Breaks before |
+| --- | --- |
+| the file header | the first tune — which prints no break, since nothing has been engraved yet |
+| the gap between two tunes | the tune below it |
+| a tune header | that tune |
+| the tune body | the stave it stands above |
+| below a tune's last stave | whatever follows the tune |
+
+Like a staff plan, a break in the body takes effect from the start of the **stave** (one
+source line of music) it is written in, and one written part-way through a stave — between
+the voices of a multi-voice system, say — snaps back to the start of it with a
+`pageBreakSnappedToStave` warning. A page break is a system break, and the staves of a
+system are laid out together, so it cannot fall part-way through one.
+
+A `%%newpage` past the last tune in the file has nothing left to move onto a fresh page. It
+is dropped, with a `pageBreakAfterLastTune` info diagnostic, rather than leaving a blank
+page behind it — and for the same reason one at the very top of a file breaks nothing: an
+empty page is not something to break away from.
+
+### The optional page number
+
+`%%newpage N` renumbers the page it opens to `N`, and the count carries on from there, so
+the page after a `%%newpage 20` is 21. `N` must be an integer of 1 or more.
+
+An argument that is not one — `%%newpage frog`, `%%newpage 0` — produces an
+`invalidPageNumber` warning and **the page break still happens**; only the renumbering is
+dropped. The argument is optional, so a bad one is a mistyped option on a directive that is
+otherwise perfectly clear, and refusing to break the page would lose the part the author got
+right.
+
+The number reaches the `$P` and `${pagenumber}` footer substitutions and the `page` field of
+the `ceolkit-meta` scroll-sync comment, exactly as
+[`%%ceolkit:pagenumber`](EXTENSIONS.md#ceolkitpagenumber) does. The two compose: that
+directive names the document's opening page, and each `%%newpage N` renames the one it
+opens.
+
+### What CeolKit does not do
+
+`%%newpage` is the only one of §11.4.7's separation directives CeolKit implements. `%%sep`
+and `%%vskip` are still reported as unsupported and ignored, which is what §11.0.2 asks of a
+directive an application does not recognise.
+
+---
+
 ## Worked examples in the test suite
 
 The standard's own multi-voice examples are checked in end to end, parser and renderer, so

--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -235,7 +235,23 @@ T:Continued
 ...
 ```
 
+### Where it is read
+
+The last statement of the directive wins, and only the **file preamble and the first
+tune's header** are read. The number is set *before any output has been produced*, so
+that is the only place it can mean anything; a copy in a later tune's header would be
+asking to renumber pages already engraved, and is ignored.
+
+The number reaches both the `$P` and `${pagenumber}` substitutions in the footer and
+the `page` field of the `ceolkit-meta` scroll-sync comment, so a consumer pairing a
+rendered page with what the reader sees on paper agrees with the printed footer.
+
 ### Interaction with `%%newpage`
+
+> **Not yet implemented.** `%%newpage` is not supported — it reports
+> `info: Unsupported stylesheet directive '%%newpage'` and no page break occurs. It is
+> requested as [#140](https://github.com/sbeitzel/CeolKit/issues/140); this section
+> describes what the two directives will mean together once it lands.
 
 `%%newpage N` also sets the page number as a side-effect of forcing a page
 break. `%%ceolkit:pagenumber N` sets the page number *without* starting a new page,

--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -196,6 +196,14 @@ Page number substitution in headers and footers uses the `$P` placeholder
 (current page) and `$Q` placeholder (non-resetting page counter). Only `$P`
 is affected by `%%ceolkit:pagenumber`; `$Q` always starts at 1 and is never reset.
 
+This directive fixes the number **at authoring time**, which is what a multi-file
+*score* needs — the file that continues a piece knows where the previous file
+stopped. It cannot help a multi-file *compilation*: a tune assembled into a binder
+alongside others sits at a different offset in every binder it appears in, and the
+offsets shift whenever any of the tunes before it gains or loses a page. For that,
+mark the span and let the tool building the binder fill it in — see
+[Consumer-substitutable footer spans](#consumer-substitutable-footer-spans).
+
 ### Examples
 
 #### Start numbering from page 3
@@ -233,6 +241,127 @@ T:Continued
 break. `%%ceolkit:pagenumber N` sets the page number *without* starting a new page,
 so it is only meaningful before any output has been produced (i.e., in the
 file preamble or at the very start of a tune header).
+
+---
+
+## Consumer-substitutable footer spans
+
+**Syntax:** `${<name>}` inside a `%%footer` template
+
+**Scope:** the footer template it is written in
+
+### Description
+
+`${name}` marks a span of the footer as *substitutable*: CeolKit still lays out and
+draws its own value there, but the renderer emits that span as one findable,
+self-describing SVG element instead of as loose text or loose glyphs, so a downstream
+tool can replace it.
+
+This exists because outlining is a one-way door. Under the default
+`TextRendering.outlines` a footer reading `Page 1` leaves the renderer as six `<use>`
+elements and no text anywhere in the document — there is nothing left for a
+post-processor to rewrite, and only CeolKit still has the font, the metrics and the
+layout needed to draw a different string in that spot. The mark is how an author says
+in the ABC source that a particular span is somebody else's to fill in.
+
+The motivating case is a binder: a server renders each tune's `.abc` on its own and
+concatenates the pages, so page 1 of the third tune has to print `17`. No value of
+[`%%ceolkit:pagenumber`](#ceolkitpagenumber) is right for that, because the offset is
+not knowable when the ABC is written.
+
+`${…}` is a CeolKit extension. It is not part of the ABC v2.2 header/footer
+substitution set, and it is understood only in `%%footer`.
+
+### What is emitted
+
+Each marked span becomes a group wrapping CeolKit's own rendering of the default value:
+
+```xml
+<g id="ceolkit-tag-pagenumber" class="ceolkit-tag" data-ceolkit-tag="pagenumber"
+   data-x="306" data-y="753.048" data-font-size="12"
+   data-font-family="Libertinus Serif" data-text-anchor="middle">
+  <!-- CeolKit's own rendering of the default value: outlined or <text>, per mode -->
+</g>
+```
+
+The `data-*` attributes are the contract; the group's contents are CeolKit's. A
+consumer substitutes by emptying the group and drawing its own text at the advertised
+anchor — position, size and anchor are what a stamping API needs, not the face.
+
+Three properties follow, and all three are deliberate:
+
+- **It carries its own default.** A standalone render is unchanged and correct, and a
+  consumer that ignores the group gets exactly the output it always got.
+- **It is mode-independent.** `.outlines`, `.fontFace` and `.both` all wrap the same
+  way, so a consumer never has to care which mode produced the file — and `.outlines`
+  stays the default, with no hole in the guarantee it exists to give.
+- **`id` is unique, `data-ceolkit-tag` is not.** Nothing stops a template from marking
+  one name twice; the first gets `ceolkit-tag-<name>` and later ones are suffixed
+  `-2`, `-3`, … . `data-ceolkit-tag` carries the name unchanged on every one, so a
+  consumer keying off that finds them all.
+
+### Names
+
+A name is a letter followed by letters, digits, `_`, `.` or `-`. Anything else —
+`${1st}`, an unclosed `${`, a bare `${}` — is not a mark and is engraved literally,
+which is what an author who did not mean a mark expects to see.
+
+Four names carry a value CeolKit knows:
+
+| Name | Default value |
+|------|---------------|
+| `${pagenumber}` | the current page number — the same value as `$P` |
+| `${pagecount}` | the number of pages in this render |
+| `${title}` | the first tune's title — the same value as `$T` |
+| `${date}` | the render date, formatted by `%%dateformat` — the same value as `$D` |
+
+Any other name is a mark CeolKit has no value for. It draws nothing and emits an
+empty group at the right spot, which is exactly what a consumer that means to stamp
+its own text there wants: a binder name or a section title is not CeolKit's to invent.
+
+### Layout and overflow
+
+A substituted string is usually a different width from the default (`9` becomes
+`117`). CeolKit reserves the width of its own default and advertises the anchor;
+the consumer owns the overflow. Two rules make that workable:
+
+- A column that is **nothing but the mark** keeps that column's own anchor, so a wider
+  replacement grows the way the column does — leftwards from the right margin,
+  outwards from the centre — and stays on the page.
+- A mark **mixed with other text** is placed after the text it follows, at
+  `text-anchor="start"`. A longer replacement then overflows to the right of the mark,
+  over whatever follows it in that column.
+
+So for a page number that a consumer will rewrite, give it a column of its own.
+
+### Examples
+
+#### A page number a binder compiler fills in
+
+```abc
+%%footer "$T\t\t${pagenumber}"
+X:1
+T:My Tune
+M:4/4
+L:1/8
+K:G
+GABG|DEFD|GABG|D4|
+```
+
+The rendered page reads `My Tune` at the left margin and `1` at the right. The `1`
+sits inside `<g id="ceolkit-tag-pagenumber" … data-text-anchor="end">`, so a binder
+compiler replaces it with `17` — right-aligned at the same margin — without knowing
+anything about the font.
+
+#### A name CeolKit has no value for
+
+```abc
+%%footer "${bindername}\t$T\t${pagenumber}"
+```
+
+The centre column engraves the tune title as usual. The left column is an empty group
+at the left margin waiting for the compiler's binder name, and the right column is the
+page number as above.
 
 ---
 

--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -192,9 +192,9 @@ The value must be a positive integer (≥ 1). If the argument is missing, zero,
 negative, or non-numeric, an error message is emitted and the directive is
 ignored.
 
-Page number substitution in headers and footers uses the `$P` placeholder
-(current page) and `$Q` placeholder (non-resetting page counter). Only `$P`
-is affected by `%%ceolkit:pagenumber`; `$Q` always starts at 1 and is never reset.
+Page number substitution in the footer uses the `$P` placeholder, which is the token
+this directive sets. It is one of four — see
+[`%%footer` placeholders](#footer-placeholders).
 
 This directive fixes the number **at authoring time**, which is what a multi-file
 *score* needs — the file that continues a piece knows where the previous file
@@ -257,6 +257,45 @@ rendered page with what the reader sees on paper agrees with the printed footer.
 break. `%%ceolkit:pagenumber N` sets the page number *without* starting a new page,
 so it is only meaningful before any output has been produced (i.e., in the
 file preamble or at the very start of a tune header).
+
+---
+
+## `%%footer` placeholders
+
+**Syntax:** `$<letter>` inside a `%%footer` template
+
+**Scope:** the footer template it is written in
+
+### Description
+
+CeolKit substitutes exactly four `$` placeholders:
+
+| Placeholder | Value |
+|-------------|-------|
+| `$P` | the current page number, as set by [`%%ceolkit:pagenumber`](#ceolkitpagenumber) |
+| `$T` | the first tune's title |
+| `$D` | the render date, formatted by `%%dateformat` |
+| `$d` | the same as `$D` |
+
+That set is deliberately narrower than abcm2ps's, which also defines `$F`, `$I<x>`,
+`$V`, `$P0` and `$P1`. None of those are implemented here, and neither is anything
+outside the table above.
+
+### Anything else is engraved literally, and diagnosed
+
+A `$` followed by any other letter is not a placeholder. It stays in the literal text
+and is engraved as written — under the default `TextRendering.outlines` as artwork, with
+nothing downstream able to tell what was meant — so the parser emits a warning for each
+distinct one:
+
+```
+warning: '$X' is not a footer placeholder; it will be engraved literally
+```
+
+That covers both an abcm2ps placeholder CeolKit does not implement and a typo such as
+`$p`. Two things are *not* diagnosed, because neither is a token: a `$` not followed by
+a letter (`$5`, a trailing `$`) is ordinary text, and `${name}` is a
+[consumer-substitutable span](#consumer-substitutable-footer-spans).
 
 ---
 

--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -248,15 +248,28 @@ rendered page with what the reader sees on paper agrees with the printed footer.
 
 ### Interaction with `%%newpage`
 
-> **Not yet implemented.** `%%newpage` is not supported — it reports
-> `info: Unsupported stylesheet directive '%%newpage'` and no page break occurs. It is
-> requested as [#140](https://github.com/sbeitzel/CeolKit/issues/140); this section
-> describes what the two directives will mean together once it lands.
+`%%newpage N` also sets the page number, as a side-effect of forcing a page break —
+see [CONFORMANCE.md → `%%newpage`](CONFORMANCE.md#1147-page-breaks--newpage).
+`%%ceolkit:pagenumber N` sets the page number *without* starting a new page, so it is
+only meaningful before any output has been produced (i.e., in the file preamble or at
+the very start of a tune header).
 
-`%%newpage N` also sets the page number as a side-effect of forcing a page
-break. `%%ceolkit:pagenumber N` sets the page number *without* starting a new page,
-so it is only meaningful before any output has been produced (i.e., in the
-file preamble or at the very start of a tune header).
+The two compose rather than competing: `%%ceolkit:pagenumber` names the opening page and
+each `%%newpage N` renames the one it opens, with the count carrying on from there.
+
+```abc
+%%ceolkit:pagenumber 3
+%%footer "$P"
+X:1
+...
+
+%%newpage 20
+X:2
+...
+```
+
+Page 1 of the output prints "3"; the page tune 2 starts on prints "20", and the page after
+that "21".
 
 ---
 

--- a/Sources/CeolKitModel/Diagnostic.swift
+++ b/Sources/CeolKitModel/Diagnostic.swift
@@ -80,6 +80,13 @@ public enum DiagnosticCode: String, Codable, Sendable {
     /// change without splitting the system.  It takes effect from the start of the stave
     /// enclosing it instead — see `StaffPlanChange`.
     case staffPlanSnappedToStave
+    /// A `%%newpage` was written part-way through a stave, where a page cannot break without
+    /// splitting the system.  It takes effect from the start of the stave enclosing it
+    /// instead — see `PageBreak`.
+    case pageBreakSnappedToStave
+    /// A `%%newpage` stands after the last tune in the file, so there is nothing left for it
+    /// to move onto a fresh page.  It is dropped.
+    case pageBreakAfterLastTune
     /// A `%%score` / `%%staves` names a voice the tune does not declare anywhere.  The rest
     /// of the plan is honoured.
     case staffPlanVoiceNotFound

--- a/Sources/CeolKitModel/Diagnostic.swift
+++ b/Sources/CeolKitModel/Diagnostic.swift
@@ -68,6 +68,11 @@ public enum DiagnosticCode: String, Codable, Sendable {
     // Directives
     case unknownDirective
     case redundantDirective
+    /// A `%%footer` template contains a `$`-token CeolKit does not substitute — an
+    /// abcm2ps placeholder that is not implemented here, or a typo such as `$p`.  The
+    /// characters are engraved literally, and under the default outline mode they are
+    /// engraved as artwork, so nothing downstream can tell what was meant.
+    case unknownFooterPlaceholder
     /// A `%%score` / `%%staves` payload did not parse (ABC v2.2 §11.1).  The whole
     /// directive is dropped rather than stored as a partial tree.
     case invalidStaffPlan

--- a/Sources/CeolKitModel/PageBreak.swift
+++ b/Sources/CeolKitModel/PageBreak.swift
@@ -1,0 +1,43 @@
+//
+//  PageBreak.swift
+//  CeolKit
+//
+//  Created by Stephen Beitzel on 9/3/26.
+//
+
+import Foundation
+
+/// A `%%newpage` and the point in the tune it breaks before (ABC v2.2 §11.4.7, issue #140).
+///
+/// `%%newpage` is one of the two directives whose *position* is part of what it means — the
+/// other is `%%score` (see ``StaffPlanChange``).  Every other directive CeolKit implements
+/// flattens to a last-wins scalar for the whole tune; this one says "the music from here on
+/// starts a fresh page", which is a statement about a place.
+///
+/// The unit is the **stave** — one source line of music, the same unit ``Voice/staves`` is
+/// indexed in — because a page break is a system break, and the staves of a system are laid
+/// out together.  A break written part-way through a stave is snapped back to the start of
+/// the stave enclosing it, with a ``DiagnosticCode/pageBreakSnappedToStave`` diagnostic
+/// saying so, on the same reasoning as a staff plan: the music after the directive is what
+/// the author wanted moved, and moving the whole stave moves all of it.
+public struct PageBreak: Hashable, Sendable {
+    /// Index of the stave this break falls *before*, counted from zero at the start of the
+    /// tune body.  A break written before any of the tune's music — in the file preamble
+    /// ahead of it, or in its header — is 0, and one written after all of it is the tune's
+    /// stave count, which puts the break between this tune and the next.
+    public let beforeStave: Int
+
+    /// The number the new page prints, from `%%newpage N`, or `nil` for a plain `%%newpage`
+    /// that leaves the count alone.  Numbering carries on from here, so the page after a
+    /// `%%newpage 20` is 21.
+    public let restartingAt: Int?
+
+    /// Where the directive was written, which is not where it takes effect once it snaps.
+    public let source: SourceRange
+
+    public init(beforeStave: Int, restartingAt: Int?, source: SourceRange) {
+        self.beforeStave = beforeStave
+        self.restartingAt = restartingAt
+        self.source = source
+    }
+}

--- a/Sources/CeolKitModel/Tune.swift
+++ b/Sources/CeolKitModel/Tune.swift
@@ -29,6 +29,14 @@ public struct Tune: Sendable {
     /// plan both govern from stave 0 — and the later one wins, as it does for every other
     /// directive.
     public let staffPlans: [StaffPlanChange]
+    /// Every `%%newpage` that reaches this tune, in source order, each paired with the stave
+    /// it breaks before — see ``PageBreak``.  Empty when the tune asks for no page break,
+    /// which is almost every tune.
+    ///
+    /// Unlike ``directives``, these are not also stored as ``CeolKitDirective`` values: a
+    /// page break has no meaning apart from where it falls, so the positional view is the
+    /// only one.
+    public let pageBreaks: [PageBreak]
     public let source: SourceRange
 
     public init(
@@ -45,6 +53,7 @@ public struct Tune: Sendable {
         macros: [MacroDefinition],
         directives: [CeolKitDirectiveScope],
         staffPlans: [StaffPlanChange] = [],
+        pageBreaks: [PageBreak] = [],
         source: SourceRange
     ) {
         self.reference = reference
@@ -60,6 +69,7 @@ public struct Tune: Sendable {
         self.macros = macros
         self.directives = directives
         self.staffPlans = staffPlans
+        self.pageBreaks = pageBreaks
         self.source = source
     }
 

--- a/Sources/CeolKitParser/Semantic/BodyContext.swift
+++ b/Sources/CeolKitParser/Semantic/BodyContext.swift
@@ -672,6 +672,9 @@ struct BodyContext {
     /// `%%score` / `%%staves` met in the body, in source order, each already carrying the
     /// stave it governs from.
     var bodyStaffPlans: [StaffPlanChange] = []
+    /// `%%newpage` met in the body, in source order, each already carrying the stave it
+    /// breaks before.
+    var bodyPageBreaks: [PageBreak] = []
     var hasExplicitVoice: Bool = false
     /// The `&` that opened each temporary voice (§7.4).  Its presence is also what says a
     /// layer exists at all: the states themselves live in `voices`, keyed by `VoiceKey`.

--- a/Sources/CeolKitParser/Semantic/SemanticPass.swift
+++ b/Sources/CeolKitParser/Semantic/SemanticPass.swift
@@ -14,6 +14,11 @@ struct SemanticPass {
         // filePreamble contains both the initial preamble and any inter-tune gaps (lines between
         // tunes that fall outside any tune header), so scanning it here covers both.
         var preambleCeolKitDirectives: [CeolKitDirectiveScope] = []
+        // `%%newpage` met outside any tune, in source order.  Unlike everything else in the
+        // preamble these are *not* promoted to the first tune: a break written in the gap
+        // between two tunes belongs to the one that follows it, so each is matched to its
+        // tune by source line in the walk below.
+        var preambleBreaks: [PageBreak] = []
         var currentFooter: String? = nil
         for line in file.filePreamble {
             if case .directive(let name, let payload, let src) = line {
@@ -21,6 +26,11 @@ struct SemanticPass {
                     let footer = stripQuotes(payload.trimmingCharacters(in: .whitespaces))
                     diagnoseFooterPlaceholders(footer, source: src, into: &diagnostics)
                     currentFooter = footer
+                } else if name == "newpage" {
+                    preambleBreaks.append(PageBreak(
+                        beforeStave: 0,
+                        restartingAt: parseNewPage(payload, source: src, diagnostics: &diagnostics),
+                        source: src))
                 } else if isCeolKitDirective(name) || isStandardDirective(name) {
                     var tempDiags: [Diagnostic] = []
                     if let d = parseCeolKitDirective(name: name, payload: payload, source: src, diagnostics: &tempDiags) {
@@ -52,6 +62,7 @@ struct SemanticPass {
         let fileSource = file.tunes.first?.source ?? .emptySourceRange
 
         var tunes: [Tune] = []
+        var previousTuneLine = Int.min
         for (idx, abcTune) in file.tunes.enumerated() {
             // Update footer from tune header directives (last-wins across document).
             for (name, payload, src) in abcTune.headerDirectives where name == "footer" {
@@ -59,9 +70,17 @@ struct SemanticPass {
                 diagnoseFooterPlaceholders(footer, source: src, into: &diagnostics)
                 currentFooter = footer
             }
+            // The preamble breaks standing between the previous tune and this one: they move
+            // *this* tune onto a fresh page, so they are its own, at stave 0.
+            let tuneLine = abcTune.source.line
+            let ownedBreaks = preambleBreaks.filter {
+                $0.source.line > previousTuneLine && $0.source.line < tuneLine
+            }
+            previousTuneLine = tuneLine
             let (tune, tuneDiags) = buildTune(abcTune, dialect: dialect)
             diagnostics += tuneDiags
-            if idx == 0 && !preambleCeolKitDirectives.isEmpty {
+            let extraDirectives = idx == 0 ? preambleCeolKitDirectives : []
+            if !extraDirectives.isEmpty || !ownedBreaks.isEmpty {
                 tunes.append(Tune(
                     reference: tune.reference,
                     titles: tune.titles,
@@ -74,13 +93,23 @@ struct SemanticPass {
                     voices: tune.voices,
                     userSymbols: tune.userSymbols,
                     macros: tune.macros,
-                    directives: preambleCeolKitDirectives + tune.directives,
-                    staffPlans: initialStaffPlans(from: preambleCeolKitDirectives) + tune.staffPlans,
+                    directives: extraDirectives + tune.directives,
+                    staffPlans: initialStaffPlans(from: extraDirectives) + tune.staffPlans,
+                    pageBreaks: ownedBreaks + tune.pageBreaks,
                     source: tune.source
                 ))
             } else {
                 tunes.append(tune)
             }
+        }
+
+        // A `%%newpage` past the last tune has nothing left to move onto a fresh page.
+        for orphan in preambleBreaks where orphan.source.line > previousTuneLine {
+            diagnostics.append(Diagnostic(
+                severity: .info, code: .pageBreakAfterLastTune,
+                message: "%%newpage after the last tune has nothing to break before; ignored",
+                source: orphan.source
+            ))
         }
 
         // Redundancy: %%flatbeams true is implied by %%ceolkit:pipeformat true.
@@ -140,7 +169,28 @@ struct SemanticPass {
         name == "landscape" || name == "flatbeams" || name == "writefields"
             || name == "dateformat" || name == "footer"
             || name == "straightflags" || name == "graceslurs"
-            || name == "score" || name == "staves"
+            || name == "score" || name == "staves" || name == "newpage"
+    }
+
+    /// The argument of a `%%newpage` (ABC v2.2 §11.4.7, issue #140): the number the new page
+    /// is to print, or `nil` for the bare directive, which leaves the count alone.
+    ///
+    /// The argument is optional, so a payload that does not parse is a bad *option* on a
+    /// directive that is otherwise perfectly clear.  The break is kept and only the
+    /// renumbering dropped — the author unmistakably asked for a page break, and refusing to
+    /// draw one because the number beside it was mistyped would lose the part they got right.
+    private func parseNewPage(_ payload: String, source: SourceRange,
+                              diagnostics: inout [Diagnostic]) -> Int? {
+        let trimmed = payload.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return nil }
+        if let n = Int(trimmed), n >= 1 { return n }
+        diagnostics.append(Diagnostic(
+            severity: .warning, code: .invalidPageNumber,
+            message: "%%newpage expects no argument or an integer ≥ 1 (got '\(trimmed)'); "
+                   + "the page break stands and the numbering is left alone",
+            source: source
+        ))
+        return nil
     }
 
     // MARK: - Tune builder
@@ -165,6 +215,16 @@ struct SemanticPass {
 
         // Process header directives (%%ceolkit:* etc.)
         let tuneDirectives = processDirectives(abcTune.headerDirectives, scope: .tuneGlobal, diagnostics: &diagnostics)
+
+        // A `%%newpage` in the header breaks before the tune's first stave — the whole tune
+        // starts a fresh page.
+        var headerBreaks: [PageBreak] = []
+        for (name, payload, src) in abcTune.headerDirectives where name == "newpage" {
+            headerBreaks.append(PageBreak(
+                beforeStave: 0,
+                restartingAt: parseNewPage(payload, source: src, diagnostics: &diagnostics),
+                source: src))
+        }
 
         // Resolve unitNoteLength from meter if not explicit
         if ctx.unitNoteLength == nil {
@@ -222,6 +282,7 @@ struct SemanticPass {
             macros: ctx.macros,
             directives: tuneDirectives + bodyCtx.bodyTuneDirectives,
             staffPlans: initialStaffPlans(from: tuneDirectives) + bodyCtx.bodyStaffPlans,
+            pageBreaks: headerBreaks + bodyCtx.bodyPageBreaks,
             source: abcTune.source
         )
         return (tune, diagnostics)
@@ -842,6 +903,21 @@ struct SemanticPass {
                 }
             }
             diagnostics += tempDiags
+        case "newpage":
+            // §11.4.7: the music from here on starts a fresh page.  Like a staff plan, and
+            // for the same reason — the staves of a system are laid out together — a break
+            // written part-way through one snaps back to the start of the stave enclosing it.
+            if ctx.hasStaveInProgress {
+                diagnostics.append(Diagnostic(
+                    severity: .warning, code: .pageBreakSnappedToStave,
+                    message: "%%newpage inside a stave takes effect from the start of that stave",
+                    source: source
+                ))
+            }
+            ctx.bodyPageBreaks.append(PageBreak(
+                beforeStave: ctx.currentStaveIndex,
+                restartingAt: parseNewPage(payload, source: source, diagnostics: &diagnostics),
+                source: source))
         case "landscape", "flatbeams", "ceolkit:justifylast", "ceolkit:scale",
              "ceolkit:gracenotespacing", "writefields",
              "dateformat", "footer", "straightflags", "graceslurs":

--- a/Sources/CeolKitParser/Semantic/SemanticPass.swift
+++ b/Sources/CeolKitParser/Semantic/SemanticPass.swift
@@ -18,7 +18,9 @@ struct SemanticPass {
         for line in file.filePreamble {
             if case .directive(let name, let payload, let src) = line {
                 if name == "footer" {
-                    currentFooter = stripQuotes(payload.trimmingCharacters(in: .whitespaces))
+                    let footer = stripQuotes(payload.trimmingCharacters(in: .whitespaces))
+                    diagnoseFooterPlaceholders(footer, source: src, into: &diagnostics)
+                    currentFooter = footer
                 } else if isCeolKitDirective(name) || isStandardDirective(name) {
                     var tempDiags: [Diagnostic] = []
                     if let d = parseCeolKitDirective(name: name, payload: payload, source: src, diagnostics: &tempDiags) {
@@ -52,8 +54,10 @@ struct SemanticPass {
         var tunes: [Tune] = []
         for (idx, abcTune) in file.tunes.enumerated() {
             // Update footer from tune header directives (last-wins across document).
-            for (name, payload, _) in abcTune.headerDirectives where name == "footer" {
-                currentFooter = stripQuotes(payload.trimmingCharacters(in: .whitespaces))
+            for (name, payload, src) in abcTune.headerDirectives where name == "footer" {
+                let footer = stripQuotes(payload.trimmingCharacters(in: .whitespaces))
+                diagnoseFooterPlaceholders(footer, source: src, into: &diagnostics)
+                currentFooter = footer
             }
             let (tune, tuneDiags) = buildTune(abcTune, dialect: dialect)
             diagnostics += tuneDiags
@@ -1193,6 +1197,38 @@ struct SemanticPass {
             return nil
         default:
             return nil
+        }
+    }
+
+    /// The `$`-tokens a `%%footer` template may use.  `$d` is a second spelling of `$D`.
+    private static let footerPlaceholders: Set<Character> = ["P", "T", "D", "d"]
+
+    /// Warns about every other `$`-token in a `%%footer` template (issue #141).
+    ///
+    /// The renderer substitutes `footerPlaceholders` and leaves the rest of the template in
+    /// the literal text, so `%%footer "$X"` engraves the characters `$X` — and under the
+    /// default `TextRendering.outlines` it engraves them as artwork, which nothing downstream
+    /// can read back.  Parse time is the only place anyone gets told.  This catches both an
+    /// abcm2ps placeholder CeolKit does not implement (`$F`, `$V`, `$P0`) and a typo such as
+    /// `$p`; a `$` not followed by a letter (`$5`, a trailing `$`) is ordinary text, and
+    /// `${name}` is a consumer-substitutable span, so neither is a token at all.
+    ///
+    /// One warning per distinct token: every occurrence shares the directive's source range,
+    /// so repeating them would be noise pointing at the same line.
+    private func diagnoseFooterPlaceholders(_ template: String, source: SourceRange,
+                                            into diagnostics: inout [Diagnostic]) {
+        var seen: Set<Character> = []
+        for match in template.matches(of: /\$([A-Za-z])/) {
+            guard let token = match.1.first,
+                  !Self.footerPlaceholders.contains(token),
+                  seen.insert(token).inserted else { continue }
+            diagnostics.append(Diagnostic(
+                severity: .warning,
+                code: .unknownFooterPlaceholder,
+                message: "'$\(token)' is not a footer placeholder; it will be engraved literally",
+                source: source,
+                hint: "CeolKit substitutes $P, $T, $D and $d in %%footer."
+            ))
         }
     }
 

--- a/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
+++ b/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
@@ -311,16 +311,40 @@ public struct SVGRenderer: CeolKitRenderer {
                                         graceNoteSpacing: graceNoteSpacing))
         }
 
+        let firstPageNumber = Self.firstPageNumber(of: score)
         let emitter = SVGEmitter(config: effectiveConfig, metadata: metadata,
-                                 stemDirection: documentStemDirection)
+                                 stemDirection: documentStemDirection,
+                                 firstPageNumber: firstPageNumber)
         let layout = engine.layout(tuneBlocks)
-        let finalLayout = attachFooters(layout, score: score, config: effectiveConfig)
+        let finalLayout = attachFooters(layout, score: score, config: effectiveConfig,
+                                        firstPageNumber: firstPageNumber)
         return try emitter.emit(finalLayout)
+    }
+
+    // MARK: - Page numbering
+
+    /// The number the document's first page prints, per `%%ceolkit:pagenumber` (issue #138).
+    ///
+    /// Last-wins, and read only from the first tune: the directive sets the number *before
+    /// any output has been produced*, so the file preamble and the first tune's header are
+    /// the only places it can mean anything, and the parser folds preamble directives into
+    /// the first tune's list in source order, which puts both in one place.  A copy in a
+    /// later tune's header would be asking to renumber pages already engraved — that is
+    /// `%%newpage`'s job, not this directive's — and is ignored.
+    ///
+    /// Defaults to 1, which is what every document that does not use the directive gets, so
+    /// the ordinary page number is `pageIndex + 1` exactly as it always was.
+    static func firstPageNumber(of score: Score) -> Int {
+        score.tunes.first?.directives.compactMap { scope -> Int? in
+            if case .pageNumber(let n) = scope.directive { return n }
+            return nil
+        }.last ?? 1
     }
 
     // MARK: - Footer
 
-    private func attachFooters(_ layout: ResolvedLayout, score: Score, config: SVGRenderConfig) -> ResolvedLayout {
+    private func attachFooters(_ layout: ResolvedLayout, score: Score, config: SVGRenderConfig,
+                               firstPageNumber: Int) -> ResolvedLayout {
         guard let template = score.footer, !template.isEmpty else { return layout }
         // Find the last %%dateformat directive (last-wins across preamble and tune header).
         let dateFormat = score.tunes.first?.directives.compactMap { scope -> String? in
@@ -329,7 +353,8 @@ public struct SVGRenderer: CeolKitRenderer {
         }.last
         let pageCount = layout.pages.count
         let updatedPages = layout.pages.enumerated().map { pageIndex, page -> ResolvedPage in
-            let rows = buildFooterRows(template: template, pageNumber: pageIndex + 1,
+            let rows = buildFooterRows(template: template,
+                                       pageNumber: firstPageNumber + pageIndex,
                                        pageCount: pageCount, score: score, config: config,
                                        dateFormat: dateFormat)
             return ResolvedPage(systems: page.systems, titleRows: page.titleRows, footerRows: rows)

--- a/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
+++ b/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
@@ -340,17 +340,14 @@ public struct SVGRenderer: CeolKitRenderer {
     private func buildFooterRows(template: String, pageNumber: Int, pageCount: Int,
                                   score: Score, config: SVGRenderConfig,
                                   dateFormat: String? = nil) -> [ResolvedTitleRow] {
-        let title   = score.tunes.first?.titles.first?.value ?? ""
-        let dateStr = Self.currentDateString(format: dateFormat)
+        let context = FooterContext(
+            pageNumber: pageNumber, pageCount: pageCount,
+            title: score.tunes.first?.titles.first?.value ?? "",
+            date: Self.currentDateString(format: dateFormat))
+        let columns = FooterTemplate.columns(FooterTemplate.segments(of: template,
+                                                                     context: context))
+            .map(FooterTemplate.trimmed)
 
-        var text = template
-            .replacing(/\$P/, with: String(pageNumber))
-            .replacing(/\$T/, with: title)
-            .replacing(/\$D/, with: dateStr)
-            .replacing(/\$d/, with: dateStr)
-        text = text.replacing(/\\t/, with: "\t")
-
-        let parts     = text.components(separatedBy: "\t")
         let fontSize  = 12.0
         // Shift baseline up by the descender depth so the bottom of descenders (p, g, y, …)
         // lands precisely at the bottom margin line, not below it.
@@ -360,29 +357,69 @@ public struct SVGRenderer: CeolKitRenderer {
         let centerX   = config.pageSize.width / 2.0
         let rightX    = config.pageSize.width - config.margins.right
 
-        var items: [ResolvedTitleRow.Item] = []
-        switch parts.count {
+        let placements: [(column: [FooterSegment], x: Double, anchor: TextAnchor)]
+        switch columns.count {
         case 1:
-            let t = parts[0].trimmingCharacters(in: .whitespaces)
-            if !t.isEmpty {
-                items.append(.init(text: t, x: centerX, baselineY: baselineY,
-                                   anchor: .middle, fontSize: fontSize))
-            }
+            placements = [(columns[0], centerX, .middle)]
         case 2:
-            let l = parts[0].trimmingCharacters(in: .whitespaces)
-            let r = parts[1].trimmingCharacters(in: .whitespaces)
-            if !l.isEmpty { items.append(.init(text: l, x: leftX,  baselineY: baselineY, anchor: .start, fontSize: fontSize)) }
-            if !r.isEmpty { items.append(.init(text: r, x: rightX, baselineY: baselineY, anchor: .end,   fontSize: fontSize)) }
+            placements = [(columns[0], leftX,  .start),
+                          (columns[1], rightX, .end)]
         default:
-            let l = parts[0].trimmingCharacters(in: .whitespaces)
-            let c = parts[1].trimmingCharacters(in: .whitespaces)
-            let r = parts[2].trimmingCharacters(in: .whitespaces)
-            if !l.isEmpty { items.append(.init(text: l, x: leftX,   baselineY: baselineY, anchor: .start,  fontSize: fontSize)) }
-            if !c.isEmpty { items.append(.init(text: c, x: centerX, baselineY: baselineY, anchor: .middle, fontSize: fontSize)) }
-            if !r.isEmpty { items.append(.init(text: r, x: rightX,  baselineY: baselineY, anchor: .end,    fontSize: fontSize)) }
+            placements = [(columns[0], leftX,   .start),
+                          (columns[1], centerX, .middle),
+                          (columns[2], rightX,  .end)]
         }
 
+        let items = placements.flatMap {
+            layOutFooterColumn($0.column, x: $0.x, anchor: $0.anchor,
+                               baselineY: baselineY, fontSize: fontSize)
+        }
         return items.isEmpty ? [] : [ResolvedTitleRow(items: items)]
+    }
+
+    /// Places one footer column, splitting it into separate items only where the author
+    /// marked a `${…}` span.
+    ///
+    /// A column carrying no mark is laid out exactly as it always was — one item at the
+    /// column's own anchor — so ordinary footers are byte-for-byte unchanged and no font is
+    /// read to produce them.
+    private func layOutFooterColumn(_ segments: [FooterSegment], x: Double, anchor: TextAnchor,
+                                     baselineY: Double, fontSize: Double)
+    -> [ResolvedTitleRow.Item] {
+        let text = segments.map(\.text).joined()
+        func wholeColumn(tag: String? = nil) -> [ResolvedTitleRow.Item] {
+            guard tag != nil || !text.isEmpty else { return [] }
+            return [.init(text: text, x: x, baselineY: baselineY, anchor: anchor,
+                          fontSize: fontSize, tag: tag)]
+        }
+
+        guard segments.contains(where: { $0.tagName != nil }) else { return wholeColumn() }
+        // A column that is nothing *but* the mark keeps the column's own anchor, so a
+        // consumer stamping a wider string over it grows the way the column does — leftwards
+        // at the right margin, outwards from the centre — instead of running off the page.
+        if segments.count == 1, let name = segments[0].tagName { return wholeColumn(tag: name) }
+
+        // A mark mixed in with other text has to become an element of its own, which means
+        // measuring what precedes it. Without the bundled face there is nothing to measure
+        // with, so the column falls back to one untagged run: the default text, correctly
+        // drawn, and no substitution point — better than a footer laid out by guesswork.
+        guard let face = OutlineFontSet.textFace() else { return wholeColumn() }
+        var penX: Double
+        switch anchor {
+        case .start:  penX = x
+        case .middle: penX = x - face.width(of: text, fontSize: fontSize) / 2
+        case .end:    penX = x - face.width(of: text, fontSize: fontSize)
+        }
+
+        var items: [ResolvedTitleRow.Item] = []
+        for segment in segments {
+            if segment.tagName != nil || !segment.text.isEmpty {
+                items.append(.init(text: segment.text, x: penX, baselineY: baselineY,
+                                   anchor: .start, fontSize: fontSize, tag: segment.tagName))
+            }
+            penX += face.width(of: segment.text, fontSize: fontSize)
+        }
+        return items
     }
 
     private static func currentDateString(format: String? = nil, date: Date = Date()) -> String {

--- a/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
+++ b/Sources/CeolKitSVGRenderer/CeolKitSVGRenderer.swift
@@ -99,6 +99,11 @@ public struct SVGRenderer: CeolKitRenderer {
             // boundary is always a system break; a staff plan cannot change mid-system.
             var groups: [SystemGroup] = []
             var headerWidths: [Double] = []
+            // The tune stave each system came from, parallel to `groups`.  `%%newpage` is
+            // written against a stave — one source line of music — and pagination happens in
+            // systems, so this is where the two are reconciled: it is the last point that
+            // still knows which systems the packer made out of which stave.
+            var staveOfGroup: [Int] = []
             // The key each voice is standing in, threaded across the regions: a `%%score` in
             // the body cuts the tune but does not reset it, so the region after one opens in
             // whatever key the music before it reached (#134).  Empty until a body `K:` moves
@@ -282,6 +287,15 @@ public struct SVGRenderer: CeolKitRenderer {
                          group.staves[staffIndex].headerKeyChange)
                     }
                 }
+                // Every stave but the region's last ends on a `.hard` break, which the
+                // breaker stamps on the last system it packed out of that stave.  Walking
+                // the systems it produced therefore recovers the stave each one came from,
+                // without the breaker having to carry the number through justification.
+                var stave = region.staves.lowerBound
+                for group in regionGroups {
+                    staveOfGroup.append(stave)
+                    if group.sourceForced { stave += 1 }
+                }
                 groups += regionGroups
             }
 
@@ -308,17 +322,38 @@ public struct SVGRenderer: CeolKitRenderer {
             ).build()
             tuneBlocks.append(TuneBlock(systemGroups: tuneGroups, titleRows: titleRows,
                                         titleBlockHeight: titleBlockHeight, scale: scale,
-                                        graceNoteSpacing: graceNoteSpacing))
+                                        graceNoteSpacing: graceNoteSpacing,
+                                        pageBreaks: Self.forcedPageBreaks(
+                                            tune.pageBreaks, staveOfGroup: staveOfGroup)))
         }
 
         let firstPageNumber = Self.firstPageNumber(of: score)
         let emitter = SVGEmitter(config: effectiveConfig, metadata: metadata,
                                  stemDirection: documentStemDirection,
                                  firstPageNumber: firstPageNumber)
-        let layout = engine.layout(tuneBlocks)
+        let layout = engine.layout(tuneBlocks, firstPageNumber: firstPageNumber)
         let finalLayout = attachFooters(layout, score: score, config: effectiveConfig,
                                         firstPageNumber: firstPageNumber)
         return try emitter.emit(finalLayout)
+    }
+
+    // MARK: - Page breaks
+
+    /// Resolves the tune's `%%newpage` directives from the staves they were written against
+    /// to the systems they stand in front of (issue #140).
+    ///
+    /// A break lands on the first system of its stave.  Where that stave produced no system
+    /// at all — a `%%score` region whose plan selects nothing is dropped whole — the break
+    /// moves down to the next system there is, which keeps the music the author wanted on a
+    /// fresh page on one.  A break past every system is kept, addressed one past the end:
+    /// there is nothing left in this tune to move, so what it moves is the next tune.
+    static func forcedPageBreaks(_ breaks: [PageBreak],
+                                 staveOfGroup: [Int]) -> [ForcedPageBreak] {
+        breaks.map { pageBreak in
+            let group = staveOfGroup.firstIndex { $0 >= pageBreak.beforeStave }
+                ?? staveOfGroup.count
+            return ForcedPageBreak(beforeGroup: group, pageNumber: pageBreak.restartingAt)
+        }
     }
 
     // MARK: - Page numbering
@@ -354,10 +389,11 @@ public struct SVGRenderer: CeolKitRenderer {
         let pageCount = layout.pages.count
         let updatedPages = layout.pages.enumerated().map { pageIndex, page -> ResolvedPage in
             let rows = buildFooterRows(template: template,
-                                       pageNumber: firstPageNumber + pageIndex,
+                                       pageNumber: page.pageNumber ?? firstPageNumber + pageIndex,
                                        pageCount: pageCount, score: score, config: config,
                                        dateFormat: dateFormat)
-            return ResolvedPage(systems: page.systems, titleRows: page.titleRows, footerRows: rows)
+            return ResolvedPage(systems: page.systems, titleRows: page.titleRows,
+                                footerRows: rows, pageNumber: page.pageNumber)
         }
         return ResolvedLayout(pageSize: layout.pageSize, margins: layout.margins, pages: updatedPages)
     }

--- a/Sources/CeolKitSVGRenderer/Emission/SVGBuilder.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGBuilder.swift
@@ -31,6 +31,9 @@ struct SVGBuilder: Sendable {
     /// Ids of the non-empty glyphs, in the order they were first drawn, so that the
     /// emitted `<defs>` block is stable rather than dictionary-ordered.
     private var glyphOrder: [String] = []
+    /// How many times each `${…}` mark has been wrapped in this document, so repeats of one
+    /// name still get unique `id`s — see ``tagGroup(name:x:y:fontFamily:fontSize:textAnchor:_:)``.
+    private var tagCounts: [String: Int] = [:]
 
     init(textRendering: TextRendering = .fontFace, fonts: OutlineFontSet? = nil) {
         self.textRendering = textRendering
@@ -131,6 +134,52 @@ struct SVGBuilder: Sendable {
         let inner = elements[start...].map { "  " + $0 }
         elements.replaceSubrange(start..., with:
             ["<g transform=\"\(esc(transform))\">"] + inner + ["</g>"])
+    }
+
+    /// Wraps everything `body` draws in a `<g>` that names a consumer-substitutable span
+    /// and advertises how CeolKit drew it (issue #137).
+    ///
+    /// The `data-*` attributes are the contract with a downstream consumer; the group's
+    /// contents are CeolKit's own rendering of the span's default value, in whatever mode
+    /// the document is being emitted. A consumer that ignores the group gets exactly the
+    /// output it always got; one that means to substitute empties the group and draws its
+    /// own text at the advertised anchor, which needs the position, size and anchor rather
+    /// than the face — the point of the mark, since `.outlines` leaves no text to rewrite.
+    ///
+    /// Unlike ``group(transform:)`` this is emitted even when it wraps nothing: an author
+    /// who marked a name CeolKit has no value for still gets the positioned, empty group a
+    /// consumer needs to stamp into.
+    mutating func tagGroup(
+        name: String,
+        x: Double, y: Double,
+        fontFamily: String,
+        fontSize: Double,
+        textAnchor: String,
+        _ body: (inout SVGBuilder) -> Void
+    ) {
+        var attrs = "id=\"\(esc(tagID(for: name)))\" class=\"ceolkit-tag\""
+        attrs += " data-ceolkit-tag=\"\(esc(name))\""
+        attrs += " data-x=\"\(fmt(x))\" data-y=\"\(fmt(y))\""
+        attrs += " data-font-size=\"\(fmt(fontSize))\""
+        attrs += " data-font-family=\"\(esc(fontFamily))\""
+        attrs += " data-text-anchor=\"\(esc(textAnchor))\""
+        let start = elements.count
+        body(&self)
+        let inner = elements[start...].map { "  " + $0 }
+        elements.replaceSubrange(start..., with: ["<g \(attrs)>"] + inner + ["</g>"])
+    }
+
+    /// A document-unique `id` for a mark.
+    ///
+    /// Nothing stops a template from marking the same name twice — a page number at both
+    /// margins, say — and duplicate `id`s would make the document ill-formed. The first
+    /// occurrence gets the plain id a consumer would guess; later ones are suffixed.
+    /// `data-ceolkit-tag` carries the name unchanged on every one of them, so a consumer
+    /// keying off that finds them all.
+    private mutating func tagID(for name: String) -> String {
+        let count = (tagCounts[name] ?? 0) + 1
+        tagCounts[name] = count
+        return count == 1 ? "ceolkit-tag-\(name)" : "ceolkit-tag-\(name)-\(count)"
     }
 
     mutating func path(

--- a/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
@@ -356,17 +356,39 @@ struct SVGEmitter: Sendable {
     private func emitFooterBlock(_ rows: [ResolvedTitleRow], builder: inout SVGBuilder) {
         for row in rows {
             for item in row.items {
-                builder.text(
-                    item.text,
+                guard let tag = item.tag else {
+                    emitFooterItem(item, builder: &builder)
+                    continue
+                }
+                // A `${…}` span the author marked for a downstream consumer (issue #137).
+                // CeolKit draws its own value inside the group exactly as it would have
+                // drawn it loose, so a standalone render is unchanged; the group is what
+                // makes the span findable and replaceable in every rendering mode.
+                builder.tagGroup(
+                    name: tag,
                     x: item.x,
                     y: item.baselineY,
                     fontFamily: "Libertinus Serif",
                     fontSize: item.fontSize,
-                    textAnchor: item.anchor.rawValue,
-                    className: "footer"
-                )
+                    textAnchor: item.anchor.rawValue
+                ) {
+                    guard !item.text.isEmpty else { return }
+                    emitFooterItem(item, builder: &$0)
+                }
             }
         }
+    }
+
+    private func emitFooterItem(_ item: ResolvedTitleRow.Item, builder: inout SVGBuilder) {
+        builder.text(
+            item.text,
+            x: item.x,
+            y: item.baselineY,
+            fontFamily: "Libertinus Serif",
+            fontSize: item.fontSize,
+            textAnchor: item.anchor.rawValue,
+            className: "footer"
+        )
     }
 
     // MARK: - System

--- a/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
@@ -129,7 +129,11 @@ struct SVGEmitter: Sendable {
         var documents: [String] = []
         documents.reserveCapacity(layout.pages.count)
         for (pageIndex, page) in layout.pages.enumerated() {
-            let document = emitPage(page, pageNumber: firstPageNumber + pageIndex, layout: layout,
+            // The engine stamped the number as it decided where the page fell — a
+            // `%%newpage N` both breaks and renumbers (#140).  Counting from
+            // `firstPageNumber` is the fallback for a layout assembled by hand.
+            let document = emitPage(page, pageNumber: page.pageNumber ?? firstPageNumber + pageIndex,
+                                     layout: layout,
                                      embeddedFaces: embeddedFaces, fonts: fonts,
                                      pendingTies: &pendingTies, pendingSlurs: &pendingSlurs)
             documents.append(document)

--- a/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
+++ b/Sources/CeolKitSVGRenderer/Emission/SVGEmitter.swift
@@ -80,6 +80,9 @@ struct SVGEmitter: Sendable {
     /// order — carried from ``ResolvedSystem/voiceStemDirections``, so its count is how many
     /// voices share the staff.  Empty on the page-level emitter, which draws nothing itself.
     let voiceStemDirections: [StemDirection]
+    /// The number the first page prints, per `%%ceolkit:pagenumber` (issue #138).  1 for a
+    /// document that does not use the directive, which numbers pages from 1 as before.
+    let firstPageNumber: Int
     let accidentalMetrics: AccidentalMetrics
     /// Resolves the notehead, dot and accidental collisions of one column of a shared staff
     /// (issue #79).  Consulted only where a staff carries more than one voice.
@@ -88,12 +91,14 @@ struct SVGEmitter: Sendable {
     init(config: SVGRenderConfig, metadata: BravuraMetadata,
          stemDirection: StemDirection = .auto,
          systemStemDirection: StemDirection? = nil,
-         voiceStemDirections: [StemDirection] = []) {
+         voiceStemDirections: [StemDirection] = [],
+         firstPageNumber: Int = 1) {
         self.config = config
         self.metadata = metadata
         self.documentStemDirection = stemDirection
         self.stemDirection = systemStemDirection ?? stemDirection
         self.voiceStemDirections = voiceStemDirections
+        self.firstPageNumber = firstPageNumber
         let accidentalMetrics = AccidentalMetrics(config: config, metadata: metadata)
         self.accidentalMetrics = accidentalMetrics
         self.collisions = NoteheadCollisions(
@@ -124,7 +129,7 @@ struct SVGEmitter: Sendable {
         var documents: [String] = []
         documents.reserveCapacity(layout.pages.count)
         for (pageIndex, page) in layout.pages.enumerated() {
-            let document = emitPage(page, pageNumber: pageIndex + 1, layout: layout,
+            let document = emitPage(page, pageNumber: firstPageNumber + pageIndex, layout: layout,
                                      embeddedFaces: embeddedFaces, fonts: fonts,
                                      pendingTies: &pendingTies, pendingSlurs: &pendingSlurs)
             documents.append(document)
@@ -183,7 +188,8 @@ struct SVGEmitter: Sendable {
         systemConfig.graceNoteSpacing = system.graceNoteSpacing
         return SVGEmitter(config: systemConfig, metadata: metadata,
                           stemDirection: documentStemDirection, systemStemDirection: systemStem,
-                          voiceStemDirections: system.voiceStemDirections)
+                          voiceStemDirections: system.voiceStemDirections,
+                          firstPageNumber: firstPageNumber)
     }
 
     // MARK: - Voices on a staff
@@ -320,6 +326,11 @@ struct SVGEmitter: Sendable {
     /// Emits the `ceolkit-meta` comment (issue #25) listing each staff system's
     /// originating ABC source line and page Y coordinate, so editor consumers
     /// (e.g. ScoreEdit) can synchronise scroll position with the source.
+    ///
+    /// `page` is the number the page *prints* — the same value `$P` engraves into the footer,
+    /// offset by `%%ceolkit:pagenumber` where the document sets one (issue #138) — so a
+    /// consumer pairing a rendered page with what the reader sees on paper agrees with the
+    /// footer instead of drifting from it.
     ///
     /// One anchor per staff drawn, including each staff of a multi-voice system — the
     /// geometry reader pairs anchors with staves positionally, so the two counts have to

--- a/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
@@ -362,15 +362,23 @@ public struct ResolvedTitleRow: Sendable {
         public let anchor: TextAnchor
         public let fontSize: Double
         public let isItalic: Bool
+        /// The name of the `${…}` mark this item stands for, or `nil` on ordinary text.
+        ///
+        /// Set only on footer items.  ``text`` is then CeolKit's own value for the mark —
+        /// what gets drawn where nobody replaces it — and the emitter wraps the item in a
+        /// group a downstream consumer can find and redraw (issue #137).
+        public let tag: String?
 
         public init(text: String, x: Double, baselineY: Double,
-                    anchor: TextAnchor, fontSize: Double, isItalic: Bool = false) {
+                    anchor: TextAnchor, fontSize: Double, isItalic: Bool = false,
+                    tag: String? = nil) {
             self.text = text
             self.x = x
             self.baselineY = baselineY
             self.anchor = anchor
             self.fontSize = fontSize
             self.isItalic = isItalic
+            self.tag = tag
         }
     }
 

--- a/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/ResolvedLayout.swift
@@ -189,6 +189,28 @@ public struct SystemGroup: Sendable {
     public var columnCount: Int { staves[0].measures.count }
 }
 
+/// A `%%newpage` that reached the layout, resolved from the stave it was written against to
+/// the system it stands in front of (issue #140).
+///
+/// ``CeolKitModel/PageBreak`` counts staves, which is the unit the *source* breaks in; by the
+/// time a tune is a `TuneBlock` it has been packed into systems, and a system is the unit a
+/// *page* breaks in.  The renderer resolves one to the other while it still knows which
+/// systems came from which stave.
+public struct ForcedPageBreak: Hashable, Sendable {
+    /// Index into ``TuneBlock/systemGroups`` of the system this break falls in front of.
+    /// Equal to the group count for a break past the end of the tune, which puts it between
+    /// this tune and whatever follows.
+    public let beforeGroup: Int
+
+    /// The number the new page prints, from `%%newpage N`, or `nil` to carry on counting.
+    public let pageNumber: Int?
+
+    public init(beforeGroup: Int, pageNumber: Int?) {
+        self.beforeGroup = beforeGroup
+        self.pageNumber = pageNumber
+    }
+}
+
 /// Groups the justified systems and optional title block for a single tune.
 ///
 /// `titleRows` use `baselineY` values relative to the top of the tune's title area
@@ -208,24 +230,30 @@ public struct TuneBlock: Sendable {
     /// carried through unmultiplied.  The sizer reserved the group's width with this value,
     /// so the emitter has to draw with the same one.
     public let graceNoteSpacing: Double
+    /// The `%%newpage` breaks this tune asks for, in system order (issue #140).  Empty for
+    /// almost every tune, and an empty list is the pagination this engine has always done.
+    public let pageBreaks: [ForcedPageBreak]
 
     public init(systemGroups: [JustifiedSystemGroup], titleRows: [ResolvedTitleRow] = [],
                 titleBlockHeight: Double = 0, scale: Double = 1.0,
-                graceNoteSpacing: Double = SVGRenderConfig().graceNoteSpacing) {
+                graceNoteSpacing: Double = SVGRenderConfig().graceNoteSpacing,
+                pageBreaks: [ForcedPageBreak] = []) {
         self.systemGroups = systemGroups
         self.titleRows = titleRows
         self.titleBlockHeight = titleBlockHeight
         self.scale = scale
         self.graceNoteSpacing = graceNoteSpacing
+        self.pageBreaks = pageBreaks
     }
 
     /// Convenience for single-voice music: each system becomes a group of one staff.
     public init(systems: [JustifiedSystem], titleRows: [ResolvedTitleRow] = [],
                 titleBlockHeight: Double = 0, scale: Double = 1.0,
-                graceNoteSpacing: Double = SVGRenderConfig().graceNoteSpacing) {
+                graceNoteSpacing: Double = SVGRenderConfig().graceNoteSpacing,
+                pageBreaks: [ForcedPageBreak] = []) {
         self.init(systemGroups: systems.map { JustifiedSystemGroup(staves: [$0]) },
                   titleRows: titleRows, titleBlockHeight: titleBlockHeight,
-                  scale: scale, graceNoteSpacing: graceNoteSpacing)
+                  scale: scale, graceNoteSpacing: graceNoteSpacing, pageBreaks: pageBreaks)
     }
 }
 
@@ -344,12 +372,20 @@ public struct ResolvedPage: Sendable {
     public let titleRows: [ResolvedTitleRow]
     /// Pre-positioned footer rows; present on every page that has a %%footer template.
     public let footerRows: [ResolvedTitleRow]
+    /// The number this page prints, once something has decided what it is.
+    ///
+    /// Pagination and numbering are the same walk — `%%newpage N` both breaks the page and
+    /// says what the new one is called (issue #140) — so the engine that makes the pages is
+    /// the only thing in a position to number them.  `nil` on a layout assembled by hand,
+    /// where the emitter falls back to counting from its own `firstPageNumber`.
+    public let pageNumber: Int?
 
     public init(systems: [ResolvedSystem], titleRows: [ResolvedTitleRow] = [],
-                footerRows: [ResolvedTitleRow] = []) {
+                footerRows: [ResolvedTitleRow] = [], pageNumber: Int? = nil) {
         self.systems = systems
         self.titleRows = titleRows
         self.footerRows = footerRows
+        self.pageNumber = pageNumber
     }
 }
 

--- a/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
+++ b/Sources/CeolKitSVGRenderer/Layout/VerticalLayoutEngine.swift
@@ -111,15 +111,47 @@ public struct VerticalLayoutEngine: Sendable {
     /// Lays out a sequence of tune blocks, each with its own optional title block.
     ///
     /// Tunes share pages when they fit; a new page opens only when the current page
-    /// cannot accommodate a tune's title block and its first system together.
+    /// cannot accommodate a tune's title block and its first system together, or when a
+    /// `%%newpage` in the source demands one (issue #140).
     /// Each tune's title rows are offset from their tune-relative `baselineY` values
     /// by the actual page y-origin at the moment they are placed.
-    public func layout(_ tuneBlocks: [TuneBlock]) -> ResolvedLayout {
+    ///
+    /// - Parameter firstPageNumber: what the document's opening page is called, from
+    ///   `%%ceolkit:pagenumber`.  Every page is stamped with the number it prints as it is
+    ///   closed, because a `%%newpage N` renumbers *and* breaks, and only the walk that
+    ///   decides where the pages fall can honour both at once.
+    public func layout(_ tuneBlocks: [TuneBlock], firstPageNumber: Int = 1) -> ResolvedLayout {
         var pages: [ResolvedPage] = []
         var pageSystems: [ResolvedSystem] = []
         var pageTitleRows: [ResolvedTitleRow] = []
         var y = config.margins.top
         var previousAbcLine: Int?
+        var pageNumber = firstPageNumber
+
+        /// Closes the page being built and opens an empty one below it.
+        func flushPage() {
+            pages.append(ResolvedPage(systems: pageSystems, titleRows: pageTitleRows,
+                                      pageNumber: pageNumber))
+            pageNumber += 1
+            pageSystems = []
+            pageTitleRows = []
+            y = config.margins.top
+        }
+
+        /// Applies whatever `%%newpage` stands in front of system `gi` of `block`.
+        ///
+        /// A break onto a page nothing has been drawn on yet is not a break: there is
+        /// nothing to move.  `%%newpage N` at the head of a document therefore renames the
+        /// page it already opens rather than leaving a blank one behind it — which is also
+        /// what makes it agree with `%%ceolkit:pagenumber` written in the same place.
+        func applyForcedBreak(before gi: Int, of block: TuneBlock) {
+            let landing = block.pageBreaks.filter { $0.beforeGroup == gi }
+            guard !landing.isEmpty else { return }
+            if !pageSystems.isEmpty || !pageTitleRows.isEmpty { flushPage() }
+            // Several can land on one system — one in the gap before a tune and another in
+            // its header — and the last number written wins, as it does for every directive.
+            if let restart = landing.compactMap(\.pageNumber).last { pageNumber = restart }
+        }
 
         for block in tuneBlocks {
             let groups = block.systemGroups
@@ -136,6 +168,10 @@ public struct VerticalLayoutEngine: Sendable {
             let systemGap   = tuneConfig.systemGap
             let tuneGap     = tuneConfig.tuneGap
 
+            // A `%%newpage` standing before the tune moves its title block too, so it is
+            // honoured ahead of everything else this block does.
+            applyForcedBreak(before: 0, of: block)
+
             // If the current page already has content, check whether the entire tune
             // fits in the remaining space. If not, close the current page. Tunes that
             // are taller than a full page are still forced to a fresh page here; the
@@ -143,10 +179,7 @@ public struct VerticalLayoutEngine: Sendable {
             if !pageSystems.isEmpty {
                 let tuneH = totalHeight(of: block, endingRuns: endingRuns)
                 if y + tuneH > config.pageSize.height - config.margins.bottom {
-                    pages.append(ResolvedPage(systems: pageSystems, titleRows: pageTitleRows))
-                    pageSystems = []
-                    pageTitleRows = []
-                    y = config.margins.top
+                    flushPage()
                 }
             }
 
@@ -164,13 +197,14 @@ public struct VerticalLayoutEngine: Sendable {
                 let metrics = groupMetrics(of: group, config: tuneConfig,
                                            endingRuns: endingRuns[gi])
 
+                // The tune's own breaks, resolved to the system each stands in front of.
+                // Group 0 was dealt with above, before the title block was placed.
+                if gi > 0 { applyForcedBreak(before: gi, of: block) }
+
                 // A group breaks to the next page whole: splitting it would separate staves
                 // that only mean anything read together.
                 if !pageSystems.isEmpty && y + metrics.totalHeight > config.pageSize.height - config.margins.bottom {
-                    pages.append(ResolvedPage(systems: pageSystems, titleRows: pageTitleRows))
-                    pageSystems = []
-                    pageTitleRows = []
-                    y = config.margins.top
+                    flushPage()
                 }
 
                 // Every staff in the group reports the group's line, so the anchor sequence
@@ -186,10 +220,14 @@ public struct VerticalLayoutEngine: Sendable {
                 let isLastInBlock = gi == groups.count - 1
                 y += metrics.totalHeight + (isLastInBlock ? tuneGap : systemGap)
             }
+
+            // A `%%newpage` written past the tune's last stave — at the foot of its body
+            // rather than in the gap below it — puts whatever follows on a fresh page.
+            if !groups.isEmpty { applyForcedBreak(before: groups.count, of: block) }
         }
 
         if !pageSystems.isEmpty || !pageTitleRows.isEmpty {
-            pages.append(ResolvedPage(systems: pageSystems, titleRows: pageTitleRows))
+            flushPage()
         }
 
         return ResolvedLayout(

--- a/Sources/CeolKitSVGRenderer/TitleBlock/FooterTemplate.swift
+++ b/Sources/CeolKitSVGRenderer/TitleBlock/FooterTemplate.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// One piece of a `%%footer` template once the `${…}` marks have been read out of it.
+enum FooterSegment: Equatable, Sendable {
+    /// Text CeolKit engraves and owns.
+    case literal(String)
+    /// A span the author marked `${name}` for a downstream consumer to replace, carrying the
+    /// text CeolKit draws where nobody does.
+    case tag(name: String, text: String)
+
+    var text: String {
+        switch self {
+        case .literal(let text):  return text
+        case .tag(_, let text):   return text
+        }
+    }
+
+    /// The mark's name, or `nil` on a literal.
+    var tagName: String? {
+        if case .tag(let name, _) = self { return name }
+        return nil
+    }
+}
+
+/// What a footer template's placeholders resolve to on one page.
+struct FooterContext: Sendable {
+    let pageNumber: Int
+    let pageCount: Int
+    let title: String
+    let date: String
+
+    /// The value CeolKit draws into `${name}` where no consumer replaces it.
+    ///
+    /// A name CeolKit knows nothing about — a binder title, a section name — resolves to the
+    /// empty string.  The mark still reaches the SVG as a positioned but empty group, which
+    /// is exactly what a consumer meaning to stamp its own text there wants: CeolKit has no
+    /// value for it and should not invent one.
+    func value(forTag name: String) -> String {
+        switch name.lowercased() {
+        case "pagenumber": return String(pageNumber)
+        case "pagecount":  return String(pageCount)
+        case "title":      return title
+        case "date":       return date
+        default:           return ""
+        }
+    }
+}
+
+/// Reads a `%%footer` template into the spans that make it up (issue #137).
+///
+/// `${name}` marks a span as *consumer-substitutable*: CeolKit still draws its own value
+/// there, but the renderer emits that span as one findable, self-describing element instead
+/// of as loose glyphs, so a tool assembling pages from several separately-rendered files can
+/// replace it without owning the font.  Everything else in the template is ordinary text.
+enum FooterTemplate {
+    /// A mark's name is an identifier, so that a `${` appearing in ordinary footer text
+    /// cannot be mistaken for one.  Anything that does not parse as a mark — an unclosed
+    /// brace, a name starting with a digit — stays in the literal text exactly as written,
+    /// which is what an author who did not mean a mark expects to see engraved.
+    ///
+    /// Computed rather than stored: a `Regex` is not `Sendable`, so a `static let` holding
+    /// one is a mutable global the concurrency checker rejects.
+    private static var mark: Regex<(Substring, Substring)> { /\$\{([A-Za-z][A-Za-z0-9_.-]*)\}/ }
+
+    /// Splits `template` into literal and marked spans, with every `$P`/`$T`/`$D`/`$d` in the
+    /// literals resolved and `\t` unescaped.
+    ///
+    /// Marks are read out of the *raw* template, before the other placeholders expand, so a
+    /// tune whose title happens to contain `${…}` cannot conjure a substitution point.
+    static func segments(of template: String, context: FooterContext) -> [FooterSegment] {
+        var segments: [FooterSegment] = []
+        var cursor = template.startIndex
+        for match in template.matches(of: mark) {
+            if cursor < match.range.lowerBound {
+                segments.append(.literal(expand(String(template[cursor..<match.range.lowerBound]),
+                                                context)))
+            }
+            let name = String(match.1)
+            segments.append(.tag(name: name, text: context.value(forTag: name)))
+            cursor = match.range.upperBound
+        }
+        if cursor < template.endIndex {
+            segments.append(.literal(expand(String(template[cursor...]), context)))
+        }
+        return segments
+    }
+
+    /// Splits `segments` at tab characters into the footer's columns — one, two, or three,
+    /// as `buildFooterRows` has always read a template.  A mark never spans a tab, so it
+    /// always belongs wholly to one column.
+    static func columns(_ segments: [FooterSegment]) -> [[FooterSegment]] {
+        var columns: [[FooterSegment]] = [[]]
+        for segment in segments {
+            guard case .literal(let text) = segment else {
+                columns[columns.count - 1].append(segment)
+                continue
+            }
+            for (index, piece) in text.components(separatedBy: "\t").enumerated() {
+                if index > 0 { columns.append([]) }
+                if !piece.isEmpty { columns[columns.count - 1].append(.literal(piece)) }
+            }
+        }
+        return columns
+    }
+
+    /// Strips the whitespace a column is padded with, the way trimming the whole column
+    /// string used to.  Only the literal ends are touched: a mark's default value is a value,
+    /// not padding, and a consumer comparing what it reads against what it stamps should not
+    /// have to know that CeolKit trimmed it.
+    static func trimmed(_ column: [FooterSegment]) -> [FooterSegment] {
+        var column = column
+        if case .literal(let text)? = column.first {
+            var trimmed = text
+            while let first = trimmed.first, first.isWhitespace { trimmed.removeFirst() }
+            column[0] = .literal(trimmed)
+        }
+        if case .literal(let text)? = column.last {
+            var trimmed = text
+            while let last = trimmed.last, last.isWhitespace { trimmed.removeLast() }
+            column[column.count - 1] = .literal(trimmed)
+        }
+        return column.filter { $0.tagName != nil || !$0.text.isEmpty }
+    }
+
+    private static func expand(_ text: String, _ context: FooterContext) -> String {
+        text.replacing(/\$P/, with: String(context.pageNumber))
+            .replacing(/\$T/, with: context.title)
+            .replacing(/\$D/, with: context.date)
+            .replacing(/\$d/, with: context.date)
+            .replacing(/\\t/, with: "\t")
+    }
+}

--- a/Sources/ckprobe/Report.swift
+++ b/Sources/ckprobe/Report.swift
@@ -39,9 +39,19 @@ struct Report: Codable {
         let staves: [[String]]
     }
 
+    /// One `%%newpage` and the stave it breaks before, so that a body break's position can
+    /// be read off without re-deriving it from the source.
+    struct PageBreak: Codable {
+        let beforeStave: Int
+        let line: Int
+        /// The number the new page prints, or `nil` where the directive carried none.
+        let restartingAt: Int?
+    }
+
     struct Tune: Codable {
         let directives: [String]
         let staffPlans: [StaffPlanChange]
+        let pageBreaks: [PageBreak]
         let voices: [Voice]
     }
 
@@ -69,6 +79,10 @@ extension Report {
                         line: change.source.line,
                         staves: change.plan.layout.staves.map { $0.map(name) }
                     )
+                },
+                pageBreaks: tune.pageBreaks.map {
+                    PageBreak(beforeStave: $0.beforeStave, line: $0.source.line,
+                              restartingAt: $0.restartingAt)
                 },
                 voices: tune.voices.map { voice in
                     Voice(staves: voice.staves.map { stave in
@@ -106,6 +120,11 @@ extension Report {
                 let staves = plan.staves.map { $0.joined(separator: "+") }.joined(separator: " / ")
                 out.append("  tune[\(tuneIndex)] staffPlan from stave \(plan.effectiveFromStave)"
                            + " (line \(plan.line)): \(staves)")
+            }
+            for pageBreak in tune.pageBreaks {
+                let restart = pageBreak.restartingAt.map { ", renumbering from \($0)" } ?? ""
+                out.append("  tune[\(tuneIndex)] newpage before stave \(pageBreak.beforeStave)"
+                           + " (line \(pageBreak.line))\(restart)")
             }
             for (voiceIndex, voice) in tune.voices.enumerated() {
                 let counts = voice.staves.map(\.measureCount)

--- a/Tests/CeolKitParserTests/Extensions/NewPageDirectiveTests.swift
+++ b/Tests/CeolKitParserTests/Extensions/NewPageDirectiveTests.swift
@@ -1,0 +1,228 @@
+// Where a %%newpage takes effect (ABC v2.2 §11.4.7, issue #140).
+// Parser and model only — pagination itself is checked in the renderer's NewPageTests.
+import Testing
+import CeolKitModel
+import CeolKitParser
+
+@Suite("%%newpage position (#140)")
+struct NewPageDirectiveTests {
+
+    // MARK: - Helpers
+
+    private func breaks(_ abc: String, tune index: Int = 0) -> [PageBreak] {
+        let tunes = parse(abc).score.tunes
+        guard tunes.indices.contains(index) else { return [] }
+        return tunes[index].pageBreaks
+    }
+
+    private func diagnostics(_ abc: String, code: DiagnosticCode) -> [Diagnostic] {
+        parse(abc).score.diagnostics.filter { $0.code == code }
+    }
+
+    // MARK: - Nothing to report
+
+    @Test("A tune with no %%newpage asks for no break")
+    func noDirective() {
+        #expect(breaks("""
+        X:1
+        L:1/4
+        K:C
+        CDEF|
+        """).isEmpty)
+    }
+
+    @Test("%%newpage no longer reports itself as an unsupported directive")
+    func noLongerUnknown() {
+        let unknown = diagnostics("""
+        %%newpage
+        X:1
+        L:1/4
+        K:C
+        CDEF|
+        """, code: .unknownDirective)
+        #expect(unknown.isEmpty)
+    }
+
+    // MARK: - Where the break lands
+
+    @Test("A header %%newpage breaks before the tune's first stave")
+    func headerBreak() throws {
+        let found = breaks("""
+        X:1
+        %%newpage
+        L:1/4
+        K:C
+        CDEF|
+        """)
+        try #require(found.count == 1)
+        #expect(found[0].beforeStave == 0)
+        #expect(found[0].restartingAt == nil)
+    }
+
+    @Test("A body %%newpage breaks before the stave that follows it")
+    func bodyBreak() throws {
+        let found = breaks("""
+        X:1
+        L:1/4
+        K:C
+        CDEF|
+        GABc|
+        %%newpage
+        CDEF|
+        """)
+        try #require(found.count == 1)
+        #expect(found[0].beforeStave == 2)
+    }
+
+    @Test("A %%newpage below the last stave breaks past the end of the tune")
+    func trailingBreak() throws {
+        let found = breaks("""
+        X:1
+        L:1/4
+        K:C
+        CDEF|
+        %%newpage
+        """)
+        try #require(found.count == 1)
+        #expect(found[0].beforeStave == 1)
+    }
+
+    @Test("A %%newpage in the gap between two tunes belongs to the tune below it")
+    func gapBreakBelongsToTheFollowingTune() throws {
+        let abc = """
+        X:1
+        L:1/4
+        K:C
+        CDEF|
+
+        %%newpage
+        X:2
+        L:1/4
+        K:C
+        GABc|
+        """
+        #expect(breaks(abc, tune: 0).isEmpty)
+        let second = breaks(abc, tune: 1)
+        try #require(second.count == 1)
+        #expect(second[0].beforeStave == 0)
+    }
+
+    @Test("A %%newpage past the last tune is dropped, and says so")
+    func orphanBreak() throws {
+        let abc = """
+        X:1
+        L:1/4
+        K:C
+        CDEF|
+
+        %%newpage
+        """
+        #expect(breaks(abc).isEmpty)
+        #expect(diagnostics(abc, code: .pageBreakAfterLastTune).count == 1)
+    }
+
+    // MARK: - Snapping
+
+    @Test("A %%newpage part way through a stave snaps back to the start of it")
+    func snapsToStave() throws {
+        let abc = """
+        X:1
+        L:1/4
+        V:1
+        V:2
+        K:C
+        [V:1]CDEF|
+        %%newpage
+        [V:2]GABc|
+        [V:1]CDEF|
+        [V:2]GABc|
+        """
+        let found = breaks(abc)
+        try #require(found.count == 1)
+        #expect(found[0].beforeStave == 0)
+        #expect(diagnostics(abc, code: .pageBreakSnappedToStave).count == 1)
+    }
+
+    @Test("A %%newpage on a line-set boundary does not snap, and is not warned about")
+    func boundaryDoesNotSnap() throws {
+        let abc = """
+        X:1
+        L:1/4
+        V:1
+        V:2
+        K:C
+        [V:1]CDEF|
+        [V:2]GABc|
+        %%newpage
+        [V:1]CDEF|
+        [V:2]GABc|
+        """
+        let found = breaks(abc)
+        try #require(found.count == 1)
+        #expect(found[0].beforeStave == 1)
+        #expect(diagnostics(abc, code: .pageBreakSnappedToStave).isEmpty)
+    }
+
+    // MARK: - The optional page number
+
+    @Test("%%newpage N carries the number the new page prints")
+    func carriesNumber() throws {
+        let found = breaks("""
+        X:1
+        %%newpage 20
+        L:1/4
+        K:C
+        CDEF|
+        """)
+        try #require(found.count == 1)
+        #expect(found[0].restartingAt == 20)
+    }
+
+    @Test("An argument that is not a page number leaves the break standing")
+    func badArgumentKeepsTheBreak() throws {
+        // The author unmistakably asked for a page break; only the renumbering is in doubt.
+        let abc = """
+        X:1
+        %%newpage frog
+        L:1/4
+        K:C
+        CDEF|
+        """
+        let found = breaks(abc)
+        try #require(found.count == 1)
+        #expect(found[0].restartingAt == nil)
+        #expect(diagnostics(abc, code: .invalidPageNumber).count == 1)
+    }
+
+    @Test("Page numbers below 1 are refused the same way")
+    func zeroIsRefused() throws {
+        let abc = """
+        X:1
+        %%newpage 0
+        L:1/4
+        K:C
+        CDEF|
+        """
+        let found = breaks(abc)
+        try #require(found.count == 1)
+        #expect(found[0].restartingAt == nil)
+        #expect(diagnostics(abc, code: .invalidPageNumber).count == 1)
+    }
+
+    // MARK: - Not a flattened directive
+
+    @Test("A page break is not also stored as a CeolKitDirective")
+    func notInDirectives() {
+        // It has no meaning apart from where it falls, so the positional list is the only
+        // view of it — nothing downstream should find a last-wins scalar to read instead.
+        let tune = parse("""
+        %%newpage 4
+        X:1
+        L:1/4
+        K:C
+        CDEF|
+        """).score.firstTune
+        let directives = tune?.directives ?? []
+        #expect(directives.isEmpty)
+    }
+}

--- a/Tests/CeolKitParserTests/Extensions/StandardDirectiveTests.swift
+++ b/Tests/CeolKitParserTests/Extensions/StandardDirectiveTests.swift
@@ -316,6 +316,65 @@ struct StandardDirectiveTests {
         #expect(result.score.footer == "left\\tcenter\\tright")
     }
 
+    // MARK: %%footer placeholders (issue #141)
+
+    @Test("Every recognised $ placeholder passes without a warning")
+    func footerKnownPlaceholdersSilent() {
+        let abc = "%%footer \"$T\\t$P of $D\\t$d\"\nX:1\nT:T\nM:4/4\nL:1/4\nK:C\nC|"
+        let result = parse(abc)
+        #expect(result.score.diagnostics.allSatisfy { $0.code != .unknownFooterPlaceholder })
+    }
+
+    @Test("An unrecognised $ token warns and names itself")
+    func footerUnknownPlaceholderWarns() {
+        let abc = "%%footer \"$Q\"\nX:1\nT:T\nM:4/4\nL:1/4\nK:C\nC|"
+        let result = parse(abc)
+        let warnings = result.score.diagnostics.filter { $0.code == .unknownFooterPlaceholder }
+        #expect(warnings.count == 1)
+        #expect(warnings.first?.severity == .warning)
+        #expect(warnings.first?.message.contains("$Q") == true)
+    }
+
+    @Test("A typo differing only in case is caught")
+    func footerPlaceholderCaseTypoWarns() {
+        let abc = "%%footer \"Page $p\"\nX:1\nT:T\nM:4/4\nL:1/4\nK:C\nC|"
+        let result = parse(abc)
+        let warnings = result.score.diagnostics.filter { $0.code == .unknownFooterPlaceholder }
+        #expect(warnings.count == 1)
+        #expect(warnings.first?.message.contains("$p") == true)
+    }
+
+    @Test("A repeated unknown token warns once, distinct ones once each")
+    func footerUnknownPlaceholdersDeduplicated() {
+        let abc = "%%footer \"$X $X $V\"\nX:1\nT:T\nM:4/4\nL:1/4\nK:C\nC|"
+        let result = parse(abc)
+        let warnings = result.score.diagnostics.filter { $0.code == .unknownFooterPlaceholder }
+        #expect(warnings.count == 2)
+    }
+
+    @Test("A $ that is not followed by a letter is ordinary text")
+    func footerBareDollarNotDiagnosed() {
+        let abc = "%%footer \"Price: $5, or $\"\nX:1\nT:T\nM:4/4\nL:1/4\nK:C\nC|"
+        let result = parse(abc)
+        #expect(result.score.diagnostics.allSatisfy { $0.code != .unknownFooterPlaceholder })
+    }
+
+    @Test("A ${name} span is not mistaken for a placeholder")
+    func footerTagSpanNotDiagnosed() {
+        let abc = "%%footer \"${bindername}\\t${pagenumber}\"\nX:1\nT:T\nM:4/4\nL:1/4\nK:C\nC|"
+        let result = parse(abc)
+        #expect(result.score.diagnostics.allSatisfy { $0.code != .unknownFooterPlaceholder })
+    }
+
+    @Test("An unrecognised $ token in a tune header warns too")
+    func footerUnknownPlaceholderInTuneHeaderWarns() {
+        let abc = "X:1\nT:T\n%%footer \"$F\"\nM:4/4\nL:1/4\nK:C\nC|"
+        let result = parse(abc)
+        let warnings = result.score.diagnostics.filter { $0.code == .unknownFooterPlaceholder }
+        #expect(warnings.count == 1)
+        #expect(warnings.first?.message.contains("$F") == true)
+    }
+
     // MARK: %%dateformat
 
     @Test("%%dateformat does not emit unknownDirective warning")

--- a/Tests/CeolKitSVGRendererTests/FooterTagTests.swift
+++ b/Tests/CeolKitSVGRendererTests/FooterTagTests.swift
@@ -1,0 +1,148 @@
+//
+//  FooterTagTests.swift
+//  CeolKitSVGRendererTests
+//
+//  Consumer-substitutable footer spans — issue #137.
+//
+
+import CeolKitModel
+import CeolKitParser
+import Foundation
+import Testing
+@testable import CeolKitSVGRenderer
+
+private func parse(_ source: String) -> ParseResult {
+    CeolKitParser().parse(source, options: .default)
+}
+
+private func render(_ footer: String, textRendering: TextRendering = .fontFace) throws -> String {
+    let abc = """
+    %%footer "\(footer)"
+    X:1
+    T:Marked
+    M:4/4
+    L:1/4
+    K:C
+    CDEF|
+    """
+    var config = SVGRenderConfig()
+    config.textRendering = textRendering
+    return try SVGRenderer(config: config).render(parse(abc).score).joined()
+}
+
+private let context = FooterContext(pageNumber: 4, pageCount: 9, title: "Reel", date: "1 May")
+
+@Suite("Footer substitution marks (#137)")
+struct FooterTagTests {
+
+    // MARK: - Template reading
+
+    @Test func aMarkBecomesItsOwnSegmentCarryingCeolKitsValue() {
+        let segments = FooterTemplate.segments(of: "Page ${pagenumber}", context: context)
+        #expect(segments == [.literal("Page "), .tag(name: "pagenumber", text: "4")])
+    }
+
+    @Test func knownNamesResolveToTheValuesTheOtherPlaceholdersUse() {
+        let segments = FooterTemplate.segments(
+            of: "${pagenumber}${pagecount}${title}${date}", context: context)
+        #expect(segments.map(\.text) == ["4", "9", "Reel", "1 May"])
+    }
+
+    @Test func aNameCeolKitHasNoValueForStillMarksTheSpan() {
+        let segments = FooterTemplate.segments(of: "${bindername}", context: context)
+        // Empty rather than invented: the consumer owns the text, CeolKit only owns the spot.
+        #expect(segments == [.tag(name: "bindername", text: "")])
+    }
+
+    @Test func placeholdersInsideTheMarkedValuesCannotConjureAMark() {
+        // A tune whose title contains ${…} must engrave it, not turn it into a
+        // substitution point: marks are read from the raw template, before $T expands.
+        let sneaky = FooterContext(pageNumber: 1, pageCount: 1,
+                                   title: "${pagenumber}", date: "1 May")
+        let segments = FooterTemplate.segments(of: "$T", context: sneaky)
+        #expect(segments == [.literal("${pagenumber}")])
+    }
+
+    @Test(arguments: ["${1bad}", "${un closed", "${}", "$ {pagenumber}"])
+    func textThatIsNotAMarkIsLeftAlone(_ template: String) {
+        let segments = FooterTemplate.segments(of: template, context: context)
+        #expect(segments == [.literal(template)])
+    }
+
+    @Test func columnsSplitAtTabsAndAMarkStaysWhollyInsideOne() {
+        let segments = FooterTemplate.segments(of: "a\\t${x}b\\tc", context: context)
+        let columns = FooterTemplate.columns(segments)
+        #expect(columns.count == 3)
+        #expect(columns[0] == [.literal("a")])
+        #expect(columns[1] == [.tag(name: "x", text: ""), .literal("b")])
+        #expect(columns[2] == [.literal("c")])
+    }
+
+    @Test func onlyTheLiteralEndsOfAColumnAreTrimmed() {
+        let column = FooterTemplate.trimmed(FooterTemplate.segments(
+            of: "   Page ${pagenumber}   ", context: context))
+        #expect(column == [.literal("Page "), .tag(name: "pagenumber", text: "4")])
+    }
+
+    // MARK: - Emission
+
+    @Test func aMarkedSpanIsWrappedInAFindableSelfDescribingGroup() throws {
+        let svg = try render("Page ${pagenumber}")
+        #expect(svg.contains("<g id=\"ceolkit-tag-pagenumber\" class=\"ceolkit-tag\""))
+        #expect(svg.contains("data-ceolkit-tag=\"pagenumber\""))
+        #expect(svg.contains("data-font-size=\"12\""))
+        #expect(svg.contains("data-font-family=\"Libertinus Serif\""))
+    }
+
+    @Test func theGroupCarriesCeolKitsOwnRenderingOfTheDefaultValue() throws {
+        let svg = try render("Page ${pagenumber}")
+        // A consumer that ignores the group gets exactly today's output: "Page" beside "1".
+        #expect(svg.contains(">Page </text>"))
+        #expect(svg.contains(">1</text>"))
+    }
+
+    @Test func theSpanIsWrappedInOutlineModeToo() throws {
+        // The whole point: `.outlines` leaves no text to rewrite, so the group is the only
+        // thing a consumer has to work with — it must be there in every mode.
+        let svg = try render("Page ${pagenumber}", textRendering: .outlines)
+        #expect(svg.contains("data-ceolkit-tag=\"pagenumber\""))
+        #expect(!svg.contains("<text"))
+    }
+
+    @Test func aMarkCeolKitCannotFillLeavesAnEmptyGroupAtTheRightSpot() throws {
+        let svg = try render("${bindername}", textRendering: .outlines)
+        #expect(svg.contains("data-ceolkit-tag=\"bindername\""))
+        #expect(svg.contains("data-x=\"306\""))
+        #expect(svg.contains("data-text-anchor=\"middle\""))
+    }
+
+    @Test func aColumnThatIsNothingButTheMarkKeepsTheColumnsAnchor() throws {
+        // A wider replacement then grows leftwards from the right margin instead of off
+        // the page.
+        let svg = try render("$T\\t\\t${pagenumber}")
+        #expect(svg.contains("data-text-anchor=\"end\""))
+        #expect(svg.contains("data-x=\"576\""))
+    }
+
+    @Test func aMarkMixedWithTextIsPlacedAfterTheTextItFollows() throws {
+        let svg = try render("Page ${pagenumber}")
+        let literalX = try #require(svg.firstMatch(of: #/<text x="([0-9.]+)"[^>]*>Page /#))
+        let tagX = try #require(svg.firstMatch(of: #/data-ceolkit-tag="pagenumber" data-x="([0-9.]+)"/#))
+        #expect(Double(tagX.1)! > Double(literalX.1)!)
+        // Centred column: the run as a whole still straddles the page centre.
+        #expect(Double(literalX.1)! < 306)
+    }
+
+    @Test func repeatsOfOneNameGetUniqueIdsAndTheSameTagName() throws {
+        let svg = try render("${pagenumber}\\t\\t${pagenumber}")
+        #expect(svg.contains("id=\"ceolkit-tag-pagenumber\""))
+        #expect(svg.contains("id=\"ceolkit-tag-pagenumber-2\""))
+        #expect(svg.ranges(of: "data-ceolkit-tag=\"pagenumber\"").count == 2)
+    }
+
+    @Test func anUnmarkedFooterIsUntouched() throws {
+        let svg = try render("Page $P")
+        #expect(!svg.contains("ceolkit-tag"))
+        #expect(svg.contains(">Page 1</text>"))
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/NewPageTests.swift
+++ b/Tests/CeolKitSVGRendererTests/NewPageTests.swift
@@ -1,0 +1,212 @@
+//
+//  NewPageTests.swift
+//  CeolKitSVGRendererTests
+//
+//  %%newpage reaching the page it breaks — issue #140.
+//
+
+import CeolKitModel
+import CeolKitParser
+import Foundation
+import Testing
+@testable import CeolKitSVGRenderer
+
+private func parse(_ source: String) -> ParseResult {
+    CeolKitParser().parse(source, options: .default)
+}
+
+private func render(_ abc: String) throws -> [String] {
+    var config = SVGRenderConfig()
+    config.textRendering = .fontFace
+    return try SVGRenderer(config: config).render(parse(abc).score)
+}
+
+/// What each page's footer prints, which is where `$P` lands.
+private func footers(of abc: String) throws -> [String] {
+    try render(abc).map { page in
+        page.firstMatch(of: #/class="footer">([^<]*)</#).map { String($0.1) } ?? ""
+    }
+}
+
+/// The systems on each page, named by the source line each was engraved from.
+///
+/// Read back out of the `ceolkit-meta` scroll-sync comment, which carries one anchor per
+/// system: it is the only per-system marker in the document that survives outlining, and it
+/// says *which* music landed on the page as well as how much.
+private func systemLines(of abc: String) throws -> [[Int]] {
+    try render(abc).map { page in
+        page.matches(of: #/"abcLine": (\d+)/#).compactMap { Int($0.1) }
+    }
+}
+
+@Suite("%%newpage (#140)")
+struct NewPageTests {
+
+    /// Two short tunes that would otherwise sit on one page together.
+    private func twoTunes(_ between: String) -> String {
+        """
+        X:1
+        T:First
+        M:4/4
+        L:1/8
+        K:G
+        GABG|DEFD|
+        \(between)
+        X:2
+        T:Second
+        M:4/4
+        L:1/8
+        K:G
+        GABG|DEFD|
+        """
+    }
+
+    // MARK: - Where the break falls
+
+    @Test func withoutTheDirectiveTwoShortTunesShareAPage() throws {
+        #expect(try render(twoTunes("")).count == 1)
+    }
+
+    @Test func aBreakBetweenTwoTunesPutsTheSecondOnItsOwnPage() throws {
+        let pages = try render(twoTunes("\n%%newpage"))
+        try #require(pages.count == 2)
+        #expect(pages[0].contains(">First<"))
+        #expect(pages[1].contains(">Second<"))
+    }
+
+    @Test func aBreakInATunesHeaderMovesThatTune() throws {
+        let pages = try render("""
+        X:1
+        T:First
+        M:4/4
+        L:1/8
+        K:G
+        GABG|DEFD|
+
+        X:2
+        %%newpage
+        T:Second
+        M:4/4
+        L:1/8
+        K:G
+        GABG|DEFD|
+        """)
+        try #require(pages.count == 2)
+        #expect(pages[1].contains(">Second<"))
+    }
+
+    @Test func aBreakBelowTheLastStaveOfATuneMovesWhateverFollows() throws {
+        // Written at the foot of tune 1's body rather than in the gap below it.  There is
+        // nothing of tune 1 left to move, so what it moves is tune 2.
+        let pages = try render(twoTunes("%%newpage"))
+        try #require(pages.count == 2)
+        #expect(pages[1].contains(">Second<"))
+    }
+
+    @Test func aBreakInTheBodySplitsTheTuneWhereItIsWritten() throws {
+        let pages = try systemLines(of: """
+        X:1
+        T:Split
+        M:4/4
+        L:1/8
+        K:G
+        GABG|DEFD|
+        %%newpage
+        GABG|DEFD|
+        GABG|DEFD|
+        """)
+        try #require(pages.count == 2)
+        // The stave above the directive stays behind; the two below it move.
+        #expect(pages[0] == [6])
+        #expect(pages[1] == [8, 9])
+    }
+
+    @Test func aBreakAheadOfEveryTuneLeavesNoBlankPageBehindIt() throws {
+        // Nothing has been engraved yet, so there is nothing to break away from.
+        #expect(try render("%%newpage\n" + twoTunes("")).count == 1)
+    }
+
+    // MARK: - Page numbering
+
+    @Test func aPlainBreakLeavesTheCountAlone() throws {
+        #expect(try footers(of: "%%footer \"P=$P\"\n" + twoTunes("\n%%newpage"))
+                == ["P=1", "P=2"])
+    }
+
+    @Test func newPageNRenumbersFromThere() throws {
+        #expect(try footers(of: "%%footer \"P=$P\"\n" + twoTunes("\n%%newpage 20"))
+                == ["P=1", "P=20"])
+    }
+
+    @Test func numberingCarriesOnFromTheRestartedNumber() throws {
+        let printed = try footers(of: """
+        %%footer "P=$P"
+        X:1
+        T:A
+        M:4/4
+        L:1/8
+        K:G
+        GABG|
+
+        %%newpage 20
+        X:2
+        T:B
+        M:4/4
+        L:1/8
+        K:G
+        GABG|
+
+        %%newpage
+        X:3
+        T:C
+        M:4/4
+        L:1/8
+        K:G
+        GABG|
+        """)
+        #expect(printed == ["P=1", "P=20", "P=21"])
+    }
+
+    @Test func aBreakAheadOfEveryTuneStillSetsTheOpeningNumber() throws {
+        // No page to break, but `%%newpage 7` still says what the first one is called —
+        // which is where it meets %%ceolkit:pagenumber written in the same place (#138).
+        #expect(try footers(of: "%%newpage 7\n%%footer \"P=$P\"\n" + twoTunes(""))
+                == ["P=7"])
+    }
+
+    @Test func theScrollSyncMetadataAgreesWithTheFooter() throws {
+        let pages = try render("%%footer \"P=$P\"\n" + twoTunes("\n%%newpage 20"))
+        try #require(pages.count == 2)
+        #expect(pages[0].contains("\"page\": 1"))
+        #expect(pages[1].contains("\"page\": 20"))
+    }
+
+    @Test func aBreakCarriesTheNumberEvenWhereTheNumberedTuneCameFirst() throws {
+        // %%ceolkit:pagenumber sets the opening number and %%newpage moves on from it: the
+        // two compose rather than competing (EXTENSIONS.md, "Interaction with %%newpage").
+        #expect(try footers(of: "%%ceolkit:pagenumber 3\n%%footer \"P=$P\"\n"
+                                + twoTunes("\n%%newpage"))
+                == ["P=3", "P=4"])
+    }
+
+    // MARK: - Resolving staves to systems
+
+    @Test func aBreakOnAStaveTheLayoutSplitLandsOnTheFirstOfItsSystems() throws {
+        // The stave after the break is too wide for one line, so the packer makes several
+        // systems out of it.  The break belongs in front of the first of them.
+        let bars = Array(repeating: "GABG|", count: 12).joined()
+        let pages = try systemLines(of: """
+        X:1
+        T:Wide
+        M:4/4
+        L:1/8
+        K:G
+        GABG|
+        %%newpage
+        \(bars)
+        """)
+        try #require(pages.count == 2)
+        #expect(pages[0] == [6])
+        #expect(pages[1].count > 1)
+    }
+}

--- a/Tests/CeolKitSVGRendererTests/PageNumberTests.swift
+++ b/Tests/CeolKitSVGRendererTests/PageNumberTests.swift
@@ -1,0 +1,134 @@
+//
+//  PageNumberTests.swift
+//  CeolKitSVGRendererTests
+//
+//  %%ceolkit:pagenumber reaching the page it numbers — issue #138.
+//
+
+import CeolKitModel
+import CeolKitParser
+import Foundation
+import Testing
+@testable import CeolKitSVGRenderer
+
+private func parse(_ source: String) -> ParseResult {
+    CeolKitParser().parse(source, options: .default)
+}
+
+/// One short tune, whose footer prints whatever the placeholders resolve to.
+private func oneTune(_ preamble: String, footer: String = "P=$P") -> String {
+    """
+    \(preamble)
+    %%footer "\(footer)"
+    X:1
+    T:A
+    M:4/4
+    L:1/8
+    K:G
+    GABG|DEFD|
+    """
+}
+
+/// Enough music to fill several pages of a page size deliberately made short.
+private func longTune(_ preamble: String) -> String {
+    let body = Array(repeating: "GABG|DEFD|GABG|D4|", count: 40).joined(separator: "\n")
+    return """
+    \(preamble)
+    %%footer "P=$P"
+    X:1
+    T:A
+    M:4/4
+    L:1/8
+    K:G
+    \(body)
+    """
+}
+
+private func footers(of abc: String, pageSize: PageSize = .letter) throws -> [String] {
+    var config = SVGRenderConfig()
+    config.pageSize = pageSize
+    config.textRendering = .fontFace
+    return try SVGRenderer(config: config).render(parse(abc).score).map { page in
+        page.firstMatch(of: #/class="footer">([^<]*)</#).map { String($0.1) } ?? ""
+    }
+}
+
+@Suite("%%ceolkit:pagenumber (#138)")
+struct PageNumberTests {
+
+    @Test func theFirstPagePrintsTheNumberTheDirectiveAsksFor() throws {
+        #expect(try footers(of: oneTune("%%ceolkit:pagenumber 3")) == ["P=3"])
+    }
+
+    @Test func withoutTheDirectivePagesStillNumberFromOne() throws {
+        #expect(try footers(of: oneTune("%%dateformat \"%Y\"")) == ["P=1"])
+    }
+
+    @Test func laterPagesCarryOnFromTheStatedNumber() throws {
+        // A short page forces several of them, so the sequence — not just the first page —
+        // is what gets checked.
+        let printed = try footers(of: longTune("%%ceolkit:pagenumber 17"),
+                                  pageSize: PageSize(width: 612, height: 300))
+        try #require(printed.count > 2, "the fixture must span several pages to be worth testing")
+        #expect(printed == (0..<printed.count).map { "P=\(17 + $0)" })
+    }
+
+    @Test func theDirectiveWorksInTheFirstTunesHeaderToo() throws {
+        let abc = """
+        %%footer "P=$P"
+        X:1
+        T:A
+        %%ceolkit:pagenumber 5
+        M:4/4
+        L:1/8
+        K:G
+        GABG|
+        """
+        #expect(try footers(of: abc) == ["P=5"])
+    }
+
+    @Test func theLastStatementOfTheNumberWins() throws {
+        #expect(try footers(of: oneTune("%%ceolkit:pagenumber 3\n%%ceolkit:pagenumber 8"))
+                == ["P=8"])
+    }
+
+    @Test func aCopyInALaterTunesHeaderIsIgnored() throws {
+        // The directive sets the number *before any output has been produced*.  A second
+        // tune's header is past that point, and renumbering pages already engraved is
+        // %%newpage's job, not this directive's.
+        let abc = """
+        %%footer "P=$P"
+        X:1
+        T:A
+        M:4/4
+        L:1/8
+        K:G
+        GABG|
+
+        X:2
+        T:B
+        %%ceolkit:pagenumber 9
+        M:4/4
+        L:1/8
+        K:G
+        GABG|
+        """
+        #expect(try footers(of: abc).first == "P=1")
+    }
+
+    @Test func theScrollSyncMetadataAgreesWithTheFooter() throws {
+        var config = SVGRenderConfig()
+        config.textRendering = .fontFace
+        let pages = try SVGRenderer(config: config)
+            .render(parse(oneTune("%%ceolkit:pagenumber 3")).score)
+        #expect(pages[0].contains("\"page\": 3"))
+    }
+
+    @Test func aSubstitutionMarkInheritsTheSameNumber() throws {
+        // ${pagenumber} is documented as "the same value as $P" (#137), so the offset has to
+        // reach it too — a binder compiler reading the default has to see what was drawn.
+        let printed = try footers(of: oneTune("%%ceolkit:pagenumber 4",
+                                              footer: "${pagenumber}"))
+        #expect(printed == ["4"])
+    }
+}


### PR DESCRIPTION
Release 1.4.0 — pages you can number, and hand on.

Four issues, all raised from the `svpb-tools` consumer that assembles binders out of
separately rendered tunes:

- **#140** — `%%newpage` starts a page, and `%%newpage N` renumbers it.
- **#138** — `%%ceolkit:pagenumber` reaches the page it numbers; it was parsed, validated and dropped.
- **#137** — `${name}` marks a `%%footer` span for substitution by a downstream consumer.
- **#141** — the `$Q` placeholder is removed, and unrecognised `$`-tokens are now diagnosed.

Public API is additive (`PageBreak`, `Tune.pageBreaks`, `ForcedPageBreak`,
`ResolvedPage.pageNumber`, three diagnostic codes). The one changed signature,
`VerticalLayoutEngine.layout(_:)`, gains a defaulted `firstPageNumber:` parameter, so
existing calls compile unchanged.

Verified on the tip: clean tree, `swift build` and `swift test` (1212 tests) pass, CI green.

**Merge with a merge commit** — the tag and the merge-back depend on the shared history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHKcgy7jYncpPRtanJsKDr